### PR TITLE
RFC: adding datatype support (draft 2)

### DIFF
--- a/delete_me_later_please.cpp
+++ b/delete_me_later_please.cpp
@@ -49,6 +49,7 @@ int main() {
     std::any any_float_ = float_1_1.value();
     std::cout << any_cast<float>(any_float_) << std::endl;
     auto float_ = float_1_1.value<float>();  // we know the type at compile time
+    //auto int_ = float_1_1.value<int>();  // if a type is not implemented a static assert is triggered
     std::cout << float_ << std::endl;
 
     // update value

--- a/delete_me_later_please.cpp
+++ b/delete_me_later_please.cpp
@@ -47,15 +47,16 @@ int main() {
 
     std::cout << float_1_1 << std::endl;
     std::any any_float_ = float_1_1.value();
-    std::cout << any_cast<datatypes::xsd::Float>(any_float_) << std::endl;
-    datatypes::xsd::Float float_ = float_1_1.value<datatypes::xsd::Float>();  // we know the type at compile time
+    std::cout << any_cast<float>(any_float_) << std::endl;
+    auto float_ = float_1_1.value<float>();  // we know the type at compile time
     std::cout << float_ << std::endl;
 
     // update value
     float_ *= any_cast<datatypes::xsd::Float>(any_float_) * 3;
+    // datatypes::xsd::Float is an alias for the built-in type float
     std::cout << float_ << std::endl;
     // make a new literal with new value
-    Literal updated_float{float_};
+    Literal updated_float = Literal::make(float_);
     std::cout << updated_float << std::endl;
 
 

--- a/delete_me_later_please.cpp
+++ b/delete_me_later_please.cpp
@@ -43,6 +43,22 @@ void mover2(const rdf4cpp::utils::sec::Result<int, std::string> &test) {
 int main() {
     using namespace rdf4cpp::rdf;
 
+    Literal float_1_1("1.1", IRI{"http://www.w3.org/2001/XMLSchema#float"});
+
+    std::cout << float_1_1 << std::endl;
+    std::any any_float_ = float_1_1.value();
+    std::cout << any_cast<datatypes::xsd::Float>(any_float_) << std::endl;
+    datatypes::xsd::Float float_ = float_1_1.value<datatypes::xsd::Float>();  // we know the type at compile time
+    std::cout << float_ << std::endl;
+
+    // update value
+    float_ *= any_cast<datatypes::xsd::Float>(any_float_) * 3;
+    std::cout << float_ << std::endl;
+    // make a new literal with new value
+    Literal updated_float{float_};
+    std::cout << updated_float << std::endl;
+
+
 //    storage::node::NodeStorage::new_instance<storage::node::DefaultNodeStorageBackend>();
 
     using namespace storage::node;

--- a/delete_me_later_please.cpp
+++ b/delete_me_later_please.cpp
@@ -49,7 +49,7 @@ int main() {
     std::any any_float_ = float_1_1.value();
     std::cout << any_cast<float>(any_float_) << std::endl;
     auto float_ = float_1_1.value<float>();  // we know the type at compile time
-    //auto int_ = float_1_1.value<int>();  // if a type is not implemented a static assert is triggered
+    [[maybe_unused]] auto int_ = float_1_1.value<int>();
     std::cout << float_ << std::endl;
 
     // update value

--- a/src/rdf4cpp/rdf/Literal.cpp
+++ b/src/rdf4cpp/rdf/Literal.cpp
@@ -51,6 +51,13 @@ std::ostream &operator<<(std::ostream &os, const Literal &literal) {
     os << (std::string) literal;
     return os;
 }
+std::any Literal::value() const {
+    datatypes::DatatypeRegistry::factory_function_ptr pFunction = datatypes::DatatypeRegistry::lookup(this->datatype().identifier());
+    if (pFunction)
+        return pFunction(lexical_form());
+    else
+        return {};
+}
 
 
 }  // namespace rdf4cpp::rdf

--- a/src/rdf4cpp/rdf/Literal.cpp
+++ b/src/rdf4cpp/rdf/Literal.cpp
@@ -52,9 +52,9 @@ std::ostream &operator<<(std::ostream &os, const Literal &literal) {
     return os;
 }
 std::any Literal::value() const {
-    datatypes::DatatypeRegistry::factory_function_ptr pFunction = datatypes::DatatypeRegistry::lookup(this->datatype().identifier());
-    if (pFunction)
-        return pFunction(lexical_form());
+    datatypes::DatatypeRegistry::factory_fptr_t factory = datatypes::DatatypeRegistry::get_factory(this->datatype().identifier());
+    if (factory != nullptr)
+        return factory(lexical_form());
     else
         return {};
 }

--- a/src/rdf4cpp/rdf/Literal.hpp
+++ b/src/rdf4cpp/rdf/Literal.hpp
@@ -33,7 +33,7 @@ public:
                                NodeStorage &node_storage = NodeStorage::primary_instance()) {
         // TODO: template instantiation should fail if not defined for a type
         return Literal(datatypes::RegisteredDatatype<std::decay_t<T>>::to_string(compatible_value),
-                       std::string{datatypes::RegisteredDatatype<std::decay_t<T>>::datatype_iri},
+                       datatypes::RegisteredDatatype<std::decay_t<T>>::datatype_iri(),
                        node_storage);
     }
 

--- a/src/rdf4cpp/rdf/Literal.hpp
+++ b/src/rdf4cpp/rdf/Literal.hpp
@@ -1,8 +1,10 @@
 #ifndef RDF4CPP_LITERAL_HPP
 #define RDF4CPP_LITERAL_HPP
 
+#include <any>
 #include <ostream>
 #include <rdf4cpp/rdf/Node.hpp>
+#include <rdf4cpp/rdf/datatypes/xsd.hpp>
 
 namespace rdf4cpp::rdf {
 class Literal : public Node {
@@ -18,6 +20,11 @@ public:
             NodeStorage &node_storage = NodeStorage::primary_instance());
     Literal(const std::string &lexical_form, const std::string &lang,
             NodeStorage &node_storage = NodeStorage::primary_instance());
+
+    template<datatypes::DatatypeConcept T>
+    explicit Literal(T compatible_type,
+                     NodeStorage &node_storage = NodeStorage::primary_instance())
+        : Literal((std::string) compatible_type, std::string{T::datatype_iri}, node_storage) {}
 
     [[nodiscard]] const std::string &lexical_form() const;
 
@@ -36,8 +43,19 @@ public:
     [[nodiscard]] bool is_bnode() const;
     [[nodiscard]] bool is_iri() const;
     [[nodiscard]] RDFNodeType type() const;
-    // TODO: support value retrieval from XSD data types
+
+    /**
+     * Constructs a datatype specific container from Literal.
+     * @return
+     */
+    [[nodiscard]] std::any value() const;
     // TODO: support arithmetics with XSD data types
+
+    template<typename T>
+        requires (std::is_constructible_v<T, std::string> || std::is_constructible_v<T, const std::string &> || std::is_constructible_v<T, std::string &&>)
+    T value() const {
+        return T{this->lexical_form()};
+    }
 
     friend class Node;
 };

--- a/src/rdf4cpp/rdf/Literal.hpp
+++ b/src/rdf4cpp/rdf/Literal.hpp
@@ -31,7 +31,6 @@ public:
     template<class T>
     inline static Literal make(T compatible_value,
                                NodeStorage &node_storage = NodeStorage::primary_instance()) {
-        // TODO: template instantiation should fail if not defined for a type
         return Literal(datatypes::RegisteredDatatype<std::decay_t<T>>::to_string(compatible_value),
                        datatypes::RegisteredDatatype<std::decay_t<T>>::datatype_iri(),
                        node_storage);

--- a/src/rdf4cpp/rdf/datatypes/DatatypeRegistry.hpp
+++ b/src/rdf4cpp/rdf/datatypes/DatatypeRegistry.hpp
@@ -126,17 +126,21 @@ public:
  */
 template<typename datatype_t>
 struct RegisteredDatatype {
-    /**
-     * Datatype iri
-     */
-    inline static const char *datatype_iri;
-
+private:
     /**
      * static_assert would always trigger if it wasn't dependent on a template parameter.
      * With this helper template, it only triggers if the function is instantiated.
      */
     template <typename> using always_false = std::false_type;
     template <typename T> static constexpr bool always_false_v = always_false<T>::value;
+public:
+    /**
+     * Datatype iri
+     */
+    inline static std::string datatype_iri() noexcept {
+        static_assert(always_false_v<datatype_t>, "'datatype_iri' is not defined!");
+        return {};
+    }
     /**
      * Factory function that parses a string representing datatype_t and builds an instance of datatype_t
      * @return instance of datatype_t
@@ -177,7 +181,7 @@ std::nullptr_t RegisteredDatatype<datatype_t>::init() {
 template<typename datatype_info>
 inline void DatatypeRegistry::add() {
     DatatypeRegistry::add(
-            datatype_info::datatype_iri,
+            datatype_info::datatype_iri(),
             [](const std::string &string_repr) -> std::any {
                 return std::any(datatype_info::from_string(string_repr));
             },

--- a/src/rdf4cpp/rdf/datatypes/DatatypeRegistry.hpp
+++ b/src/rdf4cpp/rdf/datatypes/DatatypeRegistry.hpp
@@ -1,0 +1,113 @@
+#ifndef RDF4CPP_DATATYPEREGISTRY_HPP
+#define RDF4CPP_DATATYPEREGISTRY_HPP
+
+#include <algorithm>
+#include <any>
+#include <vector>
+
+namespace rdf4cpp::rdf::datatypes {
+
+/**
+ * Concept required from classes deriving DatatypeBase. Guarantees full compatibility with Literal.
+ */
+template<typename T>
+concept DatatypeConcept =
+        ((std::is_constructible_v<T, std::string> || std::is_constructible_v<T, const std::string &> || std::is_constructible_v<T, std::string &&>) &&  //
+         requires(T a) {
+             { T::datatype_iri } -> std::convertible_to<std::string>;
+             { static_cast<std::string>(a) } -> std::convertible_to<std::string>;
+         });
+
+/**
+ * Registry for Literal datatype implementations.
+ * Datatypes must be registered for automatic conversation from a typed Literal with Literal::value() const.
+ * Datatypes that derived from DatatypeBase are automatically registered.
+ */
+class DatatypeRegistry {
+public:
+    /**
+     * Constructs an instance of a type from a string.
+     */
+    using factory_function_ptr = std::any (*)(std::string);
+
+    using registered_datatypes_t = std::vector<std::pair<std::string, factory_function_ptr>>;
+
+private:
+    static inline std::vector<std::pair<std::string, factory_function_ptr>> &get_mutable() {
+        static std::vector<std::pair<std::string, factory_function_ptr>> registry_;
+        return registry_;
+    }
+
+public:
+    /**
+     * Auto-register a datatype that fulfills DatatypeConcept
+     * @tparam datatype type that is registered.
+     */
+    template<DatatypeConcept datatype>
+    static inline void add() {
+        DatatypeRegistry::add(datatype::datatype_iri, [](std::string string_repr) -> std::any { return std::any(datatype{std::move(string_repr)}); });
+    }
+
+    /**
+     * Register an datatype manually
+     * @param datatype_iri datatypes iri
+     * @param factory_function factory function to construct an instance from a string
+     */
+    static inline void add(std::string datatype_iri, factory_function_ptr factory_function) {
+        auto &registry = DatatypeRegistry::get_mutable();
+        auto found = std::find_if(registry.begin(), registry.end(), [&](const auto &pair) { return pair.first == datatype_iri; });
+        if (found == registry.end()) {
+            registry.emplace_back(datatype_iri, factory_function);
+            std::sort(registry.begin(), registry.end(),
+                      [](const auto &left, const auto &right) { return left.first < right.first; });
+        } else {
+            found->second = factory_function;
+        }
+    }
+
+    /**
+     * Retrieve all registered datatypes.
+     * @return vector of pairs mapping datatype IRI std::string to factory_function_ptr
+     */
+    static inline const registered_datatypes_t &registered_datatypes() {
+        return DatatypeRegistry::get_mutable();
+    }
+
+    /**
+     * Get a factory_function_ptr for a datatype IRI std::string. The factory_function_ptr can be used like `std::any type_instance = factory_function_ptr("types string repressentation")`.
+     * @param datatype_iri datatype IRI std::string
+     * @return function pointer or nullptr
+     */
+    static inline factory_function_ptr lookup(const std::string &datatype_iri) {
+        const auto &registry = registered_datatypes();
+        auto found = std::lower_bound(registry.begin(), registry.end(),
+                                      std::pair<std::string, factory_function_ptr>{datatype_iri, nullptr},
+                                      [](const auto &left, const auto &right) { return left.first < right.first; });
+        if (found != registry.end() and found->first == datatype_iri) {
+            return found->second;
+        } else {
+            return nullptr;
+        }
+    }
+};
+
+/**
+ * Datatypes can have DatatypeBase as <a href="https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern">CRTP</a> base class. If they have, they are registered automatically.
+ * @tparam Derived The derived class is known at compile time to the base class.
+ */
+template<typename Derived>
+class DatatypeBase {
+    static inline std::nullptr_t init();
+    inline static const auto dummy = init();
+
+    // Force `dummy` to be instantiated, even though it's unused.
+    static constexpr std::integral_constant<decltype(&dummy), &dummy> dummy_helper{};
+};
+template<typename Derived>
+std::nullptr_t DatatypeBase<Derived>::init() {
+    DatatypeRegistry::add<Derived>();
+    return nullptr;
+}
+}  // namespace rdf4cpp::rdf::datatypes
+
+#endif  //RDF4CPP_DATATYPEREGISTRY_HPP

--- a/src/rdf4cpp/rdf/datatypes/DatatypeRegistry.hpp
+++ b/src/rdf4cpp/rdf/datatypes/DatatypeRegistry.hpp
@@ -9,19 +9,6 @@
 namespace rdf4cpp::rdf::datatypes {
 
 /**
- * Concept describing RegisteredDatatype.
- * @see RegisteredDatatype
- */
-template<typename T>
-concept register_datatype_c =
-        requires(T a, std::string s, typename T::datatype v) {
-    { T::datatype_iri } -> std::convertible_to<std::string>;
-    { T::from_string(s) } -> std::convertible_to<typename T::type>;
-    { T::to_string(v) } -> std::convertible_to<std::string>;
-}
-&&std::default_initializable<T>;
-
-/**
  * Registry for Literal datatype implementations.
  * Data types are registered by defining implementing and specializing members of RegisteredDatatype.
  * @see RegisteredDatatype
@@ -43,7 +30,7 @@ public:
     using registered_datatypes_t = std::vector<DatatypeEntry>;
 
 private:
-    static inline registered_datatypes_t &get_mutable() {
+    inline static registered_datatypes_t &get_mutable() {
         static registered_datatypes_t registry_;
         return registry_;
     }
@@ -62,7 +49,7 @@ public:
      * @param factory_fptr factory function to construct an instance from a string
      * @param to_string_fptr converts type instance to its string representation
      */
-    static inline void add(std::string datatype_iri, factory_fptr_t factory_fptr, to_string_fptr_t to_string_fptr) {
+    inline static void add(std::string datatype_iri, factory_fptr_t factory_fptr, to_string_fptr_t to_string_fptr) {
         auto &registry = DatatypeRegistry::get_mutable();
         auto found = std::find_if(registry.begin(), registry.end(), [&](const auto &entry) { return entry.name == datatype_iri; });
         if (found == registry.end()) {
@@ -79,7 +66,7 @@ public:
      * Retrieve all registered datatypes.
      * @return vector of pairs mapping datatype IRI std::string to factory_fptr_t
      */
-    static inline const registered_datatypes_t &registered_datatypes() {
+    inline static const registered_datatypes_t &registered_datatypes() {
         return DatatypeRegistry::get_mutable();
     }
 
@@ -88,7 +75,7 @@ public:
      * @param datatype_iri datatype IRI std::string
      * @return function pointer or nullptr
      */
-    static inline factory_fptr_t get_factory(const std::string &datatype_iri) {
+    inline static factory_fptr_t get_factory(const std::string &datatype_iri) {
         const auto &registry = registered_datatypes();
         auto found = std::lower_bound(registry.begin(), registry.end(),
                                       DatatypeEntry{datatype_iri, nullptr, nullptr},
@@ -105,7 +92,7 @@ public:
      * @param datatype_iri datatype IRI std::string
      * @return function pointer or nullptr
      */
-    static inline to_string_fptr_t get_to_string(const std::string &datatype_iri) {
+    inline static to_string_fptr_t get_to_string(const std::string &datatype_iri) {
         const auto &registry = registered_datatypes();
         auto found = std::lower_bound(registry.begin(), registry.end(),
                                       DatatypeEntry{datatype_iri, nullptr, nullptr},
@@ -120,9 +107,9 @@ public:
 
 
 /**
- * To register a datatype, datatype_iri and from_string must be defined for RegisteredDatatype<datatype_t>.
- * If datatype_t does not overload operator<<, static std::string to_string(const datatype_t &value) must be specialized..
- * @tparam datatype_t The derived class is known at compile time to the base class.
+ * To register a datatype, datatype_iri and from_string must be defined for `RegisteredDatatype<datatype_t>`.
+ * If datatype_t does not overload `operator<<`, to_string(const datatype_t &value) must be specialized.
+ * @tparam datatype_t datatype that is being registered
  */
 template<typename datatype_t>
 struct RegisteredDatatype {
@@ -131,8 +118,11 @@ private:
      * static_assert would always trigger if it wasn't dependent on a template parameter.
      * With this helper template, it only triggers if the function is instantiated.
      */
-    template <typename> using always_false = std::false_type;
-    template <typename T> static constexpr bool always_false_v = always_false<T>::value;
+    template<typename>
+    using always_false = std::false_type;
+    template<typename T>
+    static constexpr bool always_false_v = always_false<T>::value;
+
 public:
     /**
      * Datatype iri
@@ -145,7 +135,7 @@ public:
      * Factory function that parses a string representing datatype_t and builds an instance of datatype_t
      * @return instance of datatype_t
      */
-    inline static datatype_t from_string(const std::string &){
+    inline static datatype_t from_string(const std::string &) {
         //If this implementation is used the user forgot to provide their own.
         static_assert(always_false_v<datatype_t>, "'from_string' is not implemented for this type!");
     }
@@ -166,7 +156,7 @@ public:
     typedef datatype_t datatype;
 
 private:
-    static inline std::nullptr_t init();
+    inline static std::nullptr_t init();
     inline static const auto dummy = init();
 
     // Force `dummy` to be instantiated, even though it's unused.

--- a/src/rdf4cpp/rdf/datatypes/DatatypeRegistry.hpp
+++ b/src/rdf4cpp/rdf/datatypes/DatatypeRegistry.hpp
@@ -130,11 +130,21 @@ struct RegisteredDatatype {
      * Datatype iri
      */
     inline static const char *datatype_iri;
+
+    /**
+     * static_assert would always trigger if it wasn't dependent on a template parameter.
+     * With this helper template, it only triggers if the function is instantiated.
+     */
+    template <typename> using always_false = std::false_type;
+    template <typename T> static constexpr bool always_false_v = always_false<T>::value;
     /**
      * Factory function that parses a string representing datatype_t and builds an instance of datatype_t
      * @return instance of datatype_t
      */
-    inline static datatype_t from_string(const std::string &);
+    inline static datatype_t from_string(const std::string &){
+        //If this implementation is used the user forgot to provide their own.
+        static_assert(always_false_v<datatype_t>, "'from_string' is not implemented for this type!");
+    }
     /**
      * Returns string representation of a datatype_t.
      * @param value an datatype_t instance

--- a/src/rdf4cpp/rdf/datatypes/xsd.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd.hpp
@@ -3,4 +3,11 @@
 
 #include <rdf4cpp/rdf/datatypes/xsd/Float.hpp>
 
+namespace rdf4cpp::rdf::datatypes::xsd {
+/**
+ * Namespace where datatypes from XSD datatypes are implemented.
+ * @see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+ */
+}
+
 #endif  //RDF4CPP_XSD_HPP

--- a/src/rdf4cpp/rdf/datatypes/xsd.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd.hpp
@@ -2,6 +2,7 @@
 #define RDF4CPP_XSD_HPP
 
 #include <rdf4cpp/rdf/datatypes/xsd/Float.hpp>
+#include <rdf4cpp/rdf/datatypes/xsd/Int.hpp>
 
 namespace rdf4cpp::rdf::datatypes::xsd {
 /**

--- a/src/rdf4cpp/rdf/datatypes/xsd.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd.hpp
@@ -4,11 +4,12 @@
 #include <rdf4cpp/rdf/datatypes/xsd/Float.hpp>
 #include <rdf4cpp/rdf/datatypes/xsd/Int.hpp>
 
-namespace rdf4cpp::rdf::datatypes::xsd {
 /**
- * Namespace where datatypes from XSD datatypes are implemented.
+ * Namespace where datatypes from XSD are implemented.
  * @see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
  */
+namespace rdf4cpp::rdf::datatypes::xsd {
+//
 }
 
 #endif  //RDF4CPP_XSD_HPP

--- a/src/rdf4cpp/rdf/datatypes/xsd.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd.hpp
@@ -1,0 +1,6 @@
+#ifndef RDF4CPP_XSD_HPP
+#define RDF4CPP_XSD_HPP
+
+#include <rdf4cpp/rdf/datatypes/xsd/Float.hpp>
+
+#endif  //RDF4CPP_XSD_HPP

--- a/src/rdf4cpp/rdf/datatypes/xsd/Float.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Float.hpp
@@ -16,7 +16,7 @@ using Float = float; //!< Implements <a href="http://www.w3.org/2001/XMLSchema#f
 
 namespace rdf4cpp::rdf::datatypes {
 template<>
-inline const char *RegisteredDatatype<xsd::Float>::datatype_iri = "http://www.w3.org/2001/XMLSchema#float";
+inline std::string RegisteredDatatype<xsd::Float>::datatype_iri() noexcept { return "http://www.w3.org/2001/XMLSchema#float";}
 template<>
 inline float RegisteredDatatype<xsd::Float>::from_string(const std::string &s) {
     return std::stof(s);

--- a/src/rdf4cpp/rdf/datatypes/xsd/Float.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Float.hpp
@@ -1,0 +1,107 @@
+#ifndef RDF4CPP_FLOAT_HPP
+#define RDF4CPP_FLOAT_HPP
+
+
+#include <ostream>
+#include <rdf4cpp/rdf/datatypes/DatatypeRegistry.hpp>
+
+namespace rdf4cpp::rdf::datatypes::xsd {
+
+/**
+ * Implements <a href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>
+ */
+class Float : DatatypeBase<Float> {
+
+    float value_{};
+
+public:
+    static constexpr char datatype_iri[] = "http://www.w3.org/2001/XMLSchema#float";
+
+    Float() = default;
+    explicit Float(const std::string &str)
+        // TODO: that might not be completely compliant with xsd yet
+        : value_(std::stof(str)) {}
+
+
+    Float(float value) noexcept : value_(value) {}
+
+    Float &operator=(float value) noexcept {
+        value_ = value;
+        return *this;
+    }
+    Float &operator=(char value) noexcept {
+        value_ = value;
+        return *this;
+    }
+    Float &operator=(short value) noexcept {
+        value_ = value;
+        return *this;
+    }
+
+    explicit operator float() const noexcept {
+        return value_;
+    }
+
+    Float &operator+=(Float rhs) noexcept {
+        value_ += rhs.value_;
+        return *this;
+    }
+    Float &operator-=(Float rhs) noexcept {
+        value_ -= rhs.value_;
+        return *this;
+    }
+    Float &operator*=(Float rhs) noexcept {
+        value_ *= rhs.value_;
+        return *this;
+    }
+    Float &operator/=(Float rhs) {
+        value_ /= rhs.value_;
+        return *this;
+    }
+
+    friend Float operator+(Float lhs, Float rhs) noexcept {
+        return lhs.value_ + rhs.value_;
+    }
+    friend Float operator-(Float lhs, Float rhs) noexcept {
+        return lhs.value_ - rhs.value_;
+    }
+    friend Float operator*(Float lhs, Float rhs) noexcept {
+        return lhs.value_ * rhs.value_;
+    }
+    friend Float operator/(Float lhs, Float rhs) {
+        return lhs.value_ / rhs.value_;
+    }
+
+    friend std::ostream &operator<<(std::ostream &os, const Float &inst) {
+        os << inst.value_;
+        return os;
+    }
+
+    explicit operator std::string() {
+        // TODO: this might not be xsd canonical syntax
+        return std::to_string(value_);
+    }
+
+
+    friend bool operator<(const Float &lhs, const Float &rhs) {
+        return lhs.value_ < rhs.value_;
+    }
+    friend bool operator>(const Float &lhs, const Float &rhs) {
+        return lhs.value_ > rhs.value_;
+    }
+    friend bool operator<=(const Float &lhs, const Float &rhs) {
+        return lhs.value_ <= rhs.value_;
+    }
+    friend bool operator>=(const Float &lhs, const Float &rhs) {
+        return lhs.value_ >= rhs.value_;
+    }
+    friend bool operator==(const Float &lhs, const Float &rhs) {
+        return lhs.value_ == rhs.value_;
+    }
+    friend bool operator!=(const Float &lhs, const Float &rhs) {
+        return lhs.value_ == rhs.value_;
+    }
+};
+}  // namespace rdf4cpp::rdf::datatypes::xsd
+
+#endif  //RDF4CPP_FLOAT_HPP

--- a/src/rdf4cpp/rdf/datatypes/xsd/Float.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Float.hpp
@@ -1,3 +1,7 @@
+/**
+ * @file Registers xsd:float with DatatypeRegistry
+ */
+
 #ifndef RDF4CPP_FLOAT_HPP
 #define RDF4CPP_FLOAT_HPP
 
@@ -6,102 +10,17 @@
 #include <rdf4cpp/rdf/datatypes/DatatypeRegistry.hpp>
 
 namespace rdf4cpp::rdf::datatypes::xsd {
-
-/**
- * Implements <a href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>
- */
-class Float : DatatypeBase<Float> {
-
-    float value_{};
-
-public:
-    static constexpr char datatype_iri[] = "http://www.w3.org/2001/XMLSchema#float";
-
-    Float() = default;
-    explicit Float(const std::string &str)
-        // TODO: that might not be completely compliant with xsd yet
-        : value_(std::stof(str)) {}
+using Float = float; //!< Implements <a href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>
+}
 
 
-    Float(float value) noexcept : value_(value) {}
-
-    Float &operator=(float value) noexcept {
-        value_ = value;
-        return *this;
-    }
-    Float &operator=(char value) noexcept {
-        value_ = value;
-        return *this;
-    }
-    Float &operator=(short value) noexcept {
-        value_ = value;
-        return *this;
-    }
-
-    explicit operator float() const noexcept {
-        return value_;
-    }
-
-    Float &operator+=(Float rhs) noexcept {
-        value_ += rhs.value_;
-        return *this;
-    }
-    Float &operator-=(Float rhs) noexcept {
-        value_ -= rhs.value_;
-        return *this;
-    }
-    Float &operator*=(Float rhs) noexcept {
-        value_ *= rhs.value_;
-        return *this;
-    }
-    Float &operator/=(Float rhs) {
-        value_ /= rhs.value_;
-        return *this;
-    }
-
-    friend Float operator+(Float lhs, Float rhs) noexcept {
-        return lhs.value_ + rhs.value_;
-    }
-    friend Float operator-(Float lhs, Float rhs) noexcept {
-        return lhs.value_ - rhs.value_;
-    }
-    friend Float operator*(Float lhs, Float rhs) noexcept {
-        return lhs.value_ * rhs.value_;
-    }
-    friend Float operator/(Float lhs, Float rhs) {
-        return lhs.value_ / rhs.value_;
-    }
-
-    friend std::ostream &operator<<(std::ostream &os, const Float &inst) {
-        os << inst.value_;
-        return os;
-    }
-
-    explicit operator std::string() {
-        // TODO: this might not be xsd canonical syntax
-        return std::to_string(value_);
-    }
-
-
-    friend bool operator<(const Float &lhs, const Float &rhs) {
-        return lhs.value_ < rhs.value_;
-    }
-    friend bool operator>(const Float &lhs, const Float &rhs) {
-        return lhs.value_ > rhs.value_;
-    }
-    friend bool operator<=(const Float &lhs, const Float &rhs) {
-        return lhs.value_ <= rhs.value_;
-    }
-    friend bool operator>=(const Float &lhs, const Float &rhs) {
-        return lhs.value_ >= rhs.value_;
-    }
-    friend bool operator==(const Float &lhs, const Float &rhs) {
-        return lhs.value_ == rhs.value_;
-    }
-    friend bool operator!=(const Float &lhs, const Float &rhs) {
-        return lhs.value_ == rhs.value_;
-    }
-};
-}  // namespace rdf4cpp::rdf::datatypes::xsd
+namespace rdf4cpp::rdf::datatypes {
+template<>
+inline const char *RegisteredDatatype<xsd::Float>::datatype_iri = "http://www.w3.org/2001/XMLSchema#float";
+template<>
+inline float RegisteredDatatype<xsd::Float>::from_string(const std::string &s) {
+    return std::stof(s);
+}
+}  // namespace rdf4cpp::rdf::datatypes
 
 #endif  //RDF4CPP_FLOAT_HPP

--- a/src/rdf4cpp/rdf/datatypes/xsd/Float.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Float.hpp
@@ -2,25 +2,25 @@
  * @file Registers xsd:float with DatatypeRegistry
  */
 
-#ifndef RDF4CPP_FLOAT_HPP
-#define RDF4CPP_FLOAT_HPP
+#ifndef RDF4CPP_XSD_FLOAT_HPP
+#define RDF4CPP_XSD_FLOAT_HPP
 
 
 #include <ostream>
 #include <rdf4cpp/rdf/datatypes/DatatypeRegistry.hpp>
 
 namespace rdf4cpp::rdf::datatypes::xsd {
-using Float = float; //!< Implements <a href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>
+using Float = float;  //!< Implements <a href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>
 }
 
 
 namespace rdf4cpp::rdf::datatypes {
 template<>
-inline std::string RegisteredDatatype<xsd::Float>::datatype_iri() noexcept { return "http://www.w3.org/2001/XMLSchema#float";}
+inline std::string RegisteredDatatype<xsd::Float>::datatype_iri() noexcept { return "http://www.w3.org/2001/XMLSchema#float"; }
 template<>
 inline float RegisteredDatatype<xsd::Float>::from_string(const std::string &s) {
     return std::stof(s);
 }
 }  // namespace rdf4cpp::rdf::datatypes
 
-#endif  //RDF4CPP_FLOAT_HPP
+#endif  //RDF4CPP_XSD_FLOAT_HPP

--- a/src/rdf4cpp/rdf/datatypes/xsd/Int.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Int.hpp
@@ -1,0 +1,22 @@
+#ifndef RDF4CPP_INT_HPP
+#define RDF4CPP_INT_HPP
+
+#include <ostream>
+#include <cstdint>
+#include <rdf4cpp/rdf/datatypes/DatatypeRegistry.hpp>
+
+namespace rdf4cpp::rdf::datatypes::xsd {
+using Int = int32_t; //!< Implements <a href="http://www.w3.org/2001/XMLSchema#int">xsd:int</a>
+}
+
+
+namespace rdf4cpp::rdf::datatypes {
+template<>
+inline std::string RegisteredDatatype<xsd::Int>::datatype_iri() noexcept { return "http://www.w3.org/2001/XMLSchema#int";}
+
+template<>
+inline xsd::Int RegisteredDatatype<xsd::Int>::from_string(const std::string &s) {
+    return std::stoi(s);
+}
+}  // namespace rdf4cpp::rdf::datatypes
+#endif  //RDF4CPP_INT_HPP

--- a/src/rdf4cpp/rdf/datatypes/xsd/Int.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Int.hpp
@@ -1,22 +1,26 @@
-#ifndef RDF4CPP_INT_HPP
-#define RDF4CPP_INT_HPP
+/**
+ * @file Registers xsd:int with DatatypeRegistry
+ */
 
-#include <ostream>
+#ifndef RDF4CPP_XSD_INT_HPP
+#define RDF4CPP_XSD_INT_HPP
+
 #include <cstdint>
+#include <ostream>
 #include <rdf4cpp/rdf/datatypes/DatatypeRegistry.hpp>
 
 namespace rdf4cpp::rdf::datatypes::xsd {
-using Int = int32_t; //!< Implements <a href="http://www.w3.org/2001/XMLSchema#int">xsd:int</a>
+using Int = int32_t;  //!< Implements <a href="http://www.w3.org/2001/XMLSchema#int">xsd:int</a>
 }
 
 
 namespace rdf4cpp::rdf::datatypes {
 template<>
-inline std::string RegisteredDatatype<xsd::Int>::datatype_iri() noexcept { return "http://www.w3.org/2001/XMLSchema#int";}
+inline std::string RegisteredDatatype<xsd::Int>::datatype_iri() noexcept { return "http://www.w3.org/2001/XMLSchema#int"; }
 
 template<>
 inline xsd::Int RegisteredDatatype<xsd::Int>::from_string(const std::string &s) {
     return std::stoi(s);
 }
 }  // namespace rdf4cpp::rdf::datatypes
-#endif  //RDF4CPP_INT_HPP
+#endif  //RDF4CPP_XSD_INT_HPP


### PR DESCRIPTION
- adds interfaces to support typed literals
- adds an exemplary implementation of xsd:float

technical:
- datatypes are registered by implementing 1 (2 if operator<< is not overloaded) static function and 1 static field
  - static from_string method
  - static to_string method (if operator<< is not defined or doesn't return the required representation)
  - static string datatype_iri
- such types provide their datatype IRI (static member)

Compared to https://github.com/rdf4cpp/rdf4cpp/pull/6:

\+ Does not require wrappers around primitive types

<del>\- Construction of IRIs from unregistered types fails at link-time not at compile-time</del>
