### PR TITLE
RFC: adding datatype support

### DIFF
--- a/delete_me_later_please.cpp
+++ b/delete_me_later_please.cpp
@@ -43,6 +43,22 @@ void mover2(const rdf4cpp::utils::sec::Result<int, std::string> &test) {
 int main() {
     using namespace rdf4cpp::rdf;
 
+    Literal float_1_1("1.1", IRI{"http://www.w3.org/2001/XMLSchema#float"});
+
+    std::cout << float_1_1 << std::endl;
+    std::any any_float_ = float_1_1.value();
+    std::cout << any_cast<datatypes::xsd::Float>(any_float_) << std::endl;
+    datatypes::xsd::Float float_ = float_1_1.value<datatypes::xsd::Float>();  // we know the type at compile time
+    std::cout << float_ << std::endl;
+
+    // update value
+    float_ *= any_cast<datatypes::xsd::Float>(any_float_) * 3;
+    std::cout << float_ << std::endl;
+    // make a new literal with new value
+    Literal updated_float{float_};
+    std::cout << updated_float << std::endl;
+
+
 //    storage::node::NodeStorage::new_instance<storage::node::DefaultNodeStorageBackend>();
 
     using namespace storage::node;

--- a/src/rdf4cpp/rdf/Literal.cpp
+++ b/src/rdf4cpp/rdf/Literal.cpp
@@ -51,6 +51,13 @@ std::ostream &operator<<(std::ostream &os, const Literal &literal) {
     os << (std::string) literal;
     return os;
 }
+std::any Literal::value() const {
+    datatypes::DatatypeRegistry::factory_function_ptr pFunction = datatypes::DatatypeRegistry::lookup(this->datatype().identifier());
+    if (pFunction)
+        return pFunction(lexical_form());
+    else
+        return {};
+}
 
 
 }  // namespace rdf4cpp::rdf

--- a/src/rdf4cpp/rdf/Literal.hpp
+++ b/src/rdf4cpp/rdf/Literal.hpp
@@ -1,8 +1,10 @@
 #ifndef RDF4CPP_LITERAL_HPP
 #define RDF4CPP_LITERAL_HPP
 
+#include <any>
 #include <ostream>
 #include <rdf4cpp/rdf/Node.hpp>
+#include <rdf4cpp/rdf/datatypes/xsd.hpp>
 
 namespace rdf4cpp::rdf {
 class Literal : public Node {
@@ -18,6 +20,11 @@ public:
             NodeStorage &node_storage = NodeStorage::primary_instance());
     Literal(const std::string &lexical_form, const std::string &lang,
             NodeStorage &node_storage = NodeStorage::primary_instance());
+
+    template<datatypes::DatatypeConcept T>
+    explicit Literal(T compatible_type,
+                     NodeStorage &node_storage = NodeStorage::primary_instance())
+        : Literal((std::string) compatible_type, std::string{T::datatype_iri}, node_storage) {}
 
     [[nodiscard]] const std::string &lexical_form() const;
 
@@ -36,8 +43,19 @@ public:
     [[nodiscard]] bool is_bnode() const;
     [[nodiscard]] bool is_iri() const;
     [[nodiscard]] RDFNodeType type() const;
-    // TODO: support value retrieval from XSD data types
+
+    /**
+     * Constructs a datatype specific container from Literal.
+     * @return
+     */
+    [[nodiscard]] std::any value() const;
     // TODO: support arithmetics with XSD data types
+
+    template<typename T>
+        requires (std::is_constructible_v<T, std::string> || std::is_constructible_v<T, const std::string &> || std::is_constructible_v<T, std::string &&>)
+    T value() const {
+        return T{this->lexical_form()};
+    }
 
     friend class Node;
 };

--- a/src/rdf4cpp/rdf/datatypes/DatatypeRegistry.hpp
+++ b/src/rdf4cpp/rdf/datatypes/DatatypeRegistry.hpp
@@ -1,0 +1,113 @@
+#ifndef RDF4CPP_DATATYPEREGISTRY_HPP
+#define RDF4CPP_DATATYPEREGISTRY_HPP
+
+#include <algorithm>
+#include <any>
+#include <vector>
+
+namespace rdf4cpp::rdf::datatypes {
+
+/**
+ * Concept required from classes deriving DatatypeBase. Guarantees full compatibility with Literal.
+ */
+template<typename T>
+concept DatatypeConcept =
+        ((std::is_constructible_v<T, std::string> || std::is_constructible_v<T, const std::string &> || std::is_constructible_v<T, std::string &&>) &&  //
+         requires(T a) {
+             { T::datatype_iri } -> std::convertible_to<std::string>;
+             { static_cast<std::string>(a) } -> std::convertible_to<std::string>;
+         });
+
+/**
+ * Registry for Literal datatype implementations.
+ * Datatypes must be registered for automatic conversation from a typed Literal with Literal::value() const.
+ * Datatypes that derived from DatatypeBase are automatically registered.
+ */
+class DatatypeRegistry {
+public:
+    /**
+     * Constructs an instance of a type from a string.
+     */
+    using factory_function_ptr = std::any (*)(std::string);
+
+    using registered_datatypes_t = std::vector<std::pair<std::string, factory_function_ptr>>;
+
+private:
+    static inline std::vector<std::pair<std::string, factory_function_ptr>> &get_mutable() {
+        static std::vector<std::pair<std::string, factory_function_ptr>> registry_;
+        return registry_;
+    }
+
+public:
+    /**
+     * Auto-register a datatype that fulfills DatatypeConcept
+     * @tparam datatype type that is registered.
+     */
+    template<DatatypeConcept datatype>
+    static inline void add() {
+        DatatypeRegistry::add(datatype::datatype_iri, [](std::string string_repr) -> std::any { return std::any(datatype{std::move(string_repr)}); });
+    }
+
+    /**
+     * Register an datatype manually
+     * @param datatype_iri datatypes iri
+     * @param factory_function factory function to construct an instance from a string
+     */
+    static inline void add(std::string datatype_iri, factory_function_ptr factory_function) {
+        auto &registry = DatatypeRegistry::get_mutable();
+        auto found = std::find_if(registry.begin(), registry.end(), [&](const auto &pair) { return pair.first == datatype_iri; });
+        if (found == registry.end()) {
+            registry.emplace_back(datatype_iri, factory_function);
+            std::sort(registry.begin(), registry.end(),
+                      [](const auto &left, const auto &right) { return left.first < right.first; });
+        } else {
+            found->second = factory_function;
+        }
+    }
+
+    /**
+     * Retrieve all registered datatypes.
+     * @return vector of pairs mapping datatype IRI std::string to factory_function_ptr
+     */
+    static inline const registered_datatypes_t &registered_datatypes() {
+        return DatatypeRegistry::get_mutable();
+    }
+
+    /**
+     * Get a factory_function_ptr for a datatype IRI std::string. The factory_function_ptr can be used like `std::any type_instance = factory_function_ptr("types string repressentation")`.
+     * @param datatype_iri datatype IRI std::string
+     * @return function pointer or nullptr
+     */
+    static inline factory_function_ptr lookup(const std::string &datatype_iri) {
+        const auto &registry = registered_datatypes();
+        auto found = std::lower_bound(registry.begin(), registry.end(),
+                                      std::pair<std::string, factory_function_ptr>{datatype_iri, nullptr},
+                                      [](const auto &left, const auto &right) { return left.first < right.first; });
+        if (found != registry.end() and found->first == datatype_iri) {
+            return found->second;
+        } else {
+            return nullptr;
+        }
+    }
+};
+
+/**
+ * Datatypes can have DatatypeBase as <a href="https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern">CRTP</a> base class. If they have, they are registered automatically.
+ * @tparam Derived The derived class is known at compile time to the base class.
+ */
+template<typename Derived>
+class DatatypeBase {
+    static inline std::nullptr_t init();
+    inline static const auto dummy = init();
+
+    // Force `dummy` to be instantiated, even though it's unused.
+    static constexpr std::integral_constant<decltype(&dummy), &dummy> dummy_helper{};
+};
+template<typename Derived>
+std::nullptr_t DatatypeBase<Derived>::init() {
+    DatatypeRegistry::add<Derived>();
+    return nullptr;
+}
+}  // namespace rdf4cpp::rdf::datatypes
+
+#endif  //RDF4CPP_DATATYPEREGISTRY_HPP

--- a/src/rdf4cpp/rdf/datatypes/xsd.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd.hpp
@@ -1,0 +1,6 @@
+#ifndef RDF4CPP_XSD_HPP
+#define RDF4CPP_XSD_HPP
+
+#include <rdf4cpp/rdf/datatypes/xsd/Float.hpp>
+
+#endif  //RDF4CPP_XSD_HPP

--- a/src/rdf4cpp/rdf/datatypes/xsd/Float.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Float.hpp
@@ -1,0 +1,107 @@
+#ifndef RDF4CPP_FLOAT_HPP
+#define RDF4CPP_FLOAT_HPP
+
+
+#include <ostream>
+#include <rdf4cpp/rdf/datatypes/DatatypeRegistry.hpp>
+
+namespace rdf4cpp::rdf::datatypes::xsd {
+
+/**
+ * Implements <a href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>
+ */
+class Float : DatatypeBase<Float> {
+
+    float value_{};
+
+public:
+    static constexpr char datatype_iri[] = "http://www.w3.org/2001/XMLSchema#float";
+
+    Float() = default;
+    explicit Float(const std::string &str)
+        // TODO: that might not be completely compliant with xsd yet
+        : value_(std::stof(str)) {}
+
+
+    Float(float value) noexcept : value_(value) {}
+
+    Float &operator=(float value) noexcept {
+        value_ = value;
+        return *this;
+    }
+    Float &operator=(char value) noexcept {
+        value_ = value;
+        return *this;
+    }
+    Float &operator=(short value) noexcept {
+        value_ = value;
+        return *this;
+    }
+
+    explicit operator float() const noexcept {
+        return value_;
+    }
+
+    Float &operator+=(Float rhs) noexcept {
+        value_ += rhs.value_;
+        return *this;
+    }
+    Float &operator-=(Float rhs) noexcept {
+        value_ -= rhs.value_;
+        return *this;
+    }
+    Float &operator*=(Float rhs) noexcept {
+        value_ *= rhs.value_;
+        return *this;
+    }
+    Float &operator/=(Float rhs) {
+        value_ /= rhs.value_;
+        return *this;
+    }
+
+    friend Float operator+(Float lhs, Float rhs) noexcept {
+        return lhs.value_ + rhs.value_;
+    }
+    friend Float operator-(Float lhs, Float rhs) noexcept {
+        return lhs.value_ - rhs.value_;
+    }
+    friend Float operator*(Float lhs, Float rhs) noexcept {
+        return lhs.value_ * rhs.value_;
+    }
+    friend Float operator/(Float lhs, Float rhs) {
+        return lhs.value_ / rhs.value_;
+    }
+
+    friend std::ostream &operator<<(std::ostream &os, const Float &inst) {
+        os << inst.value_;
+        return os;
+    }
+
+    explicit operator std::string() {
+        // TODO: this might not be xsd canonical syntax
+        return std::to_string(value_);
+    }
+
+
+    friend bool operator<(const Float &lhs, const Float &rhs) {
+        return lhs.value_ < rhs.value_;
+    }
+    friend bool operator>(const Float &lhs, const Float &rhs) {
+        return lhs.value_ > rhs.value_;
+    }
+    friend bool operator<=(const Float &lhs, const Float &rhs) {
+        return lhs.value_ <= rhs.value_;
+    }
+    friend bool operator>=(const Float &lhs, const Float &rhs) {
+        return lhs.value_ >= rhs.value_;
+    }
+    friend bool operator==(const Float &lhs, const Float &rhs) {
+        return lhs.value_ == rhs.value_;
+    }
+    friend bool operator!=(const Float &lhs, const Float &rhs) {
+        return lhs.value_ == rhs.value_;
+    }
+};
+}  // namespace rdf4cpp::rdf::datatypes::xsd
+
+#endif  //RDF4CPP_FLOAT_HPP


### PR DESCRIPTION
- adds interfaces to support typed literals
- adds an exemplary implementation of xsd:float

technical:
- datatypes CRTP inheriting from DatatypeBase are registered automatically
- such types provide their datatype IRI (static member)
- must be constructible from string
- must be convertible to string