### PR TITLE
improve ReferenceNodeStorageBackend

### DIFF
--- a/src/rdf4cpp/rdf/Literal.cpp
+++ b/src/rdf4cpp/rdf/Literal.cpp
@@ -49,6 +49,10 @@ Literal::operator std::string() const {
 
         for (auto const &character : lexical) {
             switch (character) {
+                case '\\': {
+                    out << R"(\\)";
+                    break;
+                }
                 case '\n': {
                     out << R"(\n)";
                     break;

--- a/src/rdf4cpp/rdf/Literal.cpp
+++ b/src/rdf4cpp/rdf/Literal.cpp
@@ -43,8 +43,32 @@ std::string_view Literal::language_tag() const {
 Literal::operator std::string() const {
     // TODO: escape non-standard chars correctly
     auto quote_lexical = [](std::string_view lexical) -> std::string {
-        // TODO: escape quotes (") in lexical + escape everything that needs to be escaped in N-Tripels/N-Quads
-        return "\"" + std::string{lexical} + "\"";
+        // TODO: escape everything that needs to be escaped in N-Tripels/N-Quads
+        std::ostringstream out{};
+        out << "\"";
+
+        for (auto const &character : lexical) {
+            switch (character) {
+                case '\n': {
+                    out << R"(\n)";
+                    break;
+                }
+                case '\r': {
+                    out << R"(\r)";
+                    break;
+                }
+                case '"': {
+                    out << R"(\")";
+                    break;
+                }
+                    [[likely]] default : {
+                        out << character;
+                        break;
+                    }
+            }
+        }
+        out << "\"";
+        return out.str();
     };
     const auto &literal = handle_.literal_backend();
     if (literal.datatype_id == NodeID::rdf_langstring_iri.first) {

--- a/src/rdf4cpp/rdf/Node.cpp
+++ b/src/rdf4cpp/rdf/Node.cpp
@@ -144,25 +144,6 @@ bool Node::operator==(const Node &other) const noexcept {
         }
     }
 }
-bool operator==(const Node &lhs, const std::unique_ptr<Node> &rhs) noexcept {
-    return lhs == *rhs;
-}
-
-bool operator==(const std::unique_ptr<Node> &lhs, Node const &rhs) noexcept {
-    return *lhs == rhs;
-}
-
-bool operator==(const std::unique_ptr<Node> &lhs, const std::unique_ptr<Node> &rhs) noexcept {
-    return *lhs == *rhs;
-}
-
-bool operator==(const Node *lhs, const std::unique_ptr<Node> &rhs) noexcept {
-    return *lhs == *rhs;
-}
-
-bool operator==(const std::unique_ptr<Node> &lhs, const Node *rhs) noexcept {
-    return *lhs == *rhs;
-}
 
 Node::operator BlankNode() const {
     assert(is_blank_node());

--- a/src/rdf4cpp/rdf/Node.hpp
+++ b/src/rdf4cpp/rdf/Node.hpp
@@ -84,7 +84,7 @@ public:
     bool operator==(const Node &other) const noexcept;
 
     friend bool operator==(const Node &lhs, const std::unique_ptr<Node> &rhs) noexcept;
-
+    // TODO: remove??
     friend bool operator==(const std::unique_ptr<Node> &lhs, Node const &rhs) noexcept;
 
     friend bool operator==(const std::unique_ptr<Node> &lhs, const std::unique_ptr<Node> &rhs) noexcept;
@@ -93,7 +93,7 @@ public:
 
     friend bool operator==(const std::unique_ptr<Node> &lhs, const Node *rhs) noexcept;
 
-    std::partial_ordering operator<=>(const Node &other) const noexcept;
+    std::strong_ordering operator<=>(const Node &other) const noexcept;
 
     /**
      * Conversion to BlankNode is only safe if `(is_blank_node() == true)`

--- a/src/rdf4cpp/rdf/Node.hpp
+++ b/src/rdf4cpp/rdf/Node.hpp
@@ -83,16 +83,6 @@ public:
 
     bool operator==(const Node &other) const noexcept;
 
-    friend bool operator==(const Node &lhs, const std::unique_ptr<Node> &rhs) noexcept;
-    // TODO: remove??
-    friend bool operator==(const std::unique_ptr<Node> &lhs, Node const &rhs) noexcept;
-
-    friend bool operator==(const std::unique_ptr<Node> &lhs, const std::unique_ptr<Node> &rhs) noexcept;
-
-    friend bool operator==(const Node *lhs, const std::unique_ptr<Node> &rhs) noexcept;
-
-    friend bool operator==(const std::unique_ptr<Node> &lhs, const Node *rhs) noexcept;
-
     std::strong_ordering operator<=>(const Node &other) const noexcept;
 
     /**

--- a/src/rdf4cpp/rdf/parser/SerdParsing.cpp
+++ b/src/rdf4cpp/rdf/parser/SerdParsing.cpp
@@ -2,11 +2,19 @@
 
 #include <serd-0/serd/serd.h>
 
+#include <rdf4cpp/rdf/storage/util/robin-hood-hashing/robin_hood_hash.hpp>
+#include <rdf4cpp/rdf/storage/util/tsl/sparse_map.h>
+
 using Quad = rdf4cpp::rdf::Quad;
 using namespace rdf4cpp::rdf;
 
 struct SerdHandle {
-    std::map<std::string, std::string> prefixes;
+    using PrefixMap = rdf4cpp::rdf::storage::util::tsl::sparse_map<
+            std::string,
+            std::string,
+            rdf4cpp::rdf::storage::util::robin_hood::hash<std::string>>;
+
+    PrefixMap prefixes;
     Dataset *datset;
 };
 
@@ -130,7 +138,7 @@ namespace rdf4cpp::rdf {
 void import_rdf_file(const std::string &path, Dataset *dataset) {
     SerdHandle serd_handle;
     serd_handle.datset = dataset;
-            SerdReader *reader = serd_reader_new(SERD_TURTLE, (void *) &serd_handle,
+    SerdReader *reader = serd_reader_new(SERD_TURTLE, (void *) &serd_handle,
                                          nullptr,
                                          reinterpret_cast<SerdBaseSink>(on_base),
                                          reinterpret_cast<SerdPrefixSink>(on_prefix),

--- a/src/rdf4cpp/rdf/storage/node/identifier/NodeBackendHandle.hpp
+++ b/src/rdf4cpp/rdf/storage/node/identifier/NodeBackendHandle.hpp
@@ -20,7 +20,7 @@ namespace rdf4cpp::rdf::storage::node::identifier {
  */
 class NodeBackendHandle {
 private:
-    uint64_t raw_{};
+    uint64_t raw_;
 
 public:
     NodeBackendHandle() noexcept = default;
@@ -97,7 +97,7 @@ public:
      */
     [[nodiscard]] uint64_t raw() const noexcept;
 
-    std::partial_ordering operator<=>(NodeBackendHandle const &other) const noexcept = default;
+    auto operator<=>(NodeBackendHandle const &other) const noexcept = default;
 
     bool operator==(NodeBackendHandle const &other) const noexcept = default;
 

--- a/src/rdf4cpp/rdf/storage/node/identifier/NodeID.hpp
+++ b/src/rdf4cpp/rdf/storage/node/identifier/NodeID.hpp
@@ -74,7 +74,7 @@ public:
     [[nodiscard]] constexpr uint64_t value() const noexcept { return value_; }
     //    void value(uint64_t val) { assert(val < (1UL << 48)); value_ = val; }
 
-    constexpr std::partial_ordering operator<=>(NodeID const &other) const noexcept { return value_ <=> other.value_; }
+    constexpr std::strong_ordering operator<=>(NodeID const &other) const noexcept { return value_ <=> other.value_; }
 
     constexpr bool operator==(NodeID const &other) const noexcept { return value_ == other.value_; }
 

--- a/src/rdf4cpp/rdf/storage/node/identifier/RDFNodeType.hpp
+++ b/src/rdf4cpp/rdf/storage/node/identifier/RDFNodeType.hpp
@@ -7,12 +7,13 @@
 namespace rdf4cpp::rdf::storage::node::identifier {
 /**
  * Specifies weather an RDF node is a Variable, BlankNode, IRI or Literal.
+ * The ordering BNode, IRI, Literal is the same as in SPARQL operator<.
  */
 enum class RDFNodeType : uint8_t {
-    Variable = 0,
-    BNode,
+    BNode = 0,
     IRI,
-    Literal
+    Literal,
+    Variable
 };
 
 std::string as_string(RDFNodeType rdf_node_type) noexcept;

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/BNodeBackend.cpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/BNodeBackend.cpp
@@ -3,8 +3,11 @@
 namespace rdf4cpp::rdf::storage::node::reference_node_storage {
 
 BNodeBackend::BNodeBackend(std::string_view identifier) noexcept
-    : identifier_(identifier) {}
-BNodeBackend::BNodeBackend(view::BNodeBackendView view) noexcept : identifier_(view.identifier) {}
+    : identifier_(identifier),
+      hash_(View(*this).hash()) {}
+BNodeBackend::BNodeBackend(view::BNodeBackendView view) noexcept
+    : identifier_(view.identifier),
+      hash_(View(*this).hash()) {}
 std::partial_ordering BNodeBackend::operator<=>(std::unique_ptr<BNodeBackend> const &other) const noexcept {
     if (other != nullptr)
         return *this <=> *other;

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/BNodeBackend.cpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/BNodeBackend.cpp
@@ -8,19 +8,10 @@ BNodeBackend::BNodeBackend(std::string_view identifier) noexcept
 BNodeBackend::BNodeBackend(view::BNodeBackendView view) noexcept
     : identifier_(view.identifier),
       hash_(View(*this).hash()) {}
-std::partial_ordering BNodeBackend::operator<=>(std::unique_ptr<BNodeBackend> const &other) const noexcept {
-    if (other != nullptr)
-        return *this <=> *other;
-    else
-        return std::partial_ordering::greater;
-}
 std::string_view BNodeBackend::identifier() const noexcept {
     return identifier_;
 }
 BNodeBackend::operator view::BNodeBackendView() const noexcept {
     return {.identifier = identifier()};
-}
-std::partial_ordering operator<=>(const std::unique_ptr<BNodeBackend> &self, const std::unique_ptr<BNodeBackend> &other) noexcept {
-    return *self <=> *other;
 }
 }  // namespace rdf4cpp::rdf::storage::node::reference_node_storage

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/BNodeBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/BNodeBackend.hpp
@@ -19,11 +19,6 @@ public:
     using View = view::BNodeBackendView;
     explicit BNodeBackend(std::string_view identifier) noexcept;
     explicit BNodeBackend(view::BNodeBackendView view) noexcept;
-    auto operator<=>(BNodeBackend const &) const noexcept = default;
-    auto operator<=>(view::BNodeBackendView const &other) const noexcept {
-        return view::BNodeBackendView(*this) <=> other;
-    }
-    std::partial_ordering operator<=>(std::unique_ptr<BNodeBackend> const &other) const noexcept;
 
     [[nodiscard]] std::string_view identifier() const noexcept;
 
@@ -31,20 +26,6 @@ public:
 
     explicit operator view::BNodeBackendView() const noexcept;
 };
-
-std::partial_ordering operator<=>(std::unique_ptr<BNodeBackend> const &self, std::unique_ptr<BNodeBackend> const &other) noexcept;
 }  // namespace rdf4cpp::rdf::storage::node::reference_node_storage
 
-template<>
-struct std::hash<rdf4cpp::rdf::storage::node::reference_node_storage::BNodeBackend> {
-    size_t operator()(rdf4cpp::rdf::storage::node::reference_node_storage::BNodeBackend const &x) const noexcept {
-        return x.hash();
-    }
-};
-
-namespace rdf4cpp::rdf::storage::node::view {
-inline std::partial_ordering operator<=>(BNodeBackendView const &lhs, std::unique_ptr<reference_node_storage::BNodeBackend> const &rhs) noexcept {
-    return lhs <=> BNodeBackendView(*rhs);
-}
-}  // namespace rdf4cpp::rdf::storage::node::view
 #endif  //RDF4CPP_BNODEBACKEND_HPP

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/BNodeBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/BNodeBackend.hpp
@@ -13,8 +13,10 @@ namespace rdf4cpp::rdf::storage::node::reference_node_storage {
 
 class BNodeBackend {
     std::string identifier_;
+    size_t hash_;
 
 public:
+    using View = view::BNodeBackendView;
     explicit BNodeBackend(std::string_view identifier) noexcept;
     explicit BNodeBackend(view::BNodeBackendView view) noexcept;
     auto operator<=>(BNodeBackend const &) const noexcept = default;
@@ -25,11 +27,20 @@ public:
 
     [[nodiscard]] std::string_view identifier() const noexcept;
 
+    [[nodiscard]] size_t hash() const noexcept { return hash_; }
+
     explicit operator view::BNodeBackendView() const noexcept;
 };
 
 std::partial_ordering operator<=>(std::unique_ptr<BNodeBackend> const &self, std::unique_ptr<BNodeBackend> const &other) noexcept;
 }  // namespace rdf4cpp::rdf::storage::node::reference_node_storage
+
+template<>
+struct std::hash<rdf4cpp::rdf::storage::node::reference_node_storage::BNodeBackend> {
+    size_t operator()(rdf4cpp::rdf::storage::node::reference_node_storage::BNodeBackend const &x) const noexcept {
+        return x.hash();
+    }
+};
 
 namespace rdf4cpp::rdf::storage::node::view {
 inline std::partial_ordering operator<=>(BNodeBackendView const &lhs, std::unique_ptr<reference_node_storage::BNodeBackend> const &rhs) noexcept {

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/IRIBackend.cpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/IRIBackend.cpp
@@ -8,19 +8,10 @@ IRIBackend::IRIBackend(std::string_view iri) noexcept
 IRIBackend::IRIBackend(view::IRIBackendView view) noexcept
     : iri(view.identifier),
       hash_(View(*this).hash()) {}
-std::partial_ordering IRIBackend::operator<=>(std::unique_ptr<IRIBackend> const &other) const noexcept {
-    if (other)
-        return *this <=> *other;
-    else
-        return std::partial_ordering::greater;
-}
 std::string_view IRIBackend::identifier() const noexcept {
     return iri;
 }
 IRIBackend::operator view::IRIBackendView() const noexcept {
     return {.identifier = identifier()};
-}
-std::partial_ordering operator<=>(const std::unique_ptr<IRIBackend> &self, const std::unique_ptr<IRIBackend> &other) noexcept {
-    return *self <=> *other;
 }
 }  // namespace rdf4cpp::rdf::storage::node::reference_node_storage

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/IRIBackend.cpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/IRIBackend.cpp
@@ -2,8 +2,12 @@
 
 namespace rdf4cpp::rdf::storage::node::reference_node_storage {
 
-IRIBackend::IRIBackend(std::string_view iri) noexcept : iri(iri) {}
-IRIBackend::IRIBackend(view::IRIBackendView view) noexcept : iri(view.identifier) {}
+IRIBackend::IRIBackend(std::string_view iri) noexcept
+    : iri(iri),
+      hash_(View(*this).hash()) {}
+IRIBackend::IRIBackend(view::IRIBackendView view) noexcept
+    : iri(view.identifier),
+      hash_(View(*this).hash()) {}
 std::partial_ordering IRIBackend::operator<=>(std::unique_ptr<IRIBackend> const &other) const noexcept {
     if (other)
         return *this <=> *other;

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/IRIBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/IRIBackend.hpp
@@ -20,11 +20,6 @@ public:
     using View = view::IRIBackendView;
     explicit IRIBackend(std::string_view iri) noexcept;
     explicit IRIBackend(view::IRIBackendView view) noexcept;
-    auto operator<=>(const IRIBackend &) const = default;
-    auto operator<=>(view::IRIBackendView const &other) const noexcept {
-        return view::IRIBackendView(*this) <=> other;
-    }
-    std::partial_ordering operator<=>(std::unique_ptr<IRIBackend> const &other) const noexcept;
 
     [[nodiscard]] std::string_view identifier() const noexcept;
 
@@ -32,19 +27,6 @@ public:
 
     [[nodiscard]] size_t hash() const noexcept { return hash_; }
 };
-std::partial_ordering operator<=>(std::unique_ptr<IRIBackend> const &self, std::unique_ptr<IRIBackend> const &other) noexcept;
 }  // namespace rdf4cpp::rdf::storage::node::reference_node_storage
 
-template<>
-struct std::hash<rdf4cpp::rdf::storage::node::reference_node_storage::IRIBackend> {
-    size_t operator()(rdf4cpp::rdf::storage::node::reference_node_storage::IRIBackend const &x) const noexcept {
-        return x.hash();
-    }
-};
-
-namespace rdf4cpp::rdf::storage::node::view {
-inline std::partial_ordering operator<=>(IRIBackendView const &lhs, std::unique_ptr<reference_node_storage::IRIBackend> const &rhs) noexcept {
-    return lhs <=> IRIBackendView(*rhs);
-}
-}  // namespace rdf4cpp::rdf::storage::node::view
 #endif  //RDF4CPP_IRIBACKEND_HPP

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/IRIBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/IRIBackend.hpp
@@ -14,8 +14,10 @@ namespace rdf4cpp::rdf::storage::node::reference_node_storage {
 
 class IRIBackend {
     std::string iri;
+    size_t hash_;
 
 public:
+    using View = view::IRIBackendView;
     explicit IRIBackend(std::string_view iri) noexcept;
     explicit IRIBackend(view::IRIBackendView view) noexcept;
     auto operator<=>(const IRIBackend &) const = default;
@@ -27,9 +29,19 @@ public:
     [[nodiscard]] std::string_view identifier() const noexcept;
 
     explicit operator view::IRIBackendView() const noexcept;
+
+    [[nodiscard]] size_t hash() const noexcept { return hash_; }
 };
 std::partial_ordering operator<=>(std::unique_ptr<IRIBackend> const &self, std::unique_ptr<IRIBackend> const &other) noexcept;
 }  // namespace rdf4cpp::rdf::storage::node::reference_node_storage
+
+template<>
+struct std::hash<rdf4cpp::rdf::storage::node::reference_node_storage::IRIBackend> {
+    size_t operator()(rdf4cpp::rdf::storage::node::reference_node_storage::IRIBackend const &x) const noexcept {
+        return x.hash();
+    }
+};
+
 namespace rdf4cpp::rdf::storage::node::view {
 inline std::partial_ordering operator<=>(IRIBackendView const &lhs, std::unique_ptr<reference_node_storage::IRIBackend> const &rhs) noexcept {
     return lhs <=> IRIBackendView(*rhs);

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/LiteralBackend.cpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/LiteralBackend.cpp
@@ -16,19 +16,6 @@ LiteralBackend::LiteralBackend(view::LiteralBackendView view) noexcept
       lang_tag(view.language_tag),
       hash_(View(*this).hash()){};
 
-std::partial_ordering LiteralBackend::operator<=>(LiteralBackend const &other) const noexcept {
-    return std::tie(this->datatype_id_, this->lexical, this->lang_tag) <=> std::tie(other.datatype_id_, other.lexical, other.lang_tag);
-}
-
-bool LiteralBackend::operator==(LiteralBackend const &other) const noexcept {
-    return std::tie(this->datatype_id_, this->lexical, this->lang_tag) == std::tie(other.datatype_id_, other.lexical, other.lang_tag);
-}
-std::partial_ordering LiteralBackend::operator<=>(std::unique_ptr<LiteralBackend> const &other) const noexcept {
-    if (other)
-        return *this <=> *other;
-    else
-        return std::partial_ordering::greater;
-}
 std::string_view LiteralBackend::language_tag() const noexcept {
     return lang_tag;
 }
@@ -42,9 +29,5 @@ LiteralBackend::operator view::LiteralBackendView() const noexcept {
     return {.datatype_id = datatype_id(),
             .lexical_form = lexical_form(),
             .language_tag = language_tag()};
-}
-
-std::partial_ordering operator<=>(std::unique_ptr<LiteralBackend> const &self, std::unique_ptr<LiteralBackend> const &other) noexcept {
-    return *self <=> *other;
 }
 }  // namespace rdf4cpp::rdf::storage::node::reference_node_storage

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/LiteralBackend.cpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/LiteralBackend.cpp
@@ -8,41 +8,18 @@ namespace rdf4cpp::rdf::storage::node::reference_node_storage {
 LiteralBackend::LiteralBackend(std::string_view lexical, identifier::NodeID dataType, std::string_view langTag) noexcept
     : datatype_id_(dataType),
       lexical(lexical),
-      lang_tag(langTag) {}
-LiteralBackend::LiteralBackend(view::LiteralBackendView view) noexcept : datatype_id_(view.datatype_id), lexical(view.lexical_form), lang_tag(view.language_tag){};
+      lang_tag(langTag),
+      hash_(View(*this).hash()) {}
+LiteralBackend::LiteralBackend(view::LiteralBackendView view) noexcept
+    : datatype_id_(view.datatype_id),
+      lexical(view.lexical_form),
+      lang_tag(view.language_tag),
+      hash_(View(*this).hash()){};
 
 std::partial_ordering LiteralBackend::operator<=>(LiteralBackend const &other) const noexcept {
     return std::tie(this->datatype_id_, this->lexical, this->lang_tag) <=> std::tie(other.datatype_id_, other.lexical, other.lang_tag);
 }
 
-std::string LiteralBackend::quote_lexical() const noexcept {
-    // TODO: covers only the most common cases. There might still be characters that are not allowed in N-Triple strings
-    std::ostringstream out{};
-    out << "\"";
-
-    for (auto const &character : lexical) {
-        switch (character) {
-            case '\n': {
-                out << R"(\n)";
-                break;
-            }
-            case '\r': {
-                out << R"(\r)";
-                break;
-            }
-            case '"': {
-                out << R"(\")";
-                break;
-            }
-                [[likely]] default : {
-                    out << character;
-                    break;
-                }
-        }
-    }
-    out << "\"";
-    return out.str();
-}
 bool LiteralBackend::operator==(LiteralBackend const &other) const noexcept {
     return std::tie(this->datatype_id_, this->lexical, this->lang_tag) == std::tie(other.datatype_id_, other.lexical, other.lang_tag);
 }

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/LiteralBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/LiteralBackend.hpp
@@ -15,9 +15,10 @@ class LiteralBackend {
     identifier::NodeID datatype_id_;
     std::string lexical;
     std::string lang_tag;
+    size_t hash_;
 
 public:
-    [[nodiscard]] std::string quote_lexical() const noexcept;
+    using View = view::LiteralBackendView;
     LiteralBackend(std::string_view lexical, identifier::NodeID dataType, std::string_view langTag = "") noexcept;
     explicit LiteralBackend(view::LiteralBackendView view) noexcept;
     std::partial_ordering operator<=>(LiteralBackend const &) const noexcept;
@@ -34,12 +35,21 @@ public:
 
     [[nodiscard]] std::string_view language_tag() const noexcept;
 
+    [[nodiscard]] size_t hash() const noexcept { return hash_; }
+
     explicit operator view::LiteralBackendView() const noexcept;
 };
 
 
 std::partial_ordering operator<=>(std::unique_ptr<LiteralBackend> const &self, std::unique_ptr<LiteralBackend> const &other) noexcept;
 }  // namespace rdf4cpp::rdf::storage::node::reference_node_storage
+
+template<>
+struct std::hash<rdf4cpp::rdf::storage::node::reference_node_storage::LiteralBackend> {
+    size_t operator()(rdf4cpp::rdf::storage::node::reference_node_storage::LiteralBackend const &x) const noexcept {
+        return x.hash();
+    }
+};
 
 namespace rdf4cpp::rdf::storage::node::view {
 inline std::partial_ordering operator<=>(LiteralBackendView const &lhs, std::unique_ptr<reference_node_storage::LiteralBackend> const &rhs) noexcept {

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/LiteralBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/LiteralBackend.hpp
@@ -21,11 +21,6 @@ public:
     using View = view::LiteralBackendView;
     LiteralBackend(std::string_view lexical, identifier::NodeID dataType, std::string_view langTag = "") noexcept;
     explicit LiteralBackend(view::LiteralBackendView view) noexcept;
-    std::partial_ordering operator<=>(LiteralBackend const &) const noexcept;
-    auto operator<=>(view::LiteralBackendView const &other) const noexcept {
-        return view::LiteralBackendView(*this) <=> other;
-    }
-    std::partial_ordering operator<=>(std::unique_ptr<LiteralBackend> const &other) const noexcept;
 
     bool operator==(const LiteralBackend &) const noexcept;
 
@@ -41,20 +36,6 @@ public:
 };
 
 
-std::partial_ordering operator<=>(std::unique_ptr<LiteralBackend> const &self, std::unique_ptr<LiteralBackend> const &other) noexcept;
-}  // namespace rdf4cpp::rdf::storage::node::reference_node_storage
-
-template<>
-struct std::hash<rdf4cpp::rdf::storage::node::reference_node_storage::LiteralBackend> {
-    size_t operator()(rdf4cpp::rdf::storage::node::reference_node_storage::LiteralBackend const &x) const noexcept {
-        return x.hash();
-    }
-};
-
-namespace rdf4cpp::rdf::storage::node::view {
-inline std::partial_ordering operator<=>(LiteralBackendView const &lhs, std::unique_ptr<reference_node_storage::LiteralBackend> const &rhs) noexcept {
-    return lhs <=> LiteralBackendView(*rhs);
-}
 }  // namespace rdf4cpp::rdf::storage::node::view
 
 #endif  //RDF4CPP_LITERALBACKEND_HPP

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/NodeTypeStorage.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/NodeTypeStorage.hpp
@@ -1,0 +1,53 @@
+#ifndef RDF4CPP_NODETYPESTORAGE_HPP
+#define RDF4CPP_NODETYPESTORAGE_HPP
+
+#include <rdf4cpp/rdf/storage/util/tsl/sparse_map.h>
+
+#include <rdf4cpp/rdf/storage/node/identifier/NodeID.hpp>
+
+#include <memory>
+#include <shared_mutex>
+
+
+namespace rdf4cpp::rdf::storage::node::reference_node_storage {
+/**
+ * Storage for one of the Node Backend types. Includes a shared mutex to synchronize access and bidirectional mappings between the Backend type and identifier::NodeID.
+ * @tparam BackendType_t one of BNodeBackend, IRIBackend, LiteralBackend and VariableBackend.
+ */
+template<class BackendType_t>
+struct NodeTypeStorage {
+    using Backend = BackendType_t;
+    using BackendView = typename Backend::View;
+    struct BackendTypeHash {
+        [[nodiscard]] size_t operator()(std::unique_ptr<Backend> const &x) const noexcept {
+            return x->hash();
+        }
+        [[nodiscard]] size_t operator()(BackendView const &x) const noexcept {
+            return x.hash();
+        }
+    };
+
+    struct BackendTypeEqual {
+        using is_transparent = void;
+
+        bool operator()(std::unique_ptr<Backend> const &lhs, std::unique_ptr<Backend> const &rhs) const noexcept {
+            return lhs == rhs;
+        }
+        bool operator()(BackendView const &lhs, std::unique_ptr<Backend> const &rhs) const noexcept {
+            return lhs == BackendView(*rhs);
+        }
+    };
+
+    struct NodeIDHash {
+        [[nodiscard]] size_t operator()(identifier::NodeID const &x) const noexcept {
+            return x.value();
+        }
+    };
+
+    mutable std::shared_mutex mutex;
+    util::tsl::sparse_map<identifier::NodeID, Backend *, NodeIDHash> id2data;
+    util::tsl::sparse_map<std::unique_ptr<Backend>, identifier::NodeID, BackendTypeHash, BackendTypeEqual> data2id;
+};
+}  // namespace rdf4cpp::rdf::storage::node::reference_node_storage
+
+#endif  //RDF4CPP_NODETYPESTORAGE_HPP

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/ReferenceNodeStorageBackend.cpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/ReferenceNodeStorageBackend.cpp
@@ -8,30 +8,30 @@ ReferenceNodeStorageBackend::ReferenceNodeStorageBackend() : INodeStorageBackend
     // TODO: that should be done by (Abstract)NodeContextBackend
     // some iri's like xsd:string are there by default
     for (const auto &[id, iri] : NodeID::predefined_iris) {
-        auto [iter, inserted_successfully] = iri_storage_reverse.emplace(std::make_unique<IRIBackend>(iri), id);
+        auto [iter, inserted_successfully] = iri_storage_.data2id.emplace(std::make_unique<IRIBackend>(iri), id);
         assert(inserted_successfully);
-        iri_storage.insert({id, iter->first.get()});
+        iri_storage_.id2data.emplace(id, iter->first.get());
     }
 }
 
-template<class Backend_t, bool create_if_not_present, class View_t, class Storage_t, class ReverseStorage_t, class NextIDFromView_func = void *>
-inline identifier::NodeID lookup_or_insert_impl(View_t view, std::shared_mutex &mutex, Storage_t &storage,
-                                                ReverseStorage_t &reverse_storage,
+template<class Backend_t, bool create_if_not_present, class NextIDFromView_func = void *>
+inline identifier::NodeID lookup_or_insert_impl(typename Backend_t::View const &view,
+                                                auto &storage,
                                                 NextIDFromView_func next_id_func = nullptr) noexcept {
-    std::shared_lock<std::shared_mutex> shared_lock{mutex};
-    auto found = reverse_storage.find(view);
-    if (found == reverse_storage.end()) {
+    std::shared_lock<std::shared_mutex> shared_lock{storage.mutex};
+    auto found = storage.data2id.find(view);
+    if (found == storage.data2id.end()) {
         if constexpr (create_if_not_present) {
             shared_lock.unlock();
-            std::unique_lock<std::shared_mutex> unique_lock{mutex};
+            std::unique_lock<std::shared_mutex> unique_lock{storage.mutex};
             // update found (might have changed in the meantime)
-            found = reverse_storage.find(view);
-            if (found == reverse_storage.end()) {
+            found = storage.data2id.find(view);
+            if (found == storage.data2id.end()) {
                 identifier::NodeID id = next_id_func(view);
-                auto [found2, inserted_successfully] = reverse_storage.emplace(std::make_unique<typename ReverseStorage_t::key_type::element_type>(view), id);
+                auto [found2, inserted_successfully] = storage.data2id.emplace(std::make_unique<Backend_t>(view), id);
                 assert(inserted_successfully);
                 found = std::move(found2);
-                storage.insert({id, found->first.get()});
+                storage.id2data.emplace(id, found->first.get());
                 return id;
             } else {
                 unique_lock.unlock();
@@ -48,7 +48,7 @@ inline identifier::NodeID lookup_or_insert_impl(View_t view, std::shared_mutex &
 
 identifier::NodeID ReferenceNodeStorageBackend::find_or_make_id(view::LiteralBackendView const &view) noexcept {
     return lookup_or_insert_impl<LiteralBackend, true>(
-            view, literal_mutex_, literal_storage, literal_storage_reverse,
+            view, literal_storage_,
             [this]([[maybe_unused]] view::LiteralBackendView const &literal_view) {
                 // TODO: actually use LiteralType (therefore, we will need literal_view)
                 return identifier::NodeID{next_literal_id++, identifier::LiteralType::OTHER};
@@ -57,7 +57,7 @@ identifier::NodeID ReferenceNodeStorageBackend::find_or_make_id(view::LiteralBac
 
 identifier::NodeID ReferenceNodeStorageBackend::find_or_make_id(view::IRIBackendView const &view) noexcept {
     return lookup_or_insert_impl<IRIBackend, true>(
-            view, iri_mutex_, iri_storage, iri_storage_reverse,
+            view, iri_storage_,
             [this]([[maybe_unused]] view::IRIBackendView const &view) {
                 return next_iri_id++;
             });
@@ -65,14 +65,14 @@ identifier::NodeID ReferenceNodeStorageBackend::find_or_make_id(view::IRIBackend
 
 identifier::NodeID ReferenceNodeStorageBackend::find_or_make_id(view::BNodeBackendView const &view) noexcept {
     return lookup_or_insert_impl<BNodeBackend, true>(
-            view, bnode_mutex_, bnode_storage, bnode_storage_reverse,
+            view, bnode_storage_,
             [this]([[maybe_unused]] view::BNodeBackendView const &view) {
                 return next_bnode_id++;
             });
 }
 identifier::NodeID ReferenceNodeStorageBackend::find_or_make_id(view::VariableBackendView const &view) noexcept {
     return lookup_or_insert_impl<VariableBackend, true>(
-            view, variable_mutex_, variable_storage, variable_storage_reverse,
+            view, variable_storage_,
             [this]([[maybe_unused]] view::VariableBackendView const &view) {
                 return next_variable_id++;
             });
@@ -80,36 +80,38 @@ identifier::NodeID ReferenceNodeStorageBackend::find_or_make_id(view::VariableBa
 
 identifier::NodeID ReferenceNodeStorageBackend::find_id(const view::BNodeBackendView &view) const noexcept {
     return lookup_or_insert_impl<BNodeBackend, false>(
-            view, bnode_mutex_, bnode_storage, bnode_storage_reverse);
+            view, bnode_storage_);
 }
 identifier::NodeID ReferenceNodeStorageBackend::find_id(const view::IRIBackendView &view) const noexcept {
     return lookup_or_insert_impl<IRIBackend, false>(
-            view, iri_mutex_, iri_storage, iri_storage_reverse);
+            view, iri_storage_);
 }
 identifier::NodeID ReferenceNodeStorageBackend::find_id(const view::LiteralBackendView &view) const noexcept {
     return lookup_or_insert_impl<LiteralBackend, false>(
-            view, literal_mutex_, literal_storage, literal_storage_reverse);
+            view, literal_storage_);
 }
 identifier::NodeID ReferenceNodeStorageBackend::find_id(const view::VariableBackendView &view) const noexcept {
     return lookup_or_insert_impl<VariableBackend, false>(
-            view, variable_mutex_, variable_storage, variable_storage_reverse);
+            view, variable_storage_);
+}
+
+template<typename NodeTypeStorage>
+typename NodeTypeStorage::BackendView find_backend_view(NodeTypeStorage &storage, identifier::NodeID id) {
+    std::shared_lock<std::shared_mutex> shared_lock{storage.mutex};
+    return typename NodeTypeStorage::BackendView(*storage.id2data.at(id));
 }
 
 view::IRIBackendView ReferenceNodeStorageBackend::find_iri_backend_view(identifier::NodeID id) const {
-    std::shared_lock<std::shared_mutex> shared_lock{iri_mutex_};
-    return view::IRIBackendView(*iri_storage.at(id));
+    return find_backend_view(iri_storage_, id);
 }
 view::LiteralBackendView ReferenceNodeStorageBackend::find_literal_backend_view(identifier::NodeID id) const {
-    std::shared_lock<std::shared_mutex> shared_lock{literal_mutex_};
-    return view::LiteralBackendView(*literal_storage.at(id));
+    return find_backend_view(literal_storage_, id);
 }
 view::BNodeBackendView ReferenceNodeStorageBackend::find_bnode_backend_view(identifier::NodeID id) const {
-    std::shared_lock<std::shared_mutex> shared_lock{bnode_mutex_};
-    return view::BNodeBackendView(*bnode_storage.at(id));
+    return find_backend_view(bnode_storage_, id);
 }
 view::VariableBackendView ReferenceNodeStorageBackend::find_variable_backend_view(identifier::NodeID id) const {
-    std::shared_lock<std::shared_mutex> shared_lock{variable_mutex_};
-    return view::VariableBackendView(*variable_storage.at(id));
+    return find_backend_view(variable_storage_, id);
 }
 bool ReferenceNodeStorageBackend::erase_iri([[maybe_unused]] identifier::NodeID id) const {
     throw std::runtime_error("Deleting nodes is not implemented in ReferenceNodeStorageBackend.");

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/ReferenceNodeStorageBackend.cpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/ReferenceNodeStorageBackend.cpp
@@ -5,7 +5,6 @@
 namespace rdf4cpp::rdf::storage::node::reference_node_storage {
 
 ReferenceNodeStorageBackend::ReferenceNodeStorageBackend() : INodeStorageBackend() {
-    // TODO: that should be done by (Abstract)NodeContextBackend
     // some iri's like xsd:string are there by default
     for (const auto &[id, iri] : NodeID::predefined_iris) {
         auto [iter, inserted_successfully] = iri_storage_.data2id.emplace(std::make_unique<IRIBackend>(iri), id);
@@ -14,6 +13,16 @@ ReferenceNodeStorageBackend::ReferenceNodeStorageBackend() : INodeStorageBackend
     }
 }
 
+/**
+ * Synchronized lookup (and creation) of IDs by a provided view of a Node Backend.
+ * @tparam Backend_t the Backend type. One of BNodeBackend, IRIBackend, LiteralBackend or VariableBackend
+ * @tparam create_if_not_present enables code for creating non-existing Node Backends
+ * @tparam NextIDFromView_func type of a function to generate the next ID which is assigned in case a new Node Backend is created
+ * @param view contains the data of the requested Node Backend
+ * @param storage the storage where the Node Backend is looked up
+ * @param next_id_func function to generate the next ID which is assigned in case a new Node Backend is created
+ * @return the NodeID for the looked up Node Backend. Result is null() if there was no matching Node Backend.
+ */
 template<class Backend_t, bool create_if_not_present, class NextIDFromView_func = void *>
 inline identifier::NodeID lookup_or_insert_impl(typename Backend_t::View const &view,
                                                 auto &storage,

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/ReferenceNodeStorageBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/ReferenceNodeStorageBackend.hpp
@@ -3,15 +3,13 @@
 
 #include <rdf4cpp/rdf/storage/node/INodeStorageBackend.hpp>
 
+#include <rdf4cpp/rdf/storage/node/reference_node_storage/NodeTypeStorage.hpp>
+
 #include <rdf4cpp/rdf/storage/node/reference_node_storage/BNodeBackend.hpp>
 #include <rdf4cpp/rdf/storage/node/reference_node_storage/IRIBackend.hpp>
 #include <rdf4cpp/rdf/storage/node/reference_node_storage/LiteralBackend.hpp>
 #include <rdf4cpp/rdf/storage/node/reference_node_storage/VariableBackend.hpp>
 
-#include <map>
-#include <memory>
-#include <mutex>
-#include <shared_mutex>
 
 namespace rdf4cpp::rdf::storage::node::reference_node_storage {
 
@@ -24,18 +22,10 @@ public:
     using LiteralID = identifier::LiteralID;
 
 private:
-    mutable std::shared_mutex literal_mutex_;
-    std::map<NodeID, LiteralBackend *, std::less<>> literal_storage;
-    std::map<std::unique_ptr<LiteralBackend>, NodeID, std::less<>> literal_storage_reverse;
-    mutable std::shared_mutex bnode_mutex_;
-    std::map<NodeID, BNodeBackend *, std::less<>> bnode_storage;
-    std::map<std::unique_ptr<BNodeBackend>, NodeID, std::less<>> bnode_storage_reverse;
-    mutable std::shared_mutex iri_mutex_;
-    std::map<NodeID, IRIBackend *, std::less<>> iri_storage;
-    std::map<std::unique_ptr<IRIBackend>, NodeID, std::less<>> iri_storage_reverse;
-    mutable std::shared_mutex variable_mutex_;
-    std::map<NodeID, VariableBackend *, std::less<>> variable_storage;
-    std::map<std::unique_ptr<VariableBackend>, NodeID, std::less<>> variable_storage_reverse;
+    NodeTypeStorage<BNodeBackend> bnode_storage_;
+    NodeTypeStorage<IRIBackend> iri_storage_;
+    NodeTypeStorage<LiteralBackend> literal_storage_;
+    NodeTypeStorage<VariableBackend> variable_storage_;
 
     LiteralID next_literal_id = NodeID::min_literal_id;
     NodeID next_bnode_id = NodeID::min_bnode_id;

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/VariableBackend.cpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/VariableBackend.cpp
@@ -3,8 +3,13 @@
 namespace rdf4cpp::rdf::storage::node::reference_node_storage {
 
 VariableBackend::VariableBackend(std::string_view name, bool anonymous) noexcept
-    : name_(name), anonymous_(anonymous) {}
-VariableBackend::VariableBackend(view::VariableBackendView view) noexcept : name_(view.name), anonymous_(view.is_anonymous) {}
+    : name_(name),
+      anonymous_(anonymous),
+      hash_(View(*this).hash()) {}
+VariableBackend::VariableBackend(view::VariableBackendView view) noexcept
+    : name_(view.name),
+      anonymous_(view.is_anonymous),
+      hash_(View(*this).hash()) {}
 std::partial_ordering VariableBackend::operator<=>(std::unique_ptr<VariableBackend> const &other) const noexcept {
     if (other != nullptr)
         return *this <=> *other;

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/VariableBackend.cpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/VariableBackend.cpp
@@ -10,12 +10,6 @@ VariableBackend::VariableBackend(view::VariableBackendView view) noexcept
     : name_(view.name),
       anonymous_(view.is_anonymous),
       hash_(View(*this).hash()) {}
-std::partial_ordering VariableBackend::operator<=>(std::unique_ptr<VariableBackend> const &other) const noexcept {
-    if (other != nullptr)
-        return *this <=> *other;
-    else
-        return std::partial_ordering::greater;
-}
 bool VariableBackend::is_anonymous() const noexcept {
     return anonymous_;
 }
@@ -25,8 +19,5 @@ std::string_view VariableBackend::name() const noexcept {
 VariableBackend::operator view::VariableBackendView() const noexcept {
     return {.name = name(),
             .is_anonymous = is_anonymous()};
-}
-std::partial_ordering operator<=>(const std::unique_ptr<VariableBackend> &self, const std::unique_ptr<VariableBackend> &other) noexcept {
-    return *self <=> *other;
 }
 }  // namespace rdf4cpp::rdf::storage::node::reference_node_storage

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/VariableBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/VariableBackend.hpp
@@ -20,11 +20,6 @@ public:
     using View = view::VariableBackendView;
     explicit VariableBackend(std::string_view name, bool anonymous = false) noexcept;
     explicit VariableBackend(view::VariableBackendView view) noexcept;
-    auto operator<=>(const VariableBackend &) const noexcept = default;
-    auto operator<=>(view::VariableBackendView const &other) const noexcept {
-        return view::VariableBackendView(*this) <=> other;
-    }
-    std::partial_ordering operator<=>(std::unique_ptr<VariableBackend> const &other) const noexcept;
 
     [[nodiscard]] bool is_anonymous() const noexcept;
 
@@ -35,19 +30,6 @@ public:
     explicit operator view::VariableBackendView() const noexcept;
 };
 
-std::partial_ordering operator<=>(std::unique_ptr<VariableBackend> const &self, std::unique_ptr<VariableBackend> const &other) noexcept;
 }  // namespace rdf4cpp::rdf::storage::node::reference_node_storage
 
-template<>
-struct std::hash<rdf4cpp::rdf::storage::node::reference_node_storage::VariableBackend> {
-    size_t operator()(rdf4cpp::rdf::storage::node::reference_node_storage::VariableBackend const &x) const noexcept {
-        return x.hash();
-    }
-};
-
-namespace rdf4cpp::rdf::storage::node::view {
-inline std::partial_ordering operator<=>(VariableBackendView const &lhs, std::unique_ptr<reference_node_storage::VariableBackend> const &rhs) noexcept {
-    return lhs <=> VariableBackendView(*rhs);
-}
-}  // namespace rdf4cpp::rdf::storage::node::view
 #endif  //RDF4CPP_VARIABLEBACKEND_HPP

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/VariableBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/VariableBackend.hpp
@@ -14,8 +14,10 @@ namespace rdf4cpp::rdf::storage::node::reference_node_storage {
 class VariableBackend {
     std::string name_;
     bool anonymous_;
+    size_t hash_;
 
 public:
+    using View = view::VariableBackendView;
     explicit VariableBackend(std::string_view name, bool anonymous = false) noexcept;
     explicit VariableBackend(view::VariableBackendView view) noexcept;
     auto operator<=>(const VariableBackend &) const noexcept = default;
@@ -28,11 +30,20 @@ public:
 
     [[nodiscard]] std::string_view name() const noexcept;
 
+    [[nodiscard]] size_t hash() const noexcept { return hash_; }
+
     explicit operator view::VariableBackendView() const noexcept;
 };
 
 std::partial_ordering operator<=>(std::unique_ptr<VariableBackend> const &self, std::unique_ptr<VariableBackend> const &other) noexcept;
 }  // namespace rdf4cpp::rdf::storage::node::reference_node_storage
+
+template<>
+struct std::hash<rdf4cpp::rdf::storage::node::reference_node_storage::VariableBackend> {
+    size_t operator()(rdf4cpp::rdf::storage::node::reference_node_storage::VariableBackend const &x) const noexcept {
+        return x.hash();
+    }
+};
 
 namespace rdf4cpp::rdf::storage::node::view {
 inline std::partial_ordering operator<=>(VariableBackendView const &lhs, std::unique_ptr<reference_node_storage::VariableBackend> const &rhs) noexcept {

--- a/src/rdf4cpp/rdf/storage/node/view/BNodeBackendView.cpp
+++ b/src/rdf4cpp/rdf/storage/node/view/BNodeBackendView.cpp
@@ -1,6 +1,17 @@
 #include "BNodeBackendView.hpp"
+
+#include <rdf4cpp/rdf/storage/util/robin-hood-hashing/robin_hood_hash.hpp>
+
 namespace rdf4cpp::rdf::storage::node::view {
 std::string BNodeBackendView::n_string() const noexcept {
     return "_:" + std::string{identifier};
 }
+size_t BNodeBackendView::hash() const noexcept {
+    return std::hash<BNodeBackendView>()(*this);
+}
 }  // namespace rdf4cpp::rdf::storage::node::view
+
+size_t std::hash<rdf4cpp::rdf::storage::node::view::BNodeBackendView>::operator()(const rdf4cpp::rdf::storage::node::view::BNodeBackendView &x) const noexcept {
+    using namespace rdf4cpp::rdf::storage::util;
+    return robin_hood::hash<std::string_view>()(x.identifier);
+}

--- a/src/rdf4cpp/rdf/storage/node/view/BNodeBackendView.hpp
+++ b/src/rdf4cpp/rdf/storage/node/view/BNodeBackendView.hpp
@@ -16,7 +16,14 @@ struct BNodeBackendView {
      */
     [[nodiscard]] std::string n_string() const noexcept;
     auto operator<=>(BNodeBackendView const &) const noexcept = default;
+
+    [[nodiscard]] size_t hash() const noexcept;
 };
 }  // namespace rdf4cpp::rdf::storage::node::view
+
+template<>
+struct std::hash<rdf4cpp::rdf::storage::node::view::BNodeBackendView> {
+    size_t operator()(rdf4cpp::rdf::storage::node::view::BNodeBackendView const &x) const noexcept;
+};
 
 #endif  //RDF4CPP_BNODEBACKENDHANDLE_HPP

--- a/src/rdf4cpp/rdf/storage/node/view/IRIBackendView.cpp
+++ b/src/rdf4cpp/rdf/storage/node/view/IRIBackendView.cpp
@@ -1,6 +1,17 @@
 #include "IRIBackendView.hpp"
+
+#include <rdf4cpp/rdf/storage/util/robin-hood-hashing/robin_hood_hash.hpp>
+
 namespace rdf4cpp::rdf::storage::node::view {
 std::string IRIBackendView::n_string() const noexcept {
     return "<" + std::string{identifier} + ">";
 }
+size_t IRIBackendView::hash() const noexcept {
+    return std::hash<IRIBackendView>()(*this);
+}
 }  // namespace rdf4cpp::rdf::storage::node::view
+
+size_t std::hash<rdf4cpp::rdf::storage::node::view::IRIBackendView>::operator()(const rdf4cpp::rdf::storage::node::view::IRIBackendView &x) const noexcept {
+    using namespace rdf4cpp::rdf::storage::util;
+    return robin_hood::hash<std::string_view>()(x.identifier);
+}

--- a/src/rdf4cpp/rdf/storage/node/view/IRIBackendView.hpp
+++ b/src/rdf4cpp/rdf/storage/node/view/IRIBackendView.hpp
@@ -17,6 +17,14 @@ struct IRIBackendView {
     [[nodiscard]] std::string n_string() const noexcept;
 
     auto operator<=>(IRIBackendView const &) const noexcept = default;
+
+    [[nodiscard]] size_t hash() const noexcept;
 };
 }  // namespace rdf4cpp::rdf::storage::node::view
+
+template<>
+struct std::hash<rdf4cpp::rdf::storage::node::view::IRIBackendView> {
+    size_t operator()(rdf4cpp::rdf::storage::node::view::IRIBackendView const &x) const noexcept;
+};
+
 #endif  //RDF4CPP_IRIBACKENDHANDLE_HPP

--- a/src/rdf4cpp/rdf/storage/node/view/LiteralBackendView.cpp
+++ b/src/rdf4cpp/rdf/storage/node/view/LiteralBackendView.cpp
@@ -1,3 +1,18 @@
 #include "LiteralBackendView.hpp"
+
+#include "rdf4cpp/rdf/storage/util/robin-hood-hashing/robin_hood_hash.hpp"
+
 namespace rdf4cpp::rdf::storage::node::view {
+size_t LiteralBackendView::hash() const noexcept {
+    return std::hash<LiteralBackendView>()(*this);
+}
+};  // namespace rdf4cpp::rdf::storage::node::view
+
+size_t std::hash<rdf4cpp::rdf::storage::node::view::LiteralBackendView>::operator()(const rdf4cpp::rdf::storage::node::view::LiteralBackendView &x) const noexcept {
+    using namespace rdf4cpp::rdf::storage::util;
+    return robin_hood::hash<std::array<size_t, 3>>()(
+            std::array<size_t, 3>{
+                    x.datatype_id.value(),
+                    robin_hood::hash<std::string_view>()(x.lexical_form),
+                    robin_hood::hash<std::string_view>()(x.language_tag)});
 }

--- a/src/rdf4cpp/rdf/storage/node/view/LiteralBackendView.hpp
+++ b/src/rdf4cpp/rdf/storage/node/view/LiteralBackendView.hpp
@@ -15,7 +15,14 @@ struct LiteralBackendView {
     std::string_view language_tag;
 
     auto operator<=>(LiteralBackendView const &) const noexcept = default;
+    bool operator==(LiteralBackendView const &) const noexcept = default;
+
+    [[nodiscard]] size_t hash() const noexcept;
 };
 }  // namespace rdf4cpp::rdf::storage::node::view
 
+template<>
+struct std::hash<rdf4cpp::rdf::storage::node::view::LiteralBackendView> {
+    size_t operator()(rdf4cpp::rdf::storage::node::view::LiteralBackendView const &x) const noexcept;
+};
 #endif  //RDF4CPP_LITERALBACKENDHANDLE_HPP

--- a/src/rdf4cpp/rdf/storage/node/view/VariableBackendView.cpp
+++ b/src/rdf4cpp/rdf/storage/node/view/VariableBackendView.cpp
@@ -1,4 +1,7 @@
 #include "VariableBackendView.hpp"
+
+#include "rdf4cpp/rdf/storage/util/robin-hood-hashing/robin_hood_hash.hpp"
+
 namespace rdf4cpp::rdf::storage::node::view {
 std::string VariableBackendView::n_string() const noexcept {
     if (is_anonymous)
@@ -6,4 +9,15 @@ std::string VariableBackendView::n_string() const noexcept {
     else
         return "?" + std::string{name};
 }
+size_t VariableBackendView::hash() const noexcept {
+    return std::hash<VariableBackendView>()(*this);
+}
 }  // namespace rdf4cpp::rdf::storage::node::view
+
+size_t std::hash<rdf4cpp::rdf::storage::node::view::VariableBackendView>::operator()(const rdf4cpp::rdf::storage::node::view::VariableBackendView &x) const noexcept {
+    using namespace rdf4cpp::rdf::storage::util;
+    return robin_hood::hash<std::array<size_t, 2>>()(
+            std::array<size_t, 2>{
+                    x.is_anonymous,
+                    robin_hood::hash<std::string_view>()(x.name)});
+}

--- a/src/rdf4cpp/rdf/storage/node/view/VariableBackendView.hpp
+++ b/src/rdf4cpp/rdf/storage/node/view/VariableBackendView.hpp
@@ -18,7 +18,13 @@ struct VariableBackendView {
     [[nodiscard]] std::string n_string() const noexcept;
 
     auto operator<=>(VariableBackendView const &) const noexcept = default;
-};
 
+    [[nodiscard]] size_t hash() const noexcept;
+};
 }  // namespace rdf4cpp::rdf::storage::node::view
+
+template<>
+struct std::hash<rdf4cpp::rdf::storage::node::view::VariableBackendView> {
+    size_t operator()(rdf4cpp::rdf::storage::node::view::VariableBackendView const &x) const noexcept;
+};
 #endif  //RDF4CPP_VARIABLEBACKENDHANDLE_HPP

--- a/src/rdf4cpp/rdf/storage/util/robin-hood-hashing/LICENSE
+++ b/src/rdf4cpp/rdf/storage/util/robin-hood-hashing/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018-2021 Martin Ankerl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/rdf4cpp/rdf/storage/util/robin-hood-hashing/robin_hood_hash.hpp
+++ b/src/rdf4cpp/rdf/storage/util/robin-hood-hashing/robin_hood_hash.hpp
@@ -1,0 +1,157 @@
+#ifndef RDF4CPP_ROBIN_HOOD_HASH_HPP
+#define RDF4CPP_ROBIN_HOOD_HASH_HPP
+#include <cstring>
+#include <memory>
+namespace rdf4cpp::rdf::storage::util::robin_hood {
+
+namespace detail {
+
+template<typename T>
+inline T unaligned_load(void const *ptr) noexcept {
+    // using memcpy so we don't get into unaligned load problems.
+    // compiler should optimize this very well anyways.
+    T t;
+    std::memcpy(&t, ptr, sizeof(T));
+    return t;
+}
+}  // namespace detail
+inline size_t hash_bytes(void const *ptr, size_t len) noexcept {
+    static constexpr uint64_t m = UINT64_C(0xc6a4a7935bd1e995);
+    static constexpr uint64_t seed = UINT64_C(0xe17a1465);
+    static constexpr unsigned int r = 47;
+
+    auto const *const data64 = static_cast<uint64_t const *>(ptr);
+    uint64_t h = seed ^ (len * m);
+
+    size_t const n_blocks = len / 8;
+    for (size_t i = 0; i < n_blocks; ++i) {
+        auto k = detail::unaligned_load<uint64_t>(data64 + i);
+
+        k *= m;
+        k ^= k >> r;
+        k *= m;
+
+        h ^= k;
+        h *= m;
+    }
+
+    auto const *const data8 = reinterpret_cast<uint8_t const *>(data64 + n_blocks);
+    switch (len & 7U) {
+        case 7:
+            h ^= static_cast<uint64_t>(data8[6]) << 48U;
+            [[fallthrough]];  // FALLTHROUGH
+        case 6:
+            h ^= static_cast<uint64_t>(data8[5]) << 40U;
+            [[fallthrough]];  // FALLTHROUGH
+        case 5:
+            h ^= static_cast<uint64_t>(data8[4]) << 32U;
+            [[fallthrough]];  // FALLTHROUGH
+        case 4:
+            h ^= static_cast<uint64_t>(data8[3]) << 24U;
+            [[fallthrough]];  // FALLTHROUGH
+        case 3:
+            h ^= static_cast<uint64_t>(data8[2]) << 16U;
+            [[fallthrough]];  // FALLTHROUGH
+        case 2:
+            h ^= static_cast<uint64_t>(data8[1]) << 8U;
+            [[fallthrough]];  // FALLTHROUGH
+        case 1:
+            h ^= static_cast<uint64_t>(data8[0]);
+            h *= m;
+            [[fallthrough]];  // FALLTHROUGH
+        default:
+            break;
+    }
+
+    h ^= h >> r;
+
+    // not doing the final step here, because this will be done by keyToIdx anyways
+    // h *= m;
+    // h ^= h >> r;
+    return static_cast<size_t>(h);
+}
+
+inline size_t hash_int(uint64_t x) noexcept {
+    // tried lots of different hashes, let's stick with murmurhash3. It's simple, fast, well tested,
+    // and doesn't need any special 128bit operations.
+    x ^= x >> 33U;
+    x *= UINT64_C(0xff51afd7ed558ccd);
+    x ^= x >> 33U;
+
+    // not doing the final step here, because this will be done by keyToIdx anyways
+    // x *= UINT64_C(0xc4ceb9fe1a85ec53);
+    // x ^= x >> 33U;
+    return static_cast<size_t>(x);
+}
+
+// A thin wrapper around std::hash, performing an additional simple mixing step of the result.
+template<typename T, typename Enable = void>
+struct hash : public std::hash<T> {
+    size_t operator()(T const &obj) const
+            noexcept(noexcept(std::declval<std::hash<T>>().operator()(std::declval<T const &>()))) {
+        // call base hash
+        auto result = std::hash<T>::operator()(obj);
+        // return mixed of that, to be save against identity has
+        return hash_int(static_cast<uintptr_t>(result));
+    }
+};
+
+template<typename CharT>
+struct hash<std::basic_string<CharT>> {
+    size_t operator()(std::basic_string<CharT> const &str) const noexcept {
+        return hash_bytes(str.data(), sizeof(CharT) * str.size());
+    }
+};
+
+template<typename CharT>
+struct hash<std::basic_string_view<CharT>> {
+    size_t operator()(std::basic_string_view<CharT> const &sv) const noexcept {
+        return hash_bytes(sv.data(), sizeof(CharT) * sv.size());
+    }
+};
+
+template<typename Tp, std::size_t Nm>
+struct hash<std::array<Tp, Nm>> {
+    size_t operator()(std::array<Tp, Nm> const &sv) const noexcept {
+        return hash_bytes(sv.data(), sizeof(Tp) * Nm);
+    }
+};
+
+template<class T>
+struct hash<T *> {
+    size_t operator()(T *ptr) const noexcept {
+        return hash_int(reinterpret_cast<uintptr_t>(ptr));
+    }
+};
+
+template<class T>
+struct hash<std::unique_ptr<T>> {
+    size_t operator()(std::unique_ptr<T> const &ptr) const noexcept {
+        return hash_int(reinterpret_cast<uintptr_t>(ptr.get()));
+    }
+};
+
+template<class T>
+struct hash<std::shared_ptr<T>> {
+    size_t operator()(std::shared_ptr<T> const &ptr) const noexcept {
+        return hash_int(reinterpret_cast<uintptr_t>(ptr.get()));
+    }
+};
+
+template<typename Enum>
+struct hash<Enum, typename std::enable_if<std::is_enum<Enum>::value>::type> {
+    size_t operator()(Enum e) const noexcept {
+        using Underlying = typename std::underlying_type<Enum>::type;
+        return hash<Underlying>{}(static_cast<Underlying>(e));
+    }
+};
+
+#define ROBIN_HOOD_HASH_INT(T)                           \
+    template<>                                           \
+    struct hash<T> {                                     \
+        size_t operator()(T const &obj) const noexcept { \
+            return hash_int(static_cast<uint64_t>(obj)); \
+        }                                                \
+    }
+}  // namespace rdf4cpp::rdf::storage::util::robin_hood
+#endif  //RDF4CPP_ROBIN_HOOD_HASH_HPP

--- a/src/rdf4cpp/rdf/storage/util/tsl/LICENSE
+++ b/src/rdf4cpp/rdf/storage/util/tsl/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Thibaut Goetghebuer-Planchon <tessil@gmx.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/rdf4cpp/rdf/storage/util/tsl/README.md
+++ b/src/rdf4cpp/rdf/storage/util/tsl/README.md
@@ -1,0 +1,541 @@
+[![CI](https://github.com/Tessil/sparse-map/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Tessil/sparse-map/actions/workflows/ci.yml)
+
+## A C++ implementation of a memory efficient hash map and hash set
+
+The sparse-map library is a C++ implementation of a memory efficient hash map and hash set. It uses open-addressing with
+sparse quadratic probing. The goal of the library is to be the most memory efficient possible, even at low load factor,
+while keeping reasonable performances. You can find
+an [article](https://smerity.com/articles/2015/google_sparsehash.html) of Stephen Merity which explains the idea
+behind `google::sparse_hash_map` and this project.
+
+Four classes are provided: `tsl::sparse_map`, `tsl::sparse_set`, `tsl::sparse_pg_map` and `tsl::sparse_pg_set`. The
+first two are faster and use a power of two growth policy, the last two use a prime growth policy instead and are able
+to cope better with a poor hash function. Use the prime version if there is a chance of repeating patterns in the lower
+bits of your hash (e.g. you are storing pointers with an identity hash function). See [GrowthPolicy](#growth-policy) for
+details.
+
+A **benchmark** of `tsl::sparse_map` against other hash maps may be
+found [here](https://tessil.github.io/2016/08/29/benchmark-hopscotch-map.html). The benchmark, in its additional tests
+page, notably includes `google::sparse_hash_map` and `spp::sparse_hash_map` to which `tsl::sparse_map` is an
+alternative. This page also gives some advices on which hash table structure you should try for your use case (useful if
+you are a bit lost with the multiple hash tables implementations in the `tsl` namespace).
+
+### Key features
+
+- Header-only library, just add the [include](include/) directory to your include path and you are ready to go. If you
+  use CMake, you can also use the `tsl::sparse_map` exported target from the [CMakeLists.txt](CMakeLists.txt).
+- Memory efficient while keeping good lookup speed, see
+  the [benchmark](https://tessil.github.io/2016/08/29/benchmark-hopscotch-map.html) for some numbers.
+- Support for heterogeneous lookups allowing the usage of `find` with a type different than `Key` (e.g. if you have a
+  map that uses `std::unique_ptr<foo>` as key, you can use a `foo*` or a `std::uintptr_t` as key parameter to `find`
+  without constructing a `std::unique_ptr<foo>`, see [example](#heterogeneous-lookups)).
+- No need to reserve any sentinel value from the keys.
+- If the hash is known before a lookup, it is possible to pass it as parameter to speed-up the lookup (
+  see `precalculated_hash` parameter in [API](https://tessil.github.io/sparse-map/classtsl_1_1sparse__map.html)).
+- Support for efficient serialization and deserialization (see [example](#serialization) and the `serialize/deserialize`
+  methods in the [API](https://tessil.github.io/sparse-map/classtsl_1_1sparse__map.html) for details).
+- Possibility to control the balance between insertion speed and memory usage with the `Sparsity` template parameter. A
+  high sparsity means less memory but longer insertion times, and vice-versa for low sparsity. The default medium
+  sparsity offers a good compromise (see [API](https://tessil.github.io/sparse-map/classtsl_1_1sparse__map.html#details)
+  for details). For reference, with simple 64 bits integers as keys and values, a low sparsity offers ~15% faster
+  insertions times but uses ~12% more memory. Nothing change regarding lookup speed.
+- API closely similar to `std::unordered_map` and `std::unordered_set`.
+
+### Differences compared to `std::unordered_map`
+
+`tsl::sparse_map` tries to have an interface similar to `std::unordered_map`, but some differences exist.
+
+- **By default only the basic exception safety is guaranteed** which mean that, in case of exception, all resources used
+  by the hash map will be freed (no memory leaks) but the hash map may end-up in an undefined state (undefined here
+  means that some elements may be missing). This can ONLY happen on rehash (either on insert or if `rehash` is called
+  explicitly) and will occur if the `Allocator` can't allocate memory (`std::bad_alloc`) or if the copy constructor (
+  when a nothrow move constructor is not available) throws and exception. This can be avoided by calling `reserve`
+  beforehand. It is the same guarantee that the one provided by `google::sparse_hash_map` and `spp::sparse_hash_map`
+  which don't provide the strong exception guarantee. For more information and if you need the strong exception
+  guarantee, check the `ExceptionSafety` template parameter (
+  see [API](https://tessil.github.io/sparse-map/classtsl_1_1sparse__map.html#details) for details).
+- Iterator invalidation doesn't behave in the same way, any operation modifying the hash table invalidate them (
+  see [API](https://tessil.github.io/sparse-map/classtsl_1_1sparse__map.html#details) for details).
+- References and pointers to keys or values in the map are invalidated in the same way as iterators to these
+  keys-values.
+- For iterators, `operator*()` and `operator->()` return a reference and a pointer to `const std::pair<Key, T>` instead
+  of `std::pair<const Key, T>` making the value `T` not modifiable. To modify the value you have to call the `value()`
+  method of the iterator to get a mutable reference. Example:
+
+```c++
+tsl::sparse_map<int, int> map = {{1, 1}, {2, 1}, {3, 1}};
+for(auto it = map.begin(); it != map.end(); ++it) {
+    //it->second = 2; // Illegal
+    it.value() = 2; // Ok
+}
+```
+
+- Move-only types must have a nothrow move constructor.
+- No support for some buckets related methods (like `bucket_size`, `bucket`, ...).
+
+These differences also apply between `std::unordered_set` and `tsl::sparse_set`.
+
+Thread-safety guarantees are the same as `std::unordered_map/set` (i.e. possible to have multiple readers with no
+writer).
+
+### Optimization
+
+#### Popcount
+
+The library relies heavily on the [popcount](https://en.wikipedia.org/wiki/Hamming_weight) operation.
+
+With Clang and GCC, the library uses the `__builtin_popcount` function which will use the fast CPU instruction `POPCNT`
+when the library is compiled with `-mpopcnt`. Using the `POPCNT` instruction offers an improvement of ~15% to ~30% on
+lookups. So if you are compiling your code for a specific architecture that support the operation, don't forget
+the `-mpopcnt` (or `-march=native`) flag of your compiler.
+
+On Windows with MSVC, the detection is done at runtime.
+
+#### Move constructor
+
+Make sure that your key `Key` and potential value `T` have a `noexcept` move constructor. The library will work without
+it but insertions will be much slower if the copy constructor is expensive (the structure often needs to move some
+values around on insertion).
+
+### Growth policy
+
+The library supports multiple growth policies through the `GrowthPolicy` template parameter. Three policies are provided
+by the library but you can easily implement your own if needed.
+
+* **[tsl::sh::power_of_two_growth_policy.](https://tessil.github.io/sparse-map/classtsl_1_1sh_1_1power__of__two__growth__policy.html)**
+  Default policy used by `tsl::sparse_map/set`. This policy keeps the size of the bucket array of the hash table to a
+  power of two. This constraint allows the policy to avoid the usage of the slow modulo operation to map a hash to a
+  bucket, instead of <code>hash % 2<sup>n</sup></code>, it uses <code>hash & (2<sup>n</sup> - 1)</code> (
+  see [fast modulo](https://en.wikipedia.org/wiki/Modulo_operation#Performance_issues)). Fast but this may cause a lot
+  of collisions with a poor hash function as the modulo with a power of two only masks the most significant bits in the
+  end.
+* **[tsl::sh::prime_growth_policy.](https://tessil.github.io/sparse-map/classtsl_1_1sh_1_1prime__growth__policy.html)**
+  Default policy used by `tsl::sparse_pg_map/set`. The policy keeps the size of the bucket array of the hash table to a
+  prime number. When mapping a hash to a bucket, using a prime number as modulo will result in a better distribution of
+  the hash across the buckets even with a poor hash function. To allow the compiler to optimize the modulo operation,
+  the policy use a lookup table with constant primes modulos (
+  see [API](https://tessil.github.io/sparse-map/classtsl_1_1sh_1_1prime__growth__policy.html#details) for details).
+  Slower than `tsl::sh::power_of_two_growth_policy` but more secure.
+* **[tsl::sh::mod_growth_policy.](https://tessil.github.io/sparse-map/classtsl_1_1sh_1_1mod__growth__policy.html)** The
+  policy grows the map by a customizable growth factor passed in parameter. It then just use the modulo operator to map
+  a hash to a bucket. Slower but more flexible.
+
+To implement your own policy, you have to implement the following interface.
+
+```c++
+struct custom_policy {
+    // Called on hash table construction and rehash, min_bucket_count_in_out is the minimum buckets
+    // that the hash table needs. The policy can change it to a higher number of buckets if needed 
+    // and the hash table will use this value as bucket count. If 0 bucket is asked, then the value
+    // must stay at 0.    
+    explicit custom_policy(std::size_t& min_bucket_count_in_out);
+    
+    // Return the bucket [0, bucket_count()) to which the hash belongs. 
+    // If bucket_count() is 0, it must always return 0.
+    std::size_t bucket_for_hash(std::size_t hash) const noexcept;
+    
+    // Return the number of buckets that should be used on next growth
+    std::size_t next_bucket_count() const;
+    
+    // Return the maximum number of buckets supported by the policy.
+    std::size_t max_bucket_count() const;
+    
+    // Reset the growth policy as if it was created with a bucket count of 0.
+    // After a clear, the policy must always return 0 when bucket_for_hash is called.
+    void clear() noexcept;
+}
+```
+
+### Installation
+
+To use sparse-map, just add the [include](include/) directory to your include path. It is a **header-only** library.
+
+If you use CMake, you can also use the `tsl::sparse_map` exported target from the [CMakeLists.txt](CMakeLists.txt)
+with `target_link_libraries`.
+
+```cmake
+# Example where the sparse-map project is stored in a third-party directory
+add_subdirectory(third-party/sparse-map)
+target_link_libraries(your_target PRIVATE tsl::sparse_map)  
+```
+
+If the project has been installed through `make install`, you can also use `find_package(tsl-sparse-map REQUIRED)`
+instead of `add_subdirectory`.
+
+The code should work with any C++11 standard-compliant compiler and has been tested with GCC 4.8.4, Clang 3.5.0 and
+Visual Studio 2015.
+
+To run the tests you will need the Boost Test library and CMake.
+
+```bash
+git clone https://github.com/Tessil/sparse-map.git
+cd sparse-map/tests
+mkdir build
+cd build
+cmake ..
+cmake --build .
+./tsl_sparse_map_tests 
+```
+
+### Usage
+
+The API can be found [here](https://tessil.github.io/sparse-map/).
+
+All methods are not documented yet, but they replicate the behaviour of the ones in `std::unordered_map`
+and `std::unordered_set`, except if specified otherwise.
+
+### Example
+
+```c++
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <tsl/sparse_map.h>
+#include <tsl/sparse_set.h>
+
+int main() {
+    tsl::sparse_map<std::string, int> map = {{"a", 1}, {"b", 2}};
+    map["c"] = 3;
+    map["d"] = 4;
+    
+    map.insert({"e", 5});
+    map.erase("b");
+    
+    for(auto it = map.begin(); it != map.end(); ++it) {
+        //it->second += 2; // Not valid.
+        it.value() += 2;
+    }
+    
+    // {d, 6} {a, 3} {e, 7} {c, 5}
+    for(const auto& key_value : map) {
+        std::cout << "{" << key_value.first << ", " << key_value.second << "}" << std::endl;
+    }
+    
+    
+    if(map.find("a") != map.end()) {
+        std::cout << "Found \"a\"." << std::endl;
+    }
+    
+    const std::size_t precalculated_hash = std::hash<std::string>()("a");
+    // If we already know the hash beforehand, we can pass it as argument to speed-up the lookup.
+    if(map.find("a", precalculated_hash) != map.end()) {
+        std::cout << "Found \"a\" with hash " << precalculated_hash << "." << std::endl;
+    }
+    
+    
+    
+    
+    tsl::sparse_set<int> set;
+    set.insert({1, 9, 0});
+    set.insert({2, -1, 9});
+    
+    // {0} {1} {2} {9} {-1}
+    for(const auto& key : set) {
+        std::cout << "{" << key << "}" << std::endl;
+    }
+}
+```
+
+#### Heterogeneous lookups
+
+Heterogeneous overloads allow the usage of other types than `Key` for lookup and erase operations as long as the used
+types are hashable and comparable to `Key`.
+
+To activate the heterogeneous overloads in `tsl::sparse_map/set`, the qualified-id `KeyEqual::is_transparent` must be
+valid. It works the same way as for [`std::map::find`](http://en.cppreference.com/w/cpp/container/map/find). You can
+either use [`std::equal_to<>`](http://en.cppreference.com/w/cpp/utility/functional/equal_to_void) or define your own
+function object.
+
+Both `KeyEqual` and `Hash` will need to be able to deal with the different types.
+
+```c++
+#include <functional>
+#include <iostream>
+#include <string>
+#include <tsl/sparse_map.h>
+
+
+struct employee {
+    employee(int id, std::string name) : m_id(id), m_name(std::move(name)) {
+    }
+    
+    // Either we include the comparators in the class and we use `std::equal_to<>`...
+    friend bool operator==(const employee& empl, int empl_id) {
+        return empl.m_id == empl_id;
+    }
+    
+    friend bool operator==(int empl_id, const employee& empl) {
+        return empl_id == empl.m_id;
+    }
+    
+    friend bool operator==(const employee& empl1, const employee& empl2) {
+        return empl1.m_id == empl2.m_id;
+    }
+    
+    
+    int m_id;
+    std::string m_name;
+};
+
+// ... or we implement a separate class to compare employees.
+struct equal_employee {
+    using is_transparent = void;
+    
+    bool operator()(const employee& empl, int empl_id) const {
+        return empl.m_id == empl_id;
+    }
+    
+    bool operator()(int empl_id, const employee& empl) const {
+        return empl_id == empl.m_id;
+    }
+    
+    bool operator()(const employee& empl1, const employee& empl2) const {
+        return empl1.m_id == empl2.m_id;
+    }
+};
+
+struct hash_employee {
+    std::size_t operator()(const employee& empl) const {
+        return std::hash<int>()(empl.m_id);
+    }
+    
+    std::size_t operator()(int id) const {
+        return std::hash<int>()(id);
+    }
+};
+
+
+int main() {
+    // Use std::equal_to<> which will automatically deduce and forward the parameters
+    tsl::sparse_map<employee, int, hash_employee, std::equal_to<>> map; 
+    map.insert({employee(1, "John Doe"), 2001});
+    map.insert({employee(2, "Jane Doe"), 2002});
+    map.insert({employee(3, "John Smith"), 2003});
+
+    // John Smith 2003
+    auto it = map.find(3);
+    if(it != map.end()) {
+        std::cout << it->first.m_name << " " << it->second << std::endl;
+    }
+
+    map.erase(1);
+
+
+
+    // Use a custom KeyEqual which has an is_transparent member type
+    tsl::sparse_map<employee, int, hash_employee, equal_employee> map2;
+    map2.insert({employee(4, "Johnny Doe"), 2004});
+
+    // 2004
+    std::cout << map2.at(4) << std::endl;
+}
+```
+
+#### Serialization
+
+The library provides an efficient way to serialize and deserialize a map or a set so that it can be saved to a file or
+send through the network.
+To do so, it requires the user to provide a function object for both serialization and deserialization.
+
+```c++
+struct serializer {
+    // Must support the following types for U: std::uint64_t, float 
+    // and std::pair<Key, T> if a map is used or Key for a set.
+    template<typename U>
+    void operator()(const U& value);
+};
+```
+
+```c++
+struct deserializer {
+    // Must support the following types for U: std::uint64_t, float 
+    // and std::pair<Key, T> if a map is used or Key for a set.
+    template<typename U>
+    U operator()();
+};
+```
+
+Note that the implementation leaves binary compatibility (endianness, float binary representation, size of int, ...) of
+the types it serializes/deserializes in the hands of the provided function objects if compatibility is required.
+
+More details regarding the `serialize` and `deserialize` methods can be found in
+the [API](https://tessil.github.io/sparse-map/classtsl_1_1sparse__map.html).
+
+```c++
+#include <cassert>
+#include <cstdint>
+#include <fstream>
+#include <type_traits>
+#include <tsl/sparse_map.h>
+
+
+class serializer {
+public:
+    serializer(const char* file_name) {
+        m_ostream.exceptions(m_ostream.badbit | m_ostream.failbit);
+        m_ostream.open(file_name, std::ios::binary);
+    }
+    
+    template<class T,
+             typename std::enable_if<std::is_arithmetic<T>::value>::type* = nullptr>
+    void operator()(const T& value) {
+        m_ostream.write(reinterpret_cast<const char*>(&value), sizeof(T));
+    }
+    
+    void operator()(const std::pair<std::int64_t, std::int64_t>& value) {
+        (*this)(value.first);
+        (*this)(value.second);
+    }
+
+private:
+    std::ofstream m_ostream;
+};
+
+class deserializer {
+public:
+    deserializer(const char* file_name) {
+        m_istream.exceptions(m_istream.badbit | m_istream.failbit | m_istream.eofbit);
+        m_istream.open(file_name, std::ios::binary);
+    }
+    
+    template<class T>
+    T operator()() {
+        T value;
+        deserialize(value);
+        
+        return value;
+    }
+    
+private:
+    template<class T,
+             typename std::enable_if<std::is_arithmetic<T>::value>::type* = nullptr>
+    void deserialize(T& value) {
+        m_istream.read(reinterpret_cast<char*>(&value), sizeof(T));
+    }
+    
+    void deserialize(std::pair<std::int64_t, std::int64_t>& value) {
+        deserialize(value.first);
+        deserialize(value.second);
+    }
+
+private:
+    std::ifstream m_istream;
+};
+
+
+int main() {
+    const tsl::sparse_map<std::int64_t, std::int64_t> map = {{1, -1}, {2, -2}, {3, -3}, {4, -4}};
+    
+    
+    const char* file_name = "sparse_map.data";
+    {
+        serializer serial(file_name);
+        map.serialize(serial);
+    }
+    
+    {
+        deserializer dserial(file_name);
+        auto map_deserialized = tsl::sparse_map<std::int64_t, std::int64_t>::deserialize(dserial);
+        
+        assert(map == map_deserialized);
+    }
+    
+    {
+        deserializer dserial(file_name);
+        
+        /**
+         * If the serialized and deserialized map are hash compatibles (see conditions in API), 
+         * setting the argument to true speed-up the deserialization process as we don't have 
+         * to recalculate the hash of each key. We also know how much space each bucket needs.
+         */
+        const bool hash_compatible = true;
+        auto map_deserialized = 
+            tsl::sparse_map<std::int64_t, std::int64_t>::deserialize(dserial, hash_compatible);
+        
+        assert(map == map_deserialized);
+    }
+} 
+```
+
+##### Serialization with Boost Serialization and compression with zlib
+
+It's possible to use a serialization library to avoid the boilerplate.
+
+The following example uses Boost Serialization with the Boost zlib compression stream to reduce the size of the
+resulting serialized file. The example requires C++20 due to the usage of the template parameter list syntax in lambdas,
+but it can be adapted to less recent versions.
+
+```c++
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/iostreams/filter/zlib.hpp>
+#include <boost/iostreams/filtering_stream.hpp>
+#include <boost/serialization/split_free.hpp>
+#include <boost/serialization/utility.hpp>
+#include <cassert>
+#include <cstdint>
+#include <fstream>
+#include <tsl/sparse_map.h>
+
+
+namespace boost { namespace serialization {
+    template<class Archive, class Key, class T>
+    void serialize(Archive & ar, tsl::sparse_map<Key, T>& map, const unsigned int version) {
+        split_free(ar, map, version); 
+    }
+
+    template<class Archive, class Key, class T>
+    void save(Archive & ar, const tsl::sparse_map<Key, T>& map, const unsigned int /*version*/) {
+        auto serializer = [&ar](const auto& v) { ar & v; };
+        map.serialize(serializer);
+    }
+
+    template<class Archive, class Key, class T>
+    void load(Archive & ar, tsl::sparse_map<Key, T>& map, const unsigned int /*version*/) {
+        auto deserializer = [&ar]<typename U>() { U u; ar & u; return u; };
+        map = tsl::sparse_map<Key, T>::deserialize(deserializer);
+    }
+}}
+
+
+int main() {
+    tsl::sparse_map<std::int64_t, std::int64_t> map = {{1, -1}, {2, -2}, {3, -3}, {4, -4}};
+    
+    
+    const char* file_name = "sparse_map.data";
+    {
+        std::ofstream ofs;
+        ofs.exceptions(ofs.badbit | ofs.failbit);
+        ofs.open(file_name, std::ios::binary);
+        
+        boost::iostreams::filtering_ostream fo;
+        fo.push(boost::iostreams::zlib_compressor());
+        fo.push(ofs);
+        
+        boost::archive::binary_oarchive oa(fo);
+        
+        oa << map;
+    }
+    
+    {
+        std::ifstream ifs;
+        ifs.exceptions(ifs.badbit | ifs.failbit | ifs.eofbit);
+        ifs.open(file_name, std::ios::binary);
+        
+        boost::iostreams::filtering_istream fi;
+        fi.push(boost::iostreams::zlib_decompressor());
+        fi.push(ifs);
+        
+        boost::archive::binary_iarchive ia(fi);
+     
+        tsl::sparse_map<std::int64_t, std::int64_t> map_deserialized;   
+        ia >> map_deserialized;
+        
+        assert(map == map_deserialized);
+    }
+}
+```
+
+### License
+
+The code is licensed under the MIT license, see the [LICENSE file](LICENSE) for details.

--- a/src/rdf4cpp/rdf/storage/util/tsl/sparse_growth_policy.h
+++ b/src/rdf4cpp/rdf/storage/util/tsl/sparse_growth_policy.h
@@ -1,0 +1,301 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017 Thibaut Goetghebuer-Planchon <tessil@gmx.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef RDF4CPP_TSL_SPARSE_GROWTH_POLICY_H
+#define RDF4CPP_TSL_SPARSE_GROWTH_POLICY_H
+
+#include <algorithm>
+#include <array>
+#include <climits>
+#include <cmath>
+#include <cstddef>
+#include <iterator>
+#include <limits>
+#include <ratio>
+#include <stdexcept>
+
+namespace rdf4cpp::rdf::storage::util::tsl {
+namespace sh {
+
+/**
+ * Grow the hash table by a factor of GrowthFactor keeping the bucket count to a
+ * power of two. It allows the table to use a mask operation instead of a modulo
+ * operation to map a hash to a bucket.
+ *
+ * GrowthFactor must be a power of two >= 2.
+ */
+template<std::size_t GrowthFactor>
+class power_of_two_growth_policy {
+public:
+    /**
+   * Called on the hash table creation and on rehash. The number of buckets for
+   * the table is passed in parameter. This number is a minimum, the policy may
+   * update this value with a higher value if needed (but not lower).
+   *
+   * If 0 is given, min_bucket_count_in_out must still be 0 after the policy
+   * creation and bucket_for_hash must always return 0 in this case.
+   */
+    explicit power_of_two_growth_policy(std::size_t &min_bucket_count_in_out) {
+        if (min_bucket_count_in_out > max_bucket_count()) {
+            throw std::length_error("The hash table exceeds its maximum size.");
+        }
+
+        if (min_bucket_count_in_out > 0) {
+            min_bucket_count_in_out =
+                    round_up_to_power_of_two(min_bucket_count_in_out);
+            m_mask = min_bucket_count_in_out - 1;
+        } else {
+            m_mask = 0;
+        }
+    }
+
+    /**
+   * Return the bucket [0, bucket_count()) to which the hash belongs.
+   * If bucket_count() is 0, it must always return 0.
+   */
+    std::size_t bucket_for_hash(std::size_t hash) const noexcept {
+        return hash & m_mask;
+    }
+
+    /**
+   * Return the number of buckets that should be used on next growth.
+   */
+    std::size_t next_bucket_count() const {
+        if ((m_mask + 1) > max_bucket_count() / GrowthFactor) {
+            throw std::length_error("The hash table exceeds its maximum size.");
+        }
+
+        return (m_mask + 1) * GrowthFactor;
+    }
+
+    /**
+   * Return the maximum number of buckets supported by the policy.
+   */
+    std::size_t max_bucket_count() const {
+        // Largest power of two.
+        return (std::numeric_limits<std::size_t>::max() / 2) + 1;
+    }
+
+    /**
+   * Reset the growth policy as if it was created with a bucket count of 0.
+   * After a clear, the policy must always return 0 when bucket_for_hash is
+   * called.
+   */
+    void clear() noexcept { m_mask = 0; }
+
+private:
+    static std::size_t round_up_to_power_of_two(std::size_t value) {
+        if (is_power_of_two(value)) {
+            return value;
+        }
+
+        if (value == 0) {
+            return 1;
+        }
+
+        --value;
+        for (std::size_t i = 1; i < sizeof(std::size_t) * CHAR_BIT; i *= 2) {
+            value |= value >> i;
+        }
+
+        return value + 1;
+    }
+
+    static constexpr bool is_power_of_two(std::size_t value) {
+        return value != 0 && (value & (value - 1)) == 0;
+    }
+
+protected:
+    static_assert(is_power_of_two(GrowthFactor) && GrowthFactor >= 2,
+                  "GrowthFactor must be a power of two >= 2.");
+
+    std::size_t m_mask;
+};
+
+/**
+ * Grow the hash table by GrowthFactor::num / GrowthFactor::den and use a modulo
+ * to map a hash to a bucket. Slower but it can be useful if you want a slower
+ * growth.
+ */
+template<class GrowthFactor = std::ratio<3, 2>>
+class mod_growth_policy {
+public:
+    explicit mod_growth_policy(std::size_t &min_bucket_count_in_out) {
+        if (min_bucket_count_in_out > max_bucket_count()) {
+            throw std::length_error("The hash table exceeds its maximum size.");
+        }
+
+        if (min_bucket_count_in_out > 0) {
+            m_mod = min_bucket_count_in_out;
+        } else {
+            m_mod = 1;
+        }
+    }
+
+    std::size_t bucket_for_hash(std::size_t hash) const noexcept {
+        return hash % m_mod;
+    }
+
+    std::size_t next_bucket_count() const {
+        if (m_mod == max_bucket_count()) {
+            throw std::length_error("The hash table exceeds its maximum size.");
+        }
+
+        const double next_bucket_count =
+                std::ceil(double(m_mod) * REHASH_SIZE_MULTIPLICATION_FACTOR);
+        if (!std::isnormal(next_bucket_count)) {
+            throw std::length_error("The hash table exceeds its maximum size.");
+        }
+
+        if (next_bucket_count > double(max_bucket_count())) {
+            return max_bucket_count();
+        } else {
+            return std::size_t(next_bucket_count);
+        }
+    }
+
+    std::size_t max_bucket_count() const { return MAX_BUCKET_COUNT; }
+
+    void clear() noexcept { m_mod = 1; }
+
+private:
+    static constexpr double REHASH_SIZE_MULTIPLICATION_FACTOR =
+            1.0 * GrowthFactor::num / GrowthFactor::den;
+    static const std::size_t MAX_BUCKET_COUNT =
+            std::size_t(double(std::numeric_limits<std::size_t>::max() /
+                               REHASH_SIZE_MULTIPLICATION_FACTOR));
+
+    static_assert(REHASH_SIZE_MULTIPLICATION_FACTOR >= 1.1,
+                  "Growth factor should be >= 1.1.");
+
+    std::size_t m_mod;
+};
+
+/**
+ * Grow the hash table by using prime numbers as bucket count. Slower than
+ * tsl::sh::power_of_two_growth_policy in general but will probably distribute
+ * the values around better in the buckets with a poor hash function.
+ *
+ * To allow the compiler to optimize the modulo operation, a lookup table is
+ * used with constant primes numbers.
+ *
+ * With a switch the code would look like:
+ * \code
+ * switch(iprime) { // iprime is the current prime of the hash table
+ *     case 0: hash % 5ul;
+ *             break;
+ *     case 1: hash % 17ul;
+ *             break;
+ *     case 2: hash % 29ul;
+ *             break;
+ *     ...
+ * }
+ * \endcode
+ *
+ * Due to the constant variable in the modulo the compiler is able to optimize
+ * the operation by a series of multiplications, substractions and shifts.
+ *
+ * The 'hash % 5' could become something like 'hash - (hash * 0xCCCCCCCD) >> 34)
+ * * 5' in a 64 bits environment.
+ */
+class prime_growth_policy {
+public:
+    explicit prime_growth_policy(std::size_t &min_bucket_count_in_out) {
+        auto it_prime = std::lower_bound(primes().begin(), primes().end(),
+                                         min_bucket_count_in_out);
+        if (it_prime == primes().end()) {
+            throw std::length_error("The hash table exceeds its maximum size.");
+        }
+
+        m_iprime =
+                static_cast<unsigned int>(std::distance(primes().begin(), it_prime));
+        if (min_bucket_count_in_out > 0) {
+            min_bucket_count_in_out = *it_prime;
+        } else {
+            min_bucket_count_in_out = 0;
+        }
+    }
+
+    std::size_t bucket_for_hash(std::size_t hash) const noexcept {
+        return mod_prime()[m_iprime](hash);
+    }
+
+    std::size_t next_bucket_count() const {
+        if (m_iprime + 1 >= primes().size()) {
+            throw std::length_error("The hash table exceeds its maximum size.");
+        }
+
+        return primes()[m_iprime + 1];
+    }
+
+    std::size_t max_bucket_count() const { return primes().back(); }
+
+    void clear() noexcept { m_iprime = 0; }
+
+private:
+    static const std::array<std::size_t, 40> &primes() {
+        static const std::array<std::size_t, 40> PRIMES = {
+                {1ul, 5ul, 17ul, 29ul, 37ul,
+                 53ul, 67ul, 79ul, 97ul, 131ul,
+                 193ul, 257ul, 389ul, 521ul, 769ul,
+                 1031ul, 1543ul, 2053ul, 3079ul, 6151ul,
+                 12289ul, 24593ul, 49157ul, 98317ul, 196613ul,
+                 393241ul, 786433ul, 1572869ul, 3145739ul, 6291469ul,
+                 12582917ul, 25165843ul, 50331653ul, 100663319ul, 201326611ul,
+                 402653189ul, 805306457ul, 1610612741ul, 3221225473ul, 4294967291ul}};
+
+        static_assert(
+                std::numeric_limits<decltype(m_iprime)>::max() >= PRIMES.size(),
+                "The type of m_iprime is not big enough.");
+
+        return PRIMES;
+    }
+
+    static const std::array<std::size_t (*)(std::size_t), 40> &mod_prime() {
+        // MOD_PRIME[iprime](hash) returns hash % PRIMES[iprime]. This table allows
+        // for faster modulo as the compiler can optimize the modulo code better
+        // with a constant known at the compilation.
+        static const std::array<std::size_t (*)(std::size_t), 40> MOD_PRIME = {
+                {&mod<0>, &mod<1>, &mod<2>, &mod<3>, &mod<4>, &mod<5>, &mod<6>,
+                 &mod<7>, &mod<8>, &mod<9>, &mod<10>, &mod<11>, &mod<12>, &mod<13>,
+                 &mod<14>, &mod<15>, &mod<16>, &mod<17>, &mod<18>, &mod<19>, &mod<20>,
+                 &mod<21>, &mod<22>, &mod<23>, &mod<24>, &mod<25>, &mod<26>, &mod<27>,
+                 &mod<28>, &mod<29>, &mod<30>, &mod<31>, &mod<32>, &mod<33>, &mod<34>,
+                 &mod<35>, &mod<36>, &mod<37>, &mod<38>, &mod<39>}};
+
+        return MOD_PRIME;
+    }
+
+    template<unsigned int IPrime>
+    static std::size_t mod(std::size_t hash) {
+        return hash % primes()[IPrime];
+    }
+
+private:
+    unsigned int m_iprime;
+};
+
+}
+}  // namespace rdf4cpp::rdf::storage::util::tsl::sh
+
+#endif

--- a/src/rdf4cpp/rdf/storage/util/tsl/sparse_hash.h
+++ b/src/rdf4cpp/rdf/storage/util/tsl/sparse_hash.h
@@ -1,0 +1,2219 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017 Thibaut Goetghebuer-Planchon <tessil@gmx.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef RDF4CPP_TSL_SPARSE_HASH_H
+#define RDF4CPP_TSL_SPARSE_HASH_H
+
+#include <algorithm>
+#include <cassert>
+#include <climits>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "sparse_growth_policy.h"
+
+#ifdef __INTEL_COMPILER
+#include <immintrin.h>  // For _popcnt32 and _popcnt64
+#endif
+
+#ifdef _MSC_VER
+#include <intrin.h>  // For __cpuid, __popcnt and __popcnt64
+#endif
+
+#ifdef TSL_DEBUG
+#define rdf4cpp_tsl_sh_assert(expr) assert(expr)
+#else
+#define rdf4cpp_tsl_sh_assert(expr) (static_cast<void>(0))
+#endif
+
+namespace rdf4cpp::rdf::storage::util::tsl {
+
+namespace sh {
+enum class probing { linear,
+                     quadratic };
+
+enum class exception_safety { basic,
+                              strong };
+
+enum class sparsity { high,
+                      medium,
+                      low };
+}  // namespace sh
+
+namespace detail_popcount {
+/**
+ * Define the popcount(ll) methods and pick-up the best depending on the
+ * compiler.
+ */
+
+// From Wikipedia: https://en.wikipedia.org/wiki/Hamming_weight
+inline int fallback_popcountll(unsigned long long int x) {
+    static_assert(
+            sizeof(unsigned long long int) == sizeof(std::uint64_t),
+            "sizeof(unsigned long long int) must be equal to sizeof(std::uint64_t). "
+            "Open a feature request if you need support for a platform where it "
+            "isn't the case.");
+
+    const std::uint64_t m1 = 0x5555555555555555ull;
+    const std::uint64_t m2 = 0x3333333333333333ull;
+    const std::uint64_t m4 = 0x0f0f0f0f0f0f0f0full;
+    const std::uint64_t h01 = 0x0101010101010101ull;
+
+    x -= (x >> 1ull) & m1;
+    x = (x & m2) + ((x >> 2ull) & m2);
+    x = (x + (x >> 4ull)) & m4;
+    return static_cast<int>((x * h01) >> (64ull - 8ull));
+}
+
+inline int fallback_popcount(unsigned int x) {
+    static_assert(sizeof(unsigned int) == sizeof(std::uint32_t) ||
+                          sizeof(unsigned int) == sizeof(std::uint64_t),
+                  "sizeof(unsigned int) must be equal to sizeof(std::uint32_t) "
+                  "or sizeof(std::uint64_t). "
+                  "Open a feature request if you need support for a platform "
+                  "where it isn't the case.");
+
+    if (sizeof(unsigned int) == sizeof(std::uint32_t)) {
+        const std::uint32_t m1 = 0x55555555;
+        const std::uint32_t m2 = 0x33333333;
+        const std::uint32_t m4 = 0x0f0f0f0f;
+        const std::uint32_t h01 = 0x01010101;
+
+        x -= (x >> 1) & m1;
+        x = (x & m2) + ((x >> 2) & m2);
+        x = (x + (x >> 4)) & m4;
+        return static_cast<int>((x * h01) >> (32 - 8));
+    } else {
+        return fallback_popcountll(x);
+    }
+}
+
+#if defined(__clang__) || defined(__GNUC__)
+inline int popcountll(unsigned long long int value) {
+    return __builtin_popcountll(value);
+}
+
+inline int popcount(unsigned int value) { return __builtin_popcount(value); }
+
+#elif defined(_MSC_VER)
+/**
+ * We need to check for popcount support at runtime on Windows with __cpuid
+ * See https://msdn.microsoft.com/en-us/library/bb385231.aspx
+ */
+inline bool has_popcount_support() {
+    int cpu_infos[4];
+    __cpuid(cpu_infos, 1);
+    return (cpu_infos[2] & (1 << 23)) != 0;
+}
+
+inline int popcountll(unsigned long long int value) {
+#ifdef _WIN64
+    static_assert(
+            sizeof(unsigned long long int) == sizeof(std::int64_t),
+            "sizeof(unsigned long long int) must be equal to sizeof(std::int64_t). ");
+
+    static const bool has_popcount = has_popcount_support();
+    return has_popcount
+                   ? static_cast<int>(__popcnt64(static_cast<std::int64_t>(value)))
+                   : fallback_popcountll(value);
+#else
+    return fallback_popcountll(value);
+#endif
+}
+
+inline int popcount(unsigned int value) {
+    static_assert(sizeof(unsigned int) == sizeof(std::int32_t),
+                  "sizeof(unsigned int) must be equal to sizeof(std::int32_t). ");
+
+    static const bool has_popcount = has_popcount_support();
+    return has_popcount
+                   ? static_cast<int>(__popcnt(static_cast<std::int32_t>(value)))
+                   : fallback_popcount(value);
+}
+
+#elif defined(__INTEL_COMPILER)
+inline int popcountll(unsigned long long int value) {
+    static_assert(sizeof(unsigned long long int) == sizeof(__int64), "");
+    return _popcnt64(static_cast<__int64>(value));
+}
+
+inline int popcount(unsigned int value) {
+    return _popcnt32(static_cast<int>(value));
+}
+
+#else
+inline int popcountll(unsigned long long int x) {
+    return fallback_popcountll(x);
+}
+
+inline int popcount(unsigned int x) { return fallback_popcount(x); }
+
+#endif
+}  // namespace detail_popcount
+
+namespace detail_sparse_hash {
+
+template<typename T>
+struct make_void {
+    using type = void;
+};
+
+template<typename T, typename = void>
+struct has_is_transparent : std::false_type {};
+
+template<typename T>
+struct has_is_transparent<T,
+                          typename make_void<typename T::is_transparent>::type>
+    : std::true_type {};
+
+template<typename U>
+struct is_power_of_two_policy : std::false_type {};
+
+template<std::size_t GrowthFactor>
+struct is_power_of_two_policy<tsl::sh::power_of_two_growth_policy<GrowthFactor>>
+    : std::true_type {};
+
+inline constexpr bool is_power_of_two(std::size_t value) {
+    return value != 0 && (value & (value - 1)) == 0;
+}
+
+inline std::size_t round_up_to_power_of_two(std::size_t value) {
+    if (is_power_of_two(value)) {
+        return value;
+    }
+
+    if (value == 0) {
+        return 1;
+    }
+
+    --value;
+    for (std::size_t i = 1; i < sizeof(std::size_t) * CHAR_BIT; i *= 2) {
+        value |= value >> i;
+    }
+
+    return value + 1;
+}
+
+template<typename T, typename U>
+static T numeric_cast(U value,
+                      const char *error_message = "numeric_cast() failed.") {
+    T ret = static_cast<T>(value);
+    if (static_cast<U>(ret) != value) {
+        throw std::runtime_error(error_message);
+    }
+
+    const bool is_same_signedness =
+            (std::is_unsigned<T>::value && std::is_unsigned<U>::value) ||
+            (std::is_signed<T>::value && std::is_signed<U>::value);
+    if (!is_same_signedness && (ret < T{}) != (value < U{})) {
+        throw std::runtime_error(error_message);
+    }
+
+    return ret;
+}
+
+/**
+ * Fixed size type used to represent size_type values on serialization. Need to
+ * be big enough to represent a std::size_t on 32 and 64 bits platforms, and
+ * must be the same size on both platforms.
+ */
+using slz_size_type = std::uint64_t;
+static_assert(std::numeric_limits<slz_size_type>::max() >=
+                      std::numeric_limits<std::size_t>::max(),
+              "slz_size_type must be >= std::size_t");
+
+template<class T, class Deserializer>
+static T deserialize_value(Deserializer &deserializer) {
+    // MSVC < 2017 is not conformant, circumvent the problem by removing the
+    // template keyword
+#if defined(_MSC_VER) && _MSC_VER < 1910
+    return deserializer.Deserializer::operator()<T>();
+#else
+    return deserializer.Deserializer::template operator()<T>();
+#endif
+}
+
+/**
+ * WARNING: the sparse_array class doesn't free the ressources allocated through
+ * the allocator passed in parameter in each method. You have to manually call
+ * `clear(Allocator&)` when you don't need a sparse_array object anymore.
+ *
+ * The reason is that the sparse_array doesn't store the allocator to avoid
+ * wasting space in each sparse_array when the allocator has a size > 0. It only
+ * allocates/deallocates objects with the allocator that is passed in parameter.
+ *
+ *
+ *
+ * Index denotes a value between [0, BITMAP_NB_BITS), it is an index similar to
+ * std::vector. Offset denotes the real position in `m_values` corresponding to
+ * an index.
+ *
+ * We are using raw pointers instead of std::vector to avoid loosing
+ * 2*sizeof(size_t) bytes to store the capacity and size of the vector in each
+ * sparse_array. We know we can only store up to BITMAP_NB_BITS elements in the
+ * array, we don't need such big types.
+ *
+ *
+ * T must be nothrow move constructible and/or copy constructible.
+ * Behaviour is undefined if the destructor of T throws an exception.
+ *
+ * See https://smerity.com/articles/2015/google_sparsehash.html for details on
+ * the idea behinds the implementation.
+ *
+ * TODO Check to use std::realloc and std::memmove when possible
+ */
+template<typename T, typename Allocator, tsl::sh::sparsity Sparsity>
+class sparse_array {
+public:
+    using value_type = T;
+    using size_type = std::uint_least8_t;
+    using allocator_type = Allocator;
+    using iterator = value_type *;
+    using const_iterator = const value_type *;
+
+private:
+    static const size_type CAPACITY_GROWTH_STEP =
+            (Sparsity == tsl::sh::sparsity::high) ? 2
+            : (Sparsity == tsl::sh::sparsity::medium)
+                    ? 4
+                    : 8;  // (Sparsity == tsl::sh::sparsity::low)
+
+    /**
+   * Bitmap size configuration.
+   * Use 32 bits for the bitmap on 32-bits or less environnement as popcount on
+   * 64 bits numbers is slow on these environnement. Use 64 bits bitmap
+   * otherwise.
+   */
+#if SIZE_MAX <= UINT32_MAX
+    using bitmap_type = std::uint_least32_t;
+    static const std::size_t BITMAP_NB_BITS = 32;
+    static const std::size_t BUCKET_SHIFT = 5;
+#else
+    using bitmap_type = std::uint_least64_t;
+    static const std::size_t BITMAP_NB_BITS = 64;
+    static const std::size_t BUCKET_SHIFT = 6;
+#endif
+
+    static const std::size_t BUCKET_MASK = BITMAP_NB_BITS - 1;
+
+    static_assert(is_power_of_two(BITMAP_NB_BITS),
+                  "BITMAP_NB_BITS must be a power of two.");
+    static_assert(std::numeric_limits<bitmap_type>::digits >= BITMAP_NB_BITS,
+                  "bitmap_type must be able to hold at least BITMAP_NB_BITS.");
+    static_assert((std::size_t(1) << BUCKET_SHIFT) == BITMAP_NB_BITS,
+                  "(1 << BUCKET_SHIFT) must be equal to BITMAP_NB_BITS.");
+    static_assert(std::numeric_limits<size_type>::max() >= BITMAP_NB_BITS,
+                  "size_type must be big enough to hold BITMAP_NB_BITS.");
+    static_assert(std::is_unsigned<bitmap_type>::value,
+                  "bitmap_type must be unsigned.");
+    static_assert((std::numeric_limits<bitmap_type>::max() & BUCKET_MASK) ==
+                          BITMAP_NB_BITS - 1,
+                  "");
+
+public:
+    /**
+   * Map an ibucket [0, bucket_count) in the hash table to a sparse_ibucket
+   * (a sparse_array holds multiple buckets, so there is less sparse_array than
+   * bucket_count).
+   *
+   * The bucket ibucket is in
+   * m_sparse_buckets[sparse_ibucket(ibucket)][index_in_sparse_bucket(ibucket)]
+   * instead of something like m_buckets[ibucket] in a classical hash table.
+   */
+    static std::size_t sparse_ibucket(std::size_t ibucket) {
+        return ibucket >> BUCKET_SHIFT;
+    }
+
+    /**
+   * Map an ibucket [0, bucket_count) in the hash table to an index in the
+   * sparse_array which corresponds to the bucket.
+   *
+   * The bucket ibucket is in
+   * m_sparse_buckets[sparse_ibucket(ibucket)][index_in_sparse_bucket(ibucket)]
+   * instead of something like m_buckets[ibucket] in a classical hash table.
+   */
+    static typename sparse_array::size_type index_in_sparse_bucket(
+            std::size_t ibucket) {
+        return static_cast<typename sparse_array::size_type>(
+                ibucket & sparse_array::BUCKET_MASK);
+    }
+
+    static std::size_t nb_sparse_buckets(std::size_t bucket_count) noexcept {
+        if (bucket_count == 0) {
+            return 0;
+        }
+
+        return std::max<std::size_t>(
+                1, sparse_ibucket(tsl::detail_sparse_hash::round_up_to_power_of_two(
+                           bucket_count)));
+    }
+
+public:
+    sparse_array() noexcept
+        : m_values(nullptr),
+          m_bitmap_vals(0),
+          m_bitmap_deleted_vals(0),
+          m_nb_elements(0),
+          m_capacity(0),
+          m_last_array(false) {}
+
+    explicit sparse_array(bool last_bucket) noexcept
+        : m_values(nullptr),
+          m_bitmap_vals(0),
+          m_bitmap_deleted_vals(0),
+          m_nb_elements(0),
+          m_capacity(0),
+          m_last_array(last_bucket) {}
+
+    sparse_array(size_type capacity, Allocator &alloc)
+        : m_values(nullptr),
+          m_bitmap_vals(0),
+          m_bitmap_deleted_vals(0),
+          m_nb_elements(0),
+          m_capacity(capacity),
+          m_last_array(false) {
+        if (m_capacity > 0) {
+            m_values = alloc.allocate(m_capacity);
+            rdf4cpp_tsl_sh_assert(m_values !=
+                                  nullptr);  // allocate should throw if there is a failure
+        }
+    }
+
+    sparse_array(const sparse_array &other, Allocator &alloc)
+        : m_values(nullptr),
+          m_bitmap_vals(other.m_bitmap_vals),
+          m_bitmap_deleted_vals(other.m_bitmap_deleted_vals),
+          m_nb_elements(0),
+          m_capacity(other.m_capacity),
+          m_last_array(other.m_last_array) {
+        rdf4cpp_tsl_sh_assert(other.m_capacity >= other.m_nb_elements);
+        if (m_capacity == 0) {
+            return;
+        }
+
+        m_values = alloc.allocate(m_capacity);
+        rdf4cpp_tsl_sh_assert(m_values !=
+                              nullptr);  // allocate should throw if there is a failure
+        try {
+            for (size_type i = 0; i < other.m_nb_elements; i++) {
+                construct_value(alloc, m_values + i, other.m_values[i]);
+                m_nb_elements++;
+            }
+        } catch (...) {
+            clear(alloc);
+            throw;
+        }
+    }
+
+    sparse_array(sparse_array &&other) noexcept
+        : m_values(other.m_values),
+          m_bitmap_vals(other.m_bitmap_vals),
+          m_bitmap_deleted_vals(other.m_bitmap_deleted_vals),
+          m_nb_elements(other.m_nb_elements),
+          m_capacity(other.m_capacity),
+          m_last_array(other.m_last_array) {
+        other.m_values = nullptr;
+        other.m_bitmap_vals = 0;
+        other.m_bitmap_deleted_vals = 0;
+        other.m_nb_elements = 0;
+        other.m_capacity = 0;
+    }
+
+    sparse_array(sparse_array &&other, Allocator &alloc)
+        : m_values(nullptr),
+          m_bitmap_vals(other.m_bitmap_vals),
+          m_bitmap_deleted_vals(other.m_bitmap_deleted_vals),
+          m_nb_elements(0),
+          m_capacity(other.m_capacity),
+          m_last_array(other.m_last_array) {
+        rdf4cpp_tsl_sh_assert(other.m_capacity >= other.m_nb_elements);
+        if (m_capacity == 0) {
+            return;
+        }
+
+        m_values = alloc.allocate(m_capacity);
+        rdf4cpp_tsl_sh_assert(m_values !=
+                              nullptr);  // allocate should throw if there is a failure
+        try {
+            for (size_type i = 0; i < other.m_nb_elements; i++) {
+                construct_value(alloc, m_values + i, std::move(other.m_values[i]));
+                m_nb_elements++;
+            }
+        } catch (...) {
+            clear(alloc);
+            throw;
+        }
+    }
+
+    sparse_array &operator=(const sparse_array &) = delete;
+    sparse_array &operator=(sparse_array &&) = delete;
+
+    ~sparse_array() noexcept {
+        // The code that manages the sparse_array must have called clear before
+        // destruction. See documentation of sparse_array for more details.
+        rdf4cpp_tsl_sh_assert(m_capacity == 0 && m_nb_elements == 0 && m_values == nullptr);
+    }
+
+    iterator begin() noexcept { return m_values; }
+    iterator end() noexcept { return m_values + m_nb_elements; }
+    const_iterator begin() const noexcept { return cbegin(); }
+    const_iterator end() const noexcept { return cend(); }
+    const_iterator cbegin() const noexcept { return m_values; }
+    const_iterator cend() const noexcept { return m_values + m_nb_elements; }
+
+    bool empty() const noexcept { return m_nb_elements == 0; }
+
+    size_type size() const noexcept { return m_nb_elements; }
+
+    void clear(allocator_type &alloc) noexcept {
+        destroy_and_deallocate_values(alloc, m_values, m_nb_elements, m_capacity);
+
+        m_values = nullptr;
+        m_bitmap_vals = 0;
+        m_bitmap_deleted_vals = 0;
+        m_nb_elements = 0;
+        m_capacity = 0;
+    }
+
+    bool last() const noexcept { return m_last_array; }
+
+    void set_as_last() noexcept { m_last_array = true; }
+
+    bool has_value(size_type index) const noexcept {
+        rdf4cpp_tsl_sh_assert(index < BITMAP_NB_BITS);
+        return (m_bitmap_vals & (bitmap_type(1) << index)) != 0;
+    }
+
+    bool has_deleted_value(size_type index) const noexcept {
+        rdf4cpp_tsl_sh_assert(index < BITMAP_NB_BITS);
+        return (m_bitmap_deleted_vals & (bitmap_type(1) << index)) != 0;
+    }
+
+    iterator value(size_type index) noexcept {
+        rdf4cpp_tsl_sh_assert(has_value(index));
+        return m_values + index_to_offset(index);
+    }
+
+    const_iterator value(size_type index) const noexcept {
+        rdf4cpp_tsl_sh_assert(has_value(index));
+        return m_values + index_to_offset(index);
+    }
+
+    /**
+   * Return iterator to set value.
+   */
+    template<typename... Args>
+    iterator set(allocator_type &alloc, size_type index, Args &&...value_args) {
+        rdf4cpp_tsl_sh_assert(!has_value(index));
+
+        const size_type offset = index_to_offset(index);
+        insert_at_offset(alloc, offset, std::forward<Args>(value_args)...);
+
+        m_bitmap_vals = (m_bitmap_vals | (bitmap_type(1) << index));
+        m_bitmap_deleted_vals =
+                (m_bitmap_deleted_vals & ~(bitmap_type(1) << index));
+
+        m_nb_elements++;
+
+        rdf4cpp_tsl_sh_assert(has_value(index));
+        rdf4cpp_tsl_sh_assert(!has_deleted_value(index));
+
+        return m_values + offset;
+    }
+
+    iterator erase(allocator_type &alloc, iterator position) {
+        const size_type offset =
+                static_cast<size_type>(std::distance(begin(), position));
+        return erase(alloc, position, offset_to_index(offset));
+    }
+
+    // Return the next value or end if no next value
+    iterator erase(allocator_type &alloc, iterator position, size_type index) {
+        rdf4cpp_tsl_sh_assert(has_value(index));
+        rdf4cpp_tsl_sh_assert(!has_deleted_value(index));
+
+        const size_type offset =
+                static_cast<size_type>(std::distance(begin(), position));
+        erase_at_offset(alloc, offset);
+
+        m_bitmap_vals = (m_bitmap_vals & ~(bitmap_type(1) << index));
+        m_bitmap_deleted_vals = (m_bitmap_deleted_vals | (bitmap_type(1) << index));
+
+        m_nb_elements--;
+
+        rdf4cpp_tsl_sh_assert(!has_value(index));
+        rdf4cpp_tsl_sh_assert(has_deleted_value(index));
+
+        return m_values + offset;
+    }
+
+    void swap(sparse_array &other) {
+        using std::swap;
+
+        swap(m_values, other.m_values);
+        swap(m_bitmap_vals, other.m_bitmap_vals);
+        swap(m_bitmap_deleted_vals, other.m_bitmap_deleted_vals);
+        swap(m_nb_elements, other.m_nb_elements);
+        swap(m_capacity, other.m_capacity);
+        swap(m_last_array, other.m_last_array);
+    }
+
+    static iterator mutable_iterator(const_iterator pos) {
+        return const_cast<iterator>(pos);
+    }
+
+    template<class Serializer>
+    void serialize(Serializer &serializer) const {
+        const slz_size_type sparse_bucket_size = m_nb_elements;
+        serializer(sparse_bucket_size);
+
+        const slz_size_type bitmap_vals = m_bitmap_vals;
+        serializer(bitmap_vals);
+
+        const slz_size_type bitmap_deleted_vals = m_bitmap_deleted_vals;
+        serializer(bitmap_deleted_vals);
+
+        for (const value_type &value : *this) {
+            serializer(value);
+        }
+    }
+
+    template<class Deserializer>
+    static sparse_array deserialize_hash_compatible(Deserializer &deserializer,
+                                                    Allocator &alloc) {
+        const slz_size_type sparse_bucket_size =
+                deserialize_value<slz_size_type>(deserializer);
+        const slz_size_type bitmap_vals =
+                deserialize_value<slz_size_type>(deserializer);
+        const slz_size_type bitmap_deleted_vals =
+                deserialize_value<slz_size_type>(deserializer);
+
+        if (sparse_bucket_size > BITMAP_NB_BITS) {
+            throw std::runtime_error(
+                    "Deserialized sparse_bucket_size is too big for the platform. "
+                    "Maximum should be BITMAP_NB_BITS.");
+        }
+
+        sparse_array sarray;
+        if (sparse_bucket_size == 0) {
+            return sarray;
+        }
+
+        sarray.m_bitmap_vals = numeric_cast<bitmap_type>(
+                bitmap_vals, "Deserialized bitmap_vals is too big.");
+        sarray.m_bitmap_deleted_vals = numeric_cast<bitmap_type>(
+                bitmap_deleted_vals, "Deserialized bitmap_deleted_vals is too big.");
+
+        sarray.m_capacity = numeric_cast<size_type>(
+                sparse_bucket_size, "Deserialized sparse_bucket_size is too big.");
+        sarray.m_values = alloc.allocate(sarray.m_capacity);
+
+        try {
+            for (size_type ivalue = 0; ivalue < sarray.m_capacity; ivalue++) {
+                construct_value(alloc, sarray.m_values + ivalue,
+                                deserialize_value<value_type>(deserializer));
+                sarray.m_nb_elements++;
+            }
+        } catch (...) {
+            sarray.clear(alloc);
+            throw;
+        }
+
+        return sarray;
+    }
+
+    /**
+   * Deserialize the values of the bucket and insert them all in sparse_hash
+   * through sparse_hash.insert(...).
+   */
+    template<class Deserializer, class SparseHash>
+    static void deserialize_values_into_sparse_hash(Deserializer &deserializer,
+                                                    SparseHash &sparse_hash) {
+        const slz_size_type sparse_bucket_size =
+                deserialize_value<slz_size_type>(deserializer);
+
+        const slz_size_type bitmap_vals =
+                deserialize_value<slz_size_type>(deserializer);
+        static_cast<void>(bitmap_vals);  // Ignore, not needed
+
+        const slz_size_type bitmap_deleted_vals =
+                deserialize_value<slz_size_type>(deserializer);
+        static_cast<void>(bitmap_deleted_vals);  // Ignore, not needed
+
+        for (slz_size_type ivalue = 0; ivalue < sparse_bucket_size; ivalue++) {
+            sparse_hash.insert(deserialize_value<value_type>(deserializer));
+        }
+    }
+
+private:
+    template<typename... Args>
+    static void construct_value(allocator_type &alloc, value_type *value,
+                                Args &&...value_args) {
+        std::allocator_traits<allocator_type>::construct(
+                alloc, value, std::forward<Args>(value_args)...);
+    }
+
+    static void destroy_value(allocator_type &alloc, value_type *value) noexcept {
+        std::allocator_traits<allocator_type>::destroy(alloc, value);
+    }
+
+    static void destroy_and_deallocate_values(
+            allocator_type &alloc, value_type *values, size_type nb_values,
+            size_type capacity_values) noexcept {
+        for (size_type i = 0; i < nb_values; i++) {
+            destroy_value(alloc, values + i);
+        }
+
+        alloc.deallocate(values, capacity_values);
+    }
+
+    static size_type popcount(bitmap_type val) noexcept {
+        if (sizeof(bitmap_type) <= sizeof(unsigned int)) {
+            return static_cast<size_type>(
+                    tsl::detail_popcount::popcount(static_cast<unsigned int>(val)));
+        } else {
+            return static_cast<size_type>(tsl::detail_popcount::popcountll(val));
+        }
+    }
+
+    size_type index_to_offset(size_type index) const noexcept {
+        rdf4cpp_tsl_sh_assert(index < BITMAP_NB_BITS);
+        return popcount(m_bitmap_vals &
+                        ((bitmap_type(1) << index) - bitmap_type(1)));
+    }
+
+    // TODO optimize
+    size_type offset_to_index(size_type offset) const noexcept {
+        rdf4cpp_tsl_sh_assert(offset < m_nb_elements);
+
+        bitmap_type bitmap_vals = m_bitmap_vals;
+        size_type index = 0;
+        size_type nb_ones = 0;
+
+        while (bitmap_vals != 0) {
+            if ((bitmap_vals & 0x1) == 1) {
+                if (nb_ones == offset) {
+                    break;
+                }
+
+                nb_ones++;
+            }
+
+            index++;
+            bitmap_vals = bitmap_vals >> 1;
+        }
+
+        return index;
+    }
+
+    size_type next_capacity() const noexcept {
+        return static_cast<size_type>(m_capacity + CAPACITY_GROWTH_STEP);
+    }
+
+    /**
+   * Insertion
+   *
+   * Two situations:
+   * - Either we are in a situation where
+   * std::is_nothrow_move_constructible<value_type>::value is true. In this
+   * case, on insertion we just reallocate m_values when we reach its capacity
+   * (i.e. m_nb_elements == m_capacity), otherwise we just put the new value at
+   * its appropriate place. We can easily keep the strong exception guarantee as
+   * moving the values around is safe.
+   * - Otherwise we are in a situation where
+   * std::is_nothrow_move_constructible<value_type>::value is false. In this
+   * case on EACH insertion we allocate a new area of m_nb_elements + 1 where we
+   * copy the values of m_values into it and put the new value there. On
+   * success, we set m_values to this new area. Even if slower, it's the only
+   * way to preserve to strong exception guarantee.
+   */
+    template<typename... Args, typename U = value_type,
+             typename std::enable_if<
+                     std::is_nothrow_move_constructible<U>::value>::type * = nullptr>
+    void insert_at_offset(allocator_type &alloc, size_type offset,
+                          Args &&...value_args) {
+        if (m_nb_elements < m_capacity) {
+            insert_at_offset_no_realloc(alloc, offset,
+                                        std::forward<Args>(value_args)...);
+        } else {
+            insert_at_offset_realloc(alloc, offset, next_capacity(),
+                                     std::forward<Args>(value_args)...);
+        }
+    }
+
+    template<typename... Args, typename U = value_type,
+             typename std::enable_if<!std::is_nothrow_move_constructible<
+                     U>::value>::type * = nullptr>
+    void insert_at_offset(allocator_type &alloc, size_type offset,
+                          Args &&...value_args) {
+        insert_at_offset_realloc(alloc, offset, m_nb_elements + 1,
+                                 std::forward<Args>(value_args)...);
+    }
+
+    template<typename... Args, typename U = value_type,
+             typename std::enable_if<
+                     std::is_nothrow_move_constructible<U>::value>::type * = nullptr>
+    void insert_at_offset_no_realloc(allocator_type &alloc, size_type offset,
+                                     Args &&...value_args) {
+        rdf4cpp_tsl_sh_assert(offset <= m_nb_elements);
+        rdf4cpp_tsl_sh_assert(m_nb_elements < m_capacity);
+
+        for (size_type i = m_nb_elements; i > offset; i--) {
+            construct_value(alloc, m_values + i, std::move(m_values[i - 1]));
+            destroy_value(alloc, m_values + i - 1);
+        }
+
+        try {
+            construct_value(alloc, m_values + offset,
+                            std::forward<Args>(value_args)...);
+        } catch (...) {
+            for (size_type i = offset; i < m_nb_elements; i++) {
+                construct_value(alloc, m_values + i, std::move(m_values[i + 1]));
+                destroy_value(alloc, m_values + i + 1);
+            }
+            throw;
+        }
+    }
+
+    template<typename... Args, typename U = value_type,
+             typename std::enable_if<
+                     std::is_nothrow_move_constructible<U>::value>::type * = nullptr>
+    void insert_at_offset_realloc(allocator_type &alloc, size_type offset,
+                                  size_type new_capacity, Args &&...value_args) {
+        rdf4cpp_tsl_sh_assert(new_capacity > m_nb_elements);
+
+        value_type *new_values = alloc.allocate(new_capacity);
+        // Allocate should throw if there is a failure
+        rdf4cpp_tsl_sh_assert(new_values != nullptr);
+
+        try {
+            construct_value(alloc, new_values + offset,
+                            std::forward<Args>(value_args)...);
+        } catch (...) {
+            alloc.deallocate(new_values, new_capacity);
+            throw;
+        }
+
+        // Should not throw from here
+        for (size_type i = 0; i < offset; i++) {
+            construct_value(alloc, new_values + i, std::move(m_values[i]));
+        }
+
+        for (size_type i = offset; i < m_nb_elements; i++) {
+            construct_value(alloc, new_values + i + 1, std::move(m_values[i]));
+        }
+
+        destroy_and_deallocate_values(alloc, m_values, m_nb_elements, m_capacity);
+
+        m_values = new_values;
+        m_capacity = new_capacity;
+    }
+
+    template<typename... Args, typename U = value_type,
+             typename std::enable_if<!std::is_nothrow_move_constructible<
+                     U>::value>::type * = nullptr>
+    void insert_at_offset_realloc(allocator_type &alloc, size_type offset,
+                                  size_type new_capacity, Args &&...value_args) {
+        rdf4cpp_tsl_sh_assert(new_capacity > m_nb_elements);
+
+        value_type *new_values = alloc.allocate(new_capacity);
+        // Allocate should throw if there is a failure
+        rdf4cpp_tsl_sh_assert(new_values != nullptr);
+
+        size_type nb_new_values = 0;
+        try {
+            for (size_type i = 0; i < offset; i++) {
+                construct_value(alloc, new_values + i, m_values[i]);
+                nb_new_values++;
+            }
+
+            construct_value(alloc, new_values + offset,
+                            std::forward<Args>(value_args)...);
+            nb_new_values++;
+
+            for (size_type i = offset; i < m_nb_elements; i++) {
+                construct_value(alloc, new_values + i + 1, m_values[i]);
+                nb_new_values++;
+            }
+        } catch (...) {
+            destroy_and_deallocate_values(alloc, new_values, nb_new_values,
+                                          new_capacity);
+            throw;
+        }
+
+        rdf4cpp_tsl_sh_assert(nb_new_values == m_nb_elements + 1);
+
+        destroy_and_deallocate_values(alloc, m_values, m_nb_elements, m_capacity);
+
+        m_values = new_values;
+        m_capacity = new_capacity;
+    }
+
+    /**
+   * Erasure
+   *
+   * Two situations:
+   * - Either we are in a situation where
+   * std::is_nothrow_move_constructible<value_type>::value is true. Simply
+   * destroy the value and left-shift move the value on the right of offset.
+   * - Otherwise we are in a situation where
+   * std::is_nothrow_move_constructible<value_type>::value is false. Copy all
+   * the values except the one at offset into a new heap area. On success, we
+   * set m_values to this new area. Even if slower, it's the only way to
+   * preserve to strong exception guarantee.
+   */
+    template<typename... Args, typename U = value_type,
+             typename std::enable_if<
+                     std::is_nothrow_move_constructible<U>::value>::type * = nullptr>
+    void erase_at_offset(allocator_type &alloc, size_type offset) noexcept {
+        rdf4cpp_tsl_sh_assert(offset < m_nb_elements);
+
+        destroy_value(alloc, m_values + offset);
+
+        for (size_type i = offset + 1; i < m_nb_elements; i++) {
+            construct_value(alloc, m_values + i - 1, std::move(m_values[i]));
+            destroy_value(alloc, m_values + i);
+        }
+    }
+
+    template<typename... Args, typename U = value_type,
+             typename std::enable_if<!std::is_nothrow_move_constructible<
+                     U>::value>::type * = nullptr>
+    void erase_at_offset(allocator_type &alloc, size_type offset) {
+        rdf4cpp_tsl_sh_assert(offset < m_nb_elements);
+
+        // Erasing the last element, don't need to reallocate. We keep the capacity.
+        if (offset + 1 == m_nb_elements) {
+            destroy_value(alloc, m_values + offset);
+            return;
+        }
+
+        rdf4cpp_tsl_sh_assert(m_nb_elements > 1);
+        const size_type new_capacity = m_nb_elements - 1;
+
+        value_type *new_values = alloc.allocate(new_capacity);
+        // Allocate should throw if there is a failure
+        rdf4cpp_tsl_sh_assert(new_values != nullptr);
+
+        size_type nb_new_values = 0;
+        try {
+            for (size_type i = 0; i < m_nb_elements; i++) {
+                if (i != offset) {
+                    construct_value(alloc, new_values + nb_new_values, m_values[i]);
+                    nb_new_values++;
+                }
+            }
+        } catch (...) {
+            destroy_and_deallocate_values(alloc, new_values, nb_new_values,
+                                          new_capacity);
+            throw;
+        }
+
+        rdf4cpp_tsl_sh_assert(nb_new_values == m_nb_elements - 1);
+
+        destroy_and_deallocate_values(alloc, m_values, m_nb_elements, m_capacity);
+
+        m_values = new_values;
+        m_capacity = new_capacity;
+    }
+
+private:
+    value_type *m_values;
+
+    bitmap_type m_bitmap_vals;
+    bitmap_type m_bitmap_deleted_vals;
+
+    size_type m_nb_elements;
+    size_type m_capacity;
+    bool m_last_array;
+};
+
+/**
+ * Internal common class used by `sparse_map` and `sparse_set`.
+ *
+ * `ValueType` is what will be stored by `sparse_hash` (usually `std::pair<Key,
+ * T>` for map and `Key` for set).
+ *
+ * `KeySelect` should be a `FunctionObject` which takes a `ValueType` in
+ * parameter and returns a reference to the key.
+ *
+ * `ValueSelect` should be a `FunctionObject` which takes a `ValueType` in
+ * parameter and returns a reference to the value. `ValueSelect` should be void
+ * if there is no value (in a set for example).
+ *
+ * The strong exception guarantee only holds if `ExceptionSafety` is set to
+ * `tsl::sh::exception_safety::strong`.
+ *
+ * `ValueType` must be nothrow move constructible and/or copy constructible.
+ * Behaviour is undefined if the destructor of `ValueType` throws.
+ *
+ *
+ * The class holds its buckets in a 2-dimensional fashion. Instead of having a
+ * linear `std::vector<bucket>` for [0, bucket_count) where each bucket stores
+ * one value, we have a `std::vector<sparse_array>` (m_sparse_buckets_data)
+ * where each `sparse_array` stores multiple values (up to
+ * `sparse_array::BITMAP_NB_BITS`). To convert a one dimensional `ibucket`
+ * position to a position in `std::vector<sparse_array>` and a position in
+ * `sparse_array`, use respectively the methods
+ * `sparse_array::sparse_ibucket(ibucket)` and
+ * `sparse_array::index_in_sparse_bucket(ibucket)`.
+ */
+template<class ValueType, class KeySelect, class ValueSelect, class Hash,
+         class KeyEqual, class Allocator, class GrowthPolicy,
+         tsl::sh::exception_safety ExceptionSafety, tsl::sh::sparsity Sparsity,
+         tsl::sh::probing Probing>
+class sparse_hash : private Allocator,
+                    private Hash,
+                    private KeyEqual,
+                    private GrowthPolicy {
+private:
+    template<typename U>
+    using has_mapped_type =
+            typename std::integral_constant<bool, !std::is_same<U, void>::value>;
+
+    static_assert(
+            noexcept(std::declval<GrowthPolicy>().bucket_for_hash(std::size_t(0))),
+            "GrowthPolicy::bucket_for_hash must be noexcept.");
+    static_assert(noexcept(std::declval<GrowthPolicy>().clear()),
+                  "GrowthPolicy::clear must be noexcept.");
+
+public:
+    template<bool IsConst>
+    class sparse_iterator;
+
+    using key_type = typename KeySelect::key_type;
+    using value_type = ValueType;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using hasher = Hash;
+    using key_equal = KeyEqual;
+    using allocator_type = Allocator;
+    using reference = value_type &;
+    using const_reference = const value_type &;
+    using pointer = value_type *;
+    using const_pointer = const value_type *;
+    using iterator = sparse_iterator<false>;
+    using const_iterator = sparse_iterator<true>;
+
+private:
+    using sparse_array =
+            tsl::detail_sparse_hash::sparse_array<ValueType, Allocator, Sparsity>;
+
+    using sparse_buckets_allocator = typename std::allocator_traits<
+            allocator_type>::template rebind_alloc<sparse_array>;
+    using sparse_buckets_container =
+            std::vector<sparse_array, sparse_buckets_allocator>;
+
+public:
+    /**
+   * The `operator*()` and `operator->()` methods return a const reference and
+   * const pointer respectively to the stored value type (`Key` for a set,
+   * `std::pair<Key, T>` for a map).
+   *
+   * In case of a map, to get a mutable reference to the value `T` associated to
+   * a key (the `.second` in the stored pair), you have to call `value()`.
+   */
+    template<bool IsConst>
+    class sparse_iterator {
+        friend class sparse_hash;
+
+    private:
+        using sparse_bucket_iterator = typename std::conditional<
+                IsConst, typename sparse_buckets_container::const_iterator,
+                typename sparse_buckets_container::iterator>::type;
+
+        using sparse_array_iterator =
+                typename std::conditional<IsConst,
+                                          typename sparse_array::const_iterator,
+                                          typename sparse_array::iterator>::type;
+
+        /**
+     * sparse_array_it should be nullptr if sparse_bucket_it ==
+     * m_sparse_buckets_data.end(). (TODO better way?)
+     */
+        sparse_iterator(sparse_bucket_iterator sparse_bucket_it,
+                        sparse_array_iterator sparse_array_it)
+            : m_sparse_buckets_it(sparse_bucket_it),
+              m_sparse_array_it(sparse_array_it) {}
+
+    public:
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = const typename sparse_hash::value_type;
+        using difference_type = std::ptrdiff_t;
+        using reference = value_type &;
+        using pointer = value_type *;
+
+        sparse_iterator() noexcept {}
+
+        // Copy constructor from iterator to const_iterator.
+        template<bool TIsConst = IsConst,
+                 typename std::enable_if<TIsConst>::type * = nullptr>
+        sparse_iterator(const sparse_iterator<!TIsConst> &other) noexcept
+            : m_sparse_buckets_it(other.m_sparse_buckets_it),
+              m_sparse_array_it(other.m_sparse_array_it) {}
+
+        sparse_iterator(const sparse_iterator &other) = default;
+        sparse_iterator(sparse_iterator &&other) = default;
+        sparse_iterator &operator=(const sparse_iterator &other) = default;
+        sparse_iterator &operator=(sparse_iterator &&other) = default;
+
+        const typename sparse_hash::key_type &key() const {
+            return KeySelect()(*m_sparse_array_it);
+        }
+
+        template<class U = ValueSelect,
+                 typename std::enable_if<has_mapped_type<U>::value &&
+                                         IsConst>::type * = nullptr>
+        const typename U::value_type &value() const {
+            return U()(*m_sparse_array_it);
+        }
+
+        template<class U = ValueSelect,
+                 typename std::enable_if<has_mapped_type<U>::value &&
+                                         !IsConst>::type * = nullptr>
+        typename U::value_type &value() {
+            return U()(*m_sparse_array_it);
+        }
+
+        reference operator*() const { return *m_sparse_array_it; }
+
+        pointer operator->() const { return std::addressof(*m_sparse_array_it); }
+
+        sparse_iterator &operator++() {
+            rdf4cpp_tsl_sh_assert(m_sparse_array_it != nullptr);
+            ++m_sparse_array_it;
+
+            if (m_sparse_array_it == m_sparse_buckets_it->end()) {
+                do {
+                    if (m_sparse_buckets_it->last()) {
+                        ++m_sparse_buckets_it;
+                        m_sparse_array_it = nullptr;
+                        return *this;
+                    }
+
+                    ++m_sparse_buckets_it;
+                } while (m_sparse_buckets_it->empty());
+
+                m_sparse_array_it = m_sparse_buckets_it->begin();
+            }
+
+            return *this;
+        }
+
+        sparse_iterator operator++(int) {
+            sparse_iterator tmp(*this);
+            ++*this;
+
+            return tmp;
+        }
+
+        friend bool operator==(const sparse_iterator &lhs,
+                               const sparse_iterator &rhs) {
+            return lhs.m_sparse_buckets_it == rhs.m_sparse_buckets_it &&
+                   lhs.m_sparse_array_it == rhs.m_sparse_array_it;
+        }
+
+        friend bool operator!=(const sparse_iterator &lhs,
+                               const sparse_iterator &rhs) {
+            return !(lhs == rhs);
+        }
+
+    private:
+        sparse_bucket_iterator m_sparse_buckets_it;
+        sparse_array_iterator m_sparse_array_it;
+    };
+
+public:
+    sparse_hash(size_type bucket_count, const Hash &hash, const KeyEqual &equal,
+                const Allocator &alloc, float max_load_factor)
+        : Allocator(alloc),
+          Hash(hash),
+          KeyEqual(equal),
+          GrowthPolicy(bucket_count),
+          m_sparse_buckets_data(alloc),
+          m_sparse_buckets(static_empty_sparse_bucket_ptr()),
+          m_bucket_count(bucket_count),
+          m_nb_elements(0),
+          m_nb_deleted_buckets(0) {
+        if (m_bucket_count > max_bucket_count()) {
+            throw std::length_error("The map exceeds its maximum size.");
+        }
+
+        if (m_bucket_count > 0) {
+            /*
+       * We can't use the `vector(size_type count, const Allocator& alloc)`
+       * constructor as it's only available in C++14 and we need to support
+       * C++11. We thus must resize after using the `vector(const Allocator&
+       * alloc)` constructor.
+       *
+       * We can't use `vector(size_type count, const T& value, const Allocator&
+       * alloc)` as it requires the value T to be copyable.
+       */
+            m_sparse_buckets_data.resize(
+                    sparse_array::nb_sparse_buckets(bucket_count));
+            m_sparse_buckets = m_sparse_buckets_data.data();
+
+            rdf4cpp_tsl_sh_assert(!m_sparse_buckets_data.empty());
+            m_sparse_buckets_data.back().set_as_last();
+        }
+
+        this->max_load_factor(max_load_factor);
+
+        // Check in the constructor instead of outside of a function to avoid
+        // compilation issues when value_type is not complete.
+        static_assert(std::is_nothrow_move_constructible<value_type>::value ||
+                              std::is_copy_constructible<value_type>::value,
+                      "Key, and T if present, must be nothrow move constructible "
+                      "and/or copy constructible.");
+    }
+
+    ~sparse_hash() { clear(); }
+
+    sparse_hash(const sparse_hash &other)
+        : Allocator(std::allocator_traits<
+                    Allocator>::select_on_container_copy_construction(other)),
+          Hash(other),
+          KeyEqual(other),
+          GrowthPolicy(other),
+          m_sparse_buckets_data(
+                  std::allocator_traits<
+                          Allocator>::select_on_container_copy_construction(other)),
+          m_bucket_count(other.m_bucket_count),
+          m_nb_elements(other.m_nb_elements),
+          m_nb_deleted_buckets(other.m_nb_deleted_buckets),
+          m_load_threshold_rehash(other.m_load_threshold_rehash),
+          m_load_threshold_clear_deleted(other.m_load_threshold_clear_deleted),
+          m_max_load_factor(other.m_max_load_factor) {
+        copy_buckets_from(other),
+                m_sparse_buckets = m_sparse_buckets_data.empty()
+                                           ? static_empty_sparse_bucket_ptr()
+                                           : m_sparse_buckets_data.data();
+    }
+
+    sparse_hash(sparse_hash &&other) noexcept(
+            std::is_nothrow_move_constructible<Allocator>::value
+                    &&std::is_nothrow_move_constructible<Hash>::value
+                            &&std::is_nothrow_move_constructible<KeyEqual>::value
+                                    &&std::is_nothrow_move_constructible<GrowthPolicy>::value
+                                            &&std::is_nothrow_move_constructible<
+                                                    sparse_buckets_container>::value)
+        : Allocator(std::move(other)),
+          Hash(std::move(other)),
+          KeyEqual(std::move(other)),
+          GrowthPolicy(std::move(other)),
+          m_sparse_buckets_data(std::move(other.m_sparse_buckets_data)),
+          m_sparse_buckets(m_sparse_buckets_data.empty()
+                                   ? static_empty_sparse_bucket_ptr()
+                                   : m_sparse_buckets_data.data()),
+          m_bucket_count(other.m_bucket_count),
+          m_nb_elements(other.m_nb_elements),
+          m_nb_deleted_buckets(other.m_nb_deleted_buckets),
+          m_load_threshold_rehash(other.m_load_threshold_rehash),
+          m_load_threshold_clear_deleted(other.m_load_threshold_clear_deleted),
+          m_max_load_factor(other.m_max_load_factor) {
+        other.GrowthPolicy::clear();
+        other.m_sparse_buckets_data.clear();
+        other.m_sparse_buckets = static_empty_sparse_bucket_ptr();
+        other.m_bucket_count = 0;
+        other.m_nb_elements = 0;
+        other.m_nb_deleted_buckets = 0;
+        other.m_load_threshold_rehash = 0;
+        other.m_load_threshold_clear_deleted = 0;
+    }
+
+    sparse_hash &operator=(const sparse_hash &other) {
+        if (this != &other) {
+            clear();
+
+            if (std::allocator_traits<
+                        Allocator>::propagate_on_container_copy_assignment::value) {
+                Allocator::operator=(other);
+            }
+
+            Hash::operator=(other);
+            KeyEqual::operator=(other);
+            GrowthPolicy::operator=(other);
+
+            if (std::allocator_traits<
+                        Allocator>::propagate_on_container_copy_assignment::value) {
+                m_sparse_buckets_data =
+                        sparse_buckets_container(static_cast<const Allocator &>(other));
+            } else {
+                if (m_sparse_buckets_data.size() !=
+                    other.m_sparse_buckets_data.size()) {
+                    m_sparse_buckets_data =
+                            sparse_buckets_container(static_cast<const Allocator &>(*this));
+                } else {
+                    m_sparse_buckets_data.clear();
+                }
+            }
+
+            copy_buckets_from(other);
+            m_sparse_buckets = m_sparse_buckets_data.empty()
+                                       ? static_empty_sparse_bucket_ptr()
+                                       : m_sparse_buckets_data.data();
+
+            m_bucket_count = other.m_bucket_count;
+            m_nb_elements = other.m_nb_elements;
+            m_nb_deleted_buckets = other.m_nb_deleted_buckets;
+            m_load_threshold_rehash = other.m_load_threshold_rehash;
+            m_load_threshold_clear_deleted = other.m_load_threshold_clear_deleted;
+            m_max_load_factor = other.m_max_load_factor;
+        }
+
+        return *this;
+    }
+
+    sparse_hash &operator=(sparse_hash &&other) {
+        clear();
+
+        if (std::allocator_traits<
+                    Allocator>::propagate_on_container_move_assignment::value) {
+            static_cast<Allocator &>(*this) =
+                    std::move(static_cast<Allocator &>(other));
+            m_sparse_buckets_data = std::move(other.m_sparse_buckets_data);
+        } else if (static_cast<Allocator &>(*this) !=
+                   static_cast<Allocator &>(other)) {
+            move_buckets_from(std::move(other));
+        } else {
+            static_cast<Allocator &>(*this) =
+                    std::move(static_cast<Allocator &>(other));
+            m_sparse_buckets_data = std::move(other.m_sparse_buckets_data);
+        }
+
+        m_sparse_buckets = m_sparse_buckets_data.empty()
+                                   ? static_empty_sparse_bucket_ptr()
+                                   : m_sparse_buckets_data.data();
+
+        static_cast<Hash &>(*this) = std::move(static_cast<Hash &>(other));
+        static_cast<KeyEqual &>(*this) = std::move(static_cast<KeyEqual &>(other));
+        static_cast<GrowthPolicy &>(*this) =
+                std::move(static_cast<GrowthPolicy &>(other));
+        m_bucket_count = other.m_bucket_count;
+        m_nb_elements = other.m_nb_elements;
+        m_nb_deleted_buckets = other.m_nb_deleted_buckets;
+        m_load_threshold_rehash = other.m_load_threshold_rehash;
+        m_load_threshold_clear_deleted = other.m_load_threshold_clear_deleted;
+        m_max_load_factor = other.m_max_load_factor;
+
+        other.GrowthPolicy::clear();
+        other.m_sparse_buckets_data.clear();
+        other.m_sparse_buckets = static_empty_sparse_bucket_ptr();
+        other.m_bucket_count = 0;
+        other.m_nb_elements = 0;
+        other.m_nb_deleted_buckets = 0;
+        other.m_load_threshold_rehash = 0;
+        other.m_load_threshold_clear_deleted = 0;
+
+        return *this;
+    }
+
+    allocator_type get_allocator() const {
+        return static_cast<const Allocator &>(*this);
+    }
+
+    /*
+   * Iterators
+   */
+    iterator begin() noexcept {
+        auto begin = m_sparse_buckets_data.begin();
+        while (begin != m_sparse_buckets_data.end() && begin->empty()) {
+            ++begin;
+        }
+
+        return iterator(begin, (begin != m_sparse_buckets_data.end())
+                                       ? begin->begin()
+                                       : nullptr);
+    }
+
+    const_iterator begin() const noexcept { return cbegin(); }
+
+    const_iterator cbegin() const noexcept {
+        auto begin = m_sparse_buckets_data.cbegin();
+        while (begin != m_sparse_buckets_data.cend() && begin->empty()) {
+            ++begin;
+        }
+
+        return const_iterator(begin, (begin != m_sparse_buckets_data.cend())
+                                             ? begin->cbegin()
+                                             : nullptr);
+    }
+
+    iterator end() noexcept {
+        return iterator(m_sparse_buckets_data.end(), nullptr);
+    }
+
+    const_iterator end() const noexcept { return cend(); }
+
+    const_iterator cend() const noexcept {
+        return const_iterator(m_sparse_buckets_data.cend(), nullptr);
+    }
+
+    /*
+   * Capacity
+   */
+    bool empty() const noexcept { return m_nb_elements == 0; }
+
+    size_type size() const noexcept { return m_nb_elements; }
+
+    size_type max_size() const noexcept {
+        return std::min(std::allocator_traits<Allocator>::max_size(),
+                        m_sparse_buckets_data.max_size());
+    }
+
+    /*
+   * Modifiers
+   */
+    void clear() noexcept {
+        for (auto &bucket : m_sparse_buckets_data) {
+            bucket.clear(*this);
+        }
+
+        m_nb_elements = 0;
+        m_nb_deleted_buckets = 0;
+    }
+
+    template<typename P>
+    std::pair<iterator, bool> insert(P &&value) {
+        return insert_impl(KeySelect()(value), std::forward<P>(value));
+    }
+
+    template<typename P>
+    iterator insert_hint(const_iterator hint, P &&value) {
+        if (hint != cend() &&
+            compare_keys(KeySelect()(*hint), KeySelect()(value))) {
+            return mutable_iterator(hint);
+        }
+
+        return insert(std::forward<P>(value)).first;
+    }
+
+    template<class InputIt>
+    void insert(InputIt first, InputIt last) {
+        if (std::is_base_of<
+                    std::forward_iterator_tag,
+                    typename std::iterator_traits<InputIt>::iterator_category>::value) {
+            const auto nb_elements_insert = std::distance(first, last);
+            const size_type nb_free_buckets = m_load_threshold_rehash - size();
+            rdf4cpp_tsl_sh_assert(m_load_threshold_rehash >= size());
+
+            if (nb_elements_insert > 0 &&
+                nb_free_buckets < size_type(nb_elements_insert)) {
+                reserve(size() + size_type(nb_elements_insert));
+            }
+        }
+
+        for (; first != last; ++first) {
+            insert(*first);
+        }
+    }
+
+    template<class K, class M>
+    std::pair<iterator, bool> insert_or_assign(K &&key, M &&obj) {
+        auto it = try_emplace(std::forward<K>(key), std::forward<M>(obj));
+        if (!it.second) {
+            it.first.value() = std::forward<M>(obj);
+        }
+
+        return it;
+    }
+
+    template<class K, class M>
+    iterator insert_or_assign(const_iterator hint, K &&key, M &&obj) {
+        if (hint != cend() && compare_keys(KeySelect()(*hint), key)) {
+            auto it = mutable_iterator(hint);
+            it.value() = std::forward<M>(obj);
+
+            return it;
+        }
+
+        return insert_or_assign(std::forward<K>(key), std::forward<M>(obj)).first;
+    }
+
+    template<class... Args>
+    std::pair<iterator, bool> emplace(Args &&...args) {
+        return insert(value_type(std::forward<Args>(args)...));
+    }
+
+    template<class... Args>
+    iterator emplace_hint(const_iterator hint, Args &&...args) {
+        return insert_hint(hint, value_type(std::forward<Args>(args)...));
+    }
+
+    template<class K, class... Args>
+    std::pair<iterator, bool> try_emplace(K &&key, Args &&...args) {
+        return insert_impl(key, std::piecewise_construct,
+                           std::forward_as_tuple(std::forward<K>(key)),
+                           std::forward_as_tuple(std::forward<Args>(args)...));
+    }
+
+    template<class K, class... Args>
+    iterator try_emplace_hint(const_iterator hint, K &&key, Args &&...args) {
+        if (hint != cend() && compare_keys(KeySelect()(*hint), key)) {
+            return mutable_iterator(hint);
+        }
+
+        return try_emplace(std::forward<K>(key), std::forward<Args>(args)...).first;
+    }
+
+    /**
+   * Here to avoid `template<class K> size_type erase(const K& key)` being used
+   * when we use an iterator instead of a const_iterator.
+   */
+    iterator erase(iterator pos) {
+        rdf4cpp_tsl_sh_assert(pos != end() && m_nb_elements > 0);
+        auto it_sparse_array_next =
+                pos.m_sparse_buckets_it->erase(*this, pos.m_sparse_array_it);
+        m_nb_elements--;
+        m_nb_deleted_buckets++;
+
+        if (it_sparse_array_next == pos.m_sparse_buckets_it->end()) {
+            auto it_sparse_buckets_next = pos.m_sparse_buckets_it;
+            do {
+                ++it_sparse_buckets_next;
+            } while (it_sparse_buckets_next != m_sparse_buckets_data.end() &&
+                     it_sparse_buckets_next->empty());
+
+            if (it_sparse_buckets_next == m_sparse_buckets_data.end()) {
+                return end();
+            } else {
+                return iterator(it_sparse_buckets_next,
+                                it_sparse_buckets_next->begin());
+            }
+        } else {
+            return iterator(pos.m_sparse_buckets_it, it_sparse_array_next);
+        }
+    }
+
+    iterator erase(const_iterator pos) { return erase(mutable_iterator(pos)); }
+
+    iterator erase(const_iterator first, const_iterator last) {
+        if (first == last) {
+            return mutable_iterator(first);
+        }
+
+        // TODO Optimize, could avoid the call to std::distance.
+        const size_type nb_elements_to_erase =
+                static_cast<size_type>(std::distance(first, last));
+        auto to_delete = mutable_iterator(first);
+        for (size_type i = 0; i < nb_elements_to_erase; i++) {
+            to_delete = erase(to_delete);
+        }
+
+        return to_delete;
+    }
+
+    template<class K>
+    size_type erase(const K &key) {
+        return erase(key, hash_key(key));
+    }
+
+    template<class K>
+    size_type erase(const K &key, std::size_t hash) {
+        return erase_impl(key, hash);
+    }
+
+    void swap(sparse_hash &other) {
+        using std::swap;
+
+        if (std::allocator_traits<Allocator>::propagate_on_container_swap::value) {
+            swap(static_cast<Allocator &>(*this), static_cast<Allocator &>(other));
+        } else {
+            rdf4cpp_tsl_sh_assert(static_cast<Allocator &>(*this) ==
+                                  static_cast<Allocator &>(other));
+        }
+
+        swap(static_cast<Hash &>(*this), static_cast<Hash &>(other));
+        swap(static_cast<KeyEqual &>(*this), static_cast<KeyEqual &>(other));
+        swap(static_cast<GrowthPolicy &>(*this),
+             static_cast<GrowthPolicy &>(other));
+        swap(m_sparse_buckets_data, other.m_sparse_buckets_data);
+        swap(m_sparse_buckets, other.m_sparse_buckets);
+        swap(m_bucket_count, other.m_bucket_count);
+        swap(m_nb_elements, other.m_nb_elements);
+        swap(m_nb_deleted_buckets, other.m_nb_deleted_buckets);
+        swap(m_load_threshold_rehash, other.m_load_threshold_rehash);
+        swap(m_load_threshold_clear_deleted, other.m_load_threshold_clear_deleted);
+        swap(m_max_load_factor, other.m_max_load_factor);
+    }
+
+    /*
+   * Lookup
+   */
+    template<
+            class K, class U = ValueSelect,
+            typename std::enable_if<has_mapped_type<U>::value>::type * = nullptr>
+    typename U::value_type &at(const K &key) {
+        return at(key, hash_key(key));
+    }
+
+    template<
+            class K, class U = ValueSelect,
+            typename std::enable_if<has_mapped_type<U>::value>::type * = nullptr>
+    typename U::value_type &at(const K &key, std::size_t hash) {
+        return const_cast<typename U::value_type &>(
+                static_cast<const sparse_hash *>(this)->at(key, hash));
+    }
+
+    template<
+            class K, class U = ValueSelect,
+            typename std::enable_if<has_mapped_type<U>::value>::type * = nullptr>
+    const typename U::value_type &at(const K &key) const {
+        return at(key, hash_key(key));
+    }
+
+    template<
+            class K, class U = ValueSelect,
+            typename std::enable_if<has_mapped_type<U>::value>::type * = nullptr>
+    const typename U::value_type &at(const K &key, std::size_t hash) const {
+        auto it = find(key, hash);
+        if (it != cend()) {
+            return it.value();
+        } else {
+            throw std::out_of_range("Couldn't find key.");
+        }
+    }
+
+    template<
+            class K, class U = ValueSelect,
+            typename std::enable_if<has_mapped_type<U>::value>::type * = nullptr>
+    typename U::value_type &operator[](K &&key) {
+        return try_emplace(std::forward<K>(key)).first.value();
+    }
+
+    template<class K>
+    bool contains(const K &key) const {
+        return contains(key, hash_key(key));
+    }
+
+    template<class K>
+    bool contains(const K &key, std::size_t hash) const {
+        return count(key, hash) != 0;
+    }
+
+    template<class K>
+    size_type count(const K &key) const {
+        return count(key, hash_key(key));
+    }
+
+    template<class K>
+    size_type count(const K &key, std::size_t hash) const {
+        if (find(key, hash) != cend()) {
+            return 1;
+        } else {
+            return 0;
+        }
+    }
+
+    template<class K>
+    iterator find(const K &key) {
+        return find_impl(key, hash_key(key));
+    }
+
+    template<class K>
+    iterator find(const K &key, std::size_t hash) {
+        return find_impl(key, hash);
+    }
+
+    template<class K>
+    const_iterator find(const K &key) const {
+        return find_impl(key, hash_key(key));
+    }
+
+    template<class K>
+    const_iterator find(const K &key, std::size_t hash) const {
+        return find_impl(key, hash);
+    }
+
+    template<class K>
+    std::pair<iterator, iterator> equal_range(const K &key) {
+        return equal_range(key, hash_key(key));
+    }
+
+    template<class K>
+    std::pair<iterator, iterator> equal_range(const K &key, std::size_t hash) {
+        iterator it = find(key, hash);
+        return std::make_pair(it, (it == end()) ? it : std::next(it));
+    }
+
+    template<class K>
+    std::pair<const_iterator, const_iterator> equal_range(const K &key) const {
+        return equal_range(key, hash_key(key));
+    }
+
+    template<class K>
+    std::pair<const_iterator, const_iterator> equal_range(
+            const K &key, std::size_t hash) const {
+        const_iterator it = find(key, hash);
+        return std::make_pair(it, (it == cend()) ? it : std::next(it));
+    }
+
+    /*
+   * Bucket interface
+   */
+    size_type bucket_count() const { return m_bucket_count; }
+
+    size_type max_bucket_count() const {
+        return m_sparse_buckets_data.max_size();
+    }
+
+    /*
+   * Hash policy
+   */
+    float load_factor() const {
+        if (bucket_count() == 0) {
+            return 0;
+        }
+
+        return float(m_nb_elements) / float(bucket_count());
+    }
+
+    float max_load_factor() const { return m_max_load_factor; }
+
+    void max_load_factor(float ml) {
+        m_max_load_factor = std::max(0.1f, std::min(ml, 0.8f));
+        m_load_threshold_rehash =
+                size_type(float(bucket_count()) * m_max_load_factor);
+
+        const float max_load_factor_with_deleted_buckets =
+                m_max_load_factor + 0.5f * (1.0f - m_max_load_factor);
+        rdf4cpp_tsl_sh_assert(max_load_factor_with_deleted_buckets > 0.0f &&
+                              max_load_factor_with_deleted_buckets <= 1.0f);
+        m_load_threshold_clear_deleted =
+                size_type(float(bucket_count()) * max_load_factor_with_deleted_buckets);
+    }
+
+    void rehash(size_type count) {
+        count = std::max(count,
+                         size_type(std::ceil(float(size()) / max_load_factor())));
+        rehash_impl(count);
+    }
+
+    void reserve(size_type count) {
+        rehash(size_type(std::ceil(float(count) / max_load_factor())));
+    }
+
+    /*
+   * Observers
+   */
+    hasher hash_function() const { return static_cast<const Hash &>(*this); }
+
+    key_equal key_eq() const { return static_cast<const KeyEqual &>(*this); }
+
+    /*
+   * Other
+   */
+    iterator mutable_iterator(const_iterator pos) {
+        auto it_sparse_buckets =
+                m_sparse_buckets_data.begin() +
+                std::distance(m_sparse_buckets_data.cbegin(), pos.m_sparse_buckets_it);
+
+        return iterator(it_sparse_buckets,
+                        sparse_array::mutable_iterator(pos.m_sparse_array_it));
+    }
+
+    template<class Serializer>
+    void serialize(Serializer &serializer) const {
+        serialize_impl(serializer);
+    }
+
+    template<class Deserializer>
+    void deserialize(Deserializer &deserializer, bool hash_compatible) {
+        deserialize_impl(deserializer, hash_compatible);
+    }
+
+private:
+    template<class K>
+    std::size_t hash_key(const K &key) const {
+        return Hash::operator()(key);
+    }
+
+    template<class K1, class K2>
+    bool compare_keys(const K1 &key1, const K2 &key2) const {
+        return KeyEqual::operator()(key1, key2);
+    }
+
+    size_type bucket_for_hash(std::size_t hash) const {
+        const std::size_t bucket = GrowthPolicy::bucket_for_hash(hash);
+        rdf4cpp_tsl_sh_assert(sparse_array::sparse_ibucket(bucket) <
+                                      m_sparse_buckets_data.size() ||
+                              (bucket == 0 && m_sparse_buckets_data.empty()));
+
+        return bucket;
+    }
+
+    template<class U = GrowthPolicy,
+             typename std::enable_if<is_power_of_two_policy<U>::value>::type * =
+                     nullptr>
+    size_type next_bucket(size_type ibucket, size_type iprobe) const {
+        (void) iprobe;
+        if (Probing == tsl::sh::probing::linear) {
+            return (ibucket + 1) & this->m_mask;
+        } else {
+            rdf4cpp_tsl_sh_assert(Probing == tsl::sh::probing::quadratic);
+            return (ibucket + iprobe) & this->m_mask;
+        }
+    }
+
+    template<class U = GrowthPolicy,
+             typename std::enable_if<!is_power_of_two_policy<U>::value>::type * =
+                     nullptr>
+    size_type next_bucket(size_type ibucket, size_type iprobe) const {
+        (void) iprobe;
+        if (Probing == tsl::sh::probing::linear) {
+            ibucket++;
+            return (ibucket != bucket_count()) ? ibucket : 0;
+        } else {
+            rdf4cpp_tsl_sh_assert(Probing == tsl::sh::probing::quadratic);
+            ibucket += iprobe;
+            return (ibucket < bucket_count()) ? ibucket : ibucket % bucket_count();
+        }
+    }
+
+    // TODO encapsulate m_sparse_buckets_data to avoid the managing the allocator
+    void copy_buckets_from(const sparse_hash &other) {
+        m_sparse_buckets_data.reserve(other.m_sparse_buckets_data.size());
+
+        try {
+            for (const auto &bucket : other.m_sparse_buckets_data) {
+                m_sparse_buckets_data.emplace_back(bucket,
+                                                   static_cast<Allocator &>(*this));
+            }
+        } catch (...) {
+            clear();
+            throw;
+        }
+
+        rdf4cpp_tsl_sh_assert(m_sparse_buckets_data.empty() ||
+                              m_sparse_buckets_data.back().last());
+    }
+
+    void move_buckets_from(sparse_hash &&other) {
+        m_sparse_buckets_data.reserve(other.m_sparse_buckets_data.size());
+
+        try {
+            for (auto &&bucket : other.m_sparse_buckets_data) {
+                m_sparse_buckets_data.emplace_back(std::move(bucket),
+                                                   static_cast<Allocator &>(*this));
+            }
+        } catch (...) {
+            clear();
+            throw;
+        }
+
+        rdf4cpp_tsl_sh_assert(m_sparse_buckets_data.empty() ||
+                              m_sparse_buckets_data.back().last());
+    }
+
+    template<class K, class... Args>
+    std::pair<iterator, bool> insert_impl(const K &key,
+                                          Args &&...value_type_args) {
+        if (size() >= m_load_threshold_rehash) {
+            rehash_impl(GrowthPolicy::next_bucket_count());
+        } else if (size() + m_nb_deleted_buckets >=
+                   m_load_threshold_clear_deleted) {
+            clear_deleted_buckets();
+        }
+        rdf4cpp_tsl_sh_assert(!m_sparse_buckets_data.empty());
+
+        /**
+     * We must insert the value in the first empty or deleted bucket we find. If
+     * we first find a deleted bucket, we still have to continue the search
+     * until we find an empty bucket or until we have searched all the buckets
+     * to be sure that the value is not in the hash table. We thus remember the
+     * position, if any, of the first deleted bucket we have encountered so we
+     * can insert it there if needed.
+     */
+        bool found_first_deleted_bucket = false;
+        std::size_t sparse_ibucket_first_deleted = 0;
+        typename sparse_array::size_type index_in_sparse_bucket_first_deleted = 0;
+
+        const std::size_t hash = hash_key(key);
+        std::size_t ibucket = bucket_for_hash(hash);
+
+        std::size_t probe = 0;
+        while (true) {
+            std::size_t sparse_ibucket = sparse_array::sparse_ibucket(ibucket);
+            auto index_in_sparse_bucket =
+                    sparse_array::index_in_sparse_bucket(ibucket);
+
+            if (m_sparse_buckets[sparse_ibucket].has_value(index_in_sparse_bucket)) {
+                auto value_it =
+                        m_sparse_buckets[sparse_ibucket].value(index_in_sparse_bucket);
+                if (compare_keys(key, KeySelect()(*value_it))) {
+                    return std::make_pair(
+                            iterator(m_sparse_buckets_data.begin() + sparse_ibucket,
+                                     value_it),
+                            false);
+                }
+            } else if (m_sparse_buckets[sparse_ibucket].has_deleted_value(
+                               index_in_sparse_bucket) &&
+                       probe < m_bucket_count) {
+                if (!found_first_deleted_bucket) {
+                    found_first_deleted_bucket = true;
+                    sparse_ibucket_first_deleted = sparse_ibucket;
+                    index_in_sparse_bucket_first_deleted = index_in_sparse_bucket;
+                }
+            } else if (found_first_deleted_bucket) {
+                auto it = insert_in_bucket(sparse_ibucket_first_deleted,
+                                           index_in_sparse_bucket_first_deleted,
+                                           std::forward<Args>(value_type_args)...);
+                m_nb_deleted_buckets--;
+
+                return it;
+            } else {
+                return insert_in_bucket(sparse_ibucket, index_in_sparse_bucket,
+                                        std::forward<Args>(value_type_args)...);
+            }
+
+            probe++;
+            ibucket = next_bucket(ibucket, probe);
+        }
+    }
+
+    template<class... Args>
+    std::pair<iterator, bool> insert_in_bucket(
+            std::size_t sparse_ibucket,
+            typename sparse_array::size_type index_in_sparse_bucket,
+            Args &&...value_type_args) {
+        auto value_it = m_sparse_buckets[sparse_ibucket].set(
+                *this, index_in_sparse_bucket, std::forward<Args>(value_type_args)...);
+        m_nb_elements++;
+
+        return std::make_pair(
+                iterator(m_sparse_buckets_data.begin() + sparse_ibucket, value_it),
+                true);
+    }
+
+    template<class K>
+    size_type erase_impl(const K &key, std::size_t hash) {
+        std::size_t ibucket = bucket_for_hash(hash);
+
+        std::size_t probe = 0;
+        while (true) {
+            const std::size_t sparse_ibucket = sparse_array::sparse_ibucket(ibucket);
+            const auto index_in_sparse_bucket =
+                    sparse_array::index_in_sparse_bucket(ibucket);
+
+            if (m_sparse_buckets[sparse_ibucket].has_value(index_in_sparse_bucket)) {
+                auto value_it =
+                        m_sparse_buckets[sparse_ibucket].value(index_in_sparse_bucket);
+                if (compare_keys(key, KeySelect()(*value_it))) {
+                    m_sparse_buckets[sparse_ibucket].erase(*this, value_it,
+                                                           index_in_sparse_bucket);
+                    m_nb_elements--;
+                    m_nb_deleted_buckets++;
+
+                    return 1;
+                }
+            } else if (!m_sparse_buckets[sparse_ibucket].has_deleted_value(
+                               index_in_sparse_bucket) ||
+                       probe >= m_bucket_count) {
+                return 0;
+            }
+
+            probe++;
+            ibucket = next_bucket(ibucket, probe);
+        }
+    }
+
+    template<class K>
+    iterator find_impl(const K &key, std::size_t hash) {
+        return mutable_iterator(
+                static_cast<const sparse_hash *>(this)->find(key, hash));
+    }
+
+    template<class K>
+    const_iterator find_impl(const K &key, std::size_t hash) const {
+        std::size_t ibucket = bucket_for_hash(hash);
+
+        std::size_t probe = 0;
+        while (true) {
+            const std::size_t sparse_ibucket = sparse_array::sparse_ibucket(ibucket);
+            const auto index_in_sparse_bucket =
+                    sparse_array::index_in_sparse_bucket(ibucket);
+
+            if (m_sparse_buckets[sparse_ibucket].has_value(index_in_sparse_bucket)) {
+                auto value_it =
+                        m_sparse_buckets[sparse_ibucket].value(index_in_sparse_bucket);
+                if (compare_keys(key, KeySelect()(*value_it))) {
+                    return const_iterator(m_sparse_buckets_data.cbegin() + sparse_ibucket,
+                                          value_it);
+                }
+            } else if (!m_sparse_buckets[sparse_ibucket].has_deleted_value(
+                               index_in_sparse_bucket) ||
+                       probe >= m_bucket_count) {
+                return cend();
+            }
+
+            probe++;
+            ibucket = next_bucket(ibucket, probe);
+        }
+    }
+
+    void clear_deleted_buckets() {
+        // TODO could be optimized, we could do it in-place instead of allocating a
+        // new bucket array.
+        rehash_impl(m_bucket_count);
+        rdf4cpp_tsl_sh_assert(m_nb_deleted_buckets == 0);
+    }
+
+    template<tsl::sh::exception_safety U = ExceptionSafety,
+             typename std::enable_if<U == tsl::sh::exception_safety::basic>::type
+                     * = nullptr>
+    void rehash_impl(size_type count) {
+        sparse_hash new_table(count, static_cast<Hash &>(*this),
+                              static_cast<KeyEqual &>(*this),
+                              static_cast<Allocator &>(*this), m_max_load_factor);
+
+        for (auto &bucket : m_sparse_buckets_data) {
+            for (auto &val : bucket) {
+                new_table.insert_on_rehash(std::move(val));
+            }
+
+            // TODO try to reuse some of the memory
+            bucket.clear(*this);
+        }
+
+        new_table.swap(*this);
+    }
+
+    /**
+   * TODO: For now we copy each element into the new map. We could move
+   * them if they are nothrow_move_constructible without triggering
+   * any exception if we reserve enough space in the sparse arrays beforehand.
+   */
+    template<tsl::sh::exception_safety U = ExceptionSafety,
+             typename std::enable_if<
+                     U == tsl::sh::exception_safety::strong>::type * = nullptr>
+    void rehash_impl(size_type count) {
+        sparse_hash new_table(count, static_cast<Hash &>(*this),
+                              static_cast<KeyEqual &>(*this),
+                              static_cast<Allocator &>(*this), m_max_load_factor);
+
+        for (const auto &bucket : m_sparse_buckets_data) {
+            for (const auto &val : bucket) {
+                new_table.insert_on_rehash(val);
+            }
+        }
+
+        new_table.swap(*this);
+    }
+
+    template<typename K>
+    void insert_on_rehash(K &&key_value) {
+        const key_type &key = KeySelect()(key_value);
+
+        const std::size_t hash = hash_key(key);
+        std::size_t ibucket = bucket_for_hash(hash);
+
+        std::size_t probe = 0;
+        while (true) {
+            std::size_t sparse_ibucket = sparse_array::sparse_ibucket(ibucket);
+            auto index_in_sparse_bucket =
+                    sparse_array::index_in_sparse_bucket(ibucket);
+
+            if (!m_sparse_buckets[sparse_ibucket].has_value(index_in_sparse_bucket)) {
+                m_sparse_buckets[sparse_ibucket].set(*this, index_in_sparse_bucket,
+                                                     std::forward<K>(key_value));
+                m_nb_elements++;
+
+                return;
+            } else {
+                rdf4cpp_tsl_sh_assert(!compare_keys(
+                        key, KeySelect()(*m_sparse_buckets[sparse_ibucket].value(
+                                     index_in_sparse_bucket))));
+            }
+
+            probe++;
+            ibucket = next_bucket(ibucket, probe);
+        }
+    }
+
+    template<class Serializer>
+    void serialize_impl(Serializer &serializer) const {
+        const slz_size_type version = SERIALIZATION_PROTOCOL_VERSION;
+        serializer(version);
+
+        const slz_size_type bucket_count = m_bucket_count;
+        serializer(bucket_count);
+
+        const slz_size_type nb_sparse_buckets = m_sparse_buckets_data.size();
+        serializer(nb_sparse_buckets);
+
+        const slz_size_type nb_elements = m_nb_elements;
+        serializer(nb_elements);
+
+        const slz_size_type nb_deleted_buckets = m_nb_deleted_buckets;
+        serializer(nb_deleted_buckets);
+
+        const float max_load_factor = m_max_load_factor;
+        serializer(max_load_factor);
+
+        for (const auto &bucket : m_sparse_buckets_data) {
+            bucket.serialize(serializer);
+        }
+    }
+
+    template<class Deserializer>
+    void deserialize_impl(Deserializer &deserializer, bool hash_compatible) {
+        rdf4cpp_tsl_sh_assert(
+                m_bucket_count == 0 &&
+                m_sparse_buckets_data.empty());  // Current hash table must be empty
+
+        const slz_size_type version =
+                deserialize_value<slz_size_type>(deserializer);
+        // For now we only have one version of the serialization protocol.
+        // If it doesn't match there is a problem with the file.
+        if (version != SERIALIZATION_PROTOCOL_VERSION) {
+            throw std::runtime_error(
+                    "Can't deserialize the sparse_map/set. The "
+                    "protocol version header is invalid.");
+        }
+
+        const slz_size_type bucket_count_ds =
+                deserialize_value<slz_size_type>(deserializer);
+        const slz_size_type nb_sparse_buckets =
+                deserialize_value<slz_size_type>(deserializer);
+        const slz_size_type nb_elements =
+                deserialize_value<slz_size_type>(deserializer);
+        const slz_size_type nb_deleted_buckets =
+                deserialize_value<slz_size_type>(deserializer);
+        const float max_load_factor = deserialize_value<float>(deserializer);
+
+        if (!hash_compatible) {
+            this->max_load_factor(max_load_factor);
+            reserve(numeric_cast<size_type>(nb_elements,
+                                            "Deserialized nb_elements is too big."));
+            for (slz_size_type ibucket = 0; ibucket < nb_sparse_buckets; ibucket++) {
+                sparse_array::deserialize_values_into_sparse_hash(deserializer, *this);
+            }
+        } else {
+            m_bucket_count = numeric_cast<size_type>(
+                    bucket_count_ds, "Deserialized bucket_count is too big.");
+
+            GrowthPolicy::operator=(GrowthPolicy(m_bucket_count));
+            // GrowthPolicy should not modify the bucket count we got from
+            // deserialization
+            if (m_bucket_count != bucket_count_ds) {
+                throw std::runtime_error(
+                        "The GrowthPolicy is not the same even though "
+                        "hash_compatible is true.");
+            }
+
+            if (nb_sparse_buckets !=
+                sparse_array::nb_sparse_buckets(m_bucket_count)) {
+                throw std::runtime_error("Deserialized nb_sparse_buckets is invalid.");
+            }
+
+            m_nb_elements = numeric_cast<size_type>(
+                    nb_elements, "Deserialized nb_elements is too big.");
+            m_nb_deleted_buckets = numeric_cast<size_type>(
+                    nb_deleted_buckets, "Deserialized nb_deleted_buckets is too big.");
+
+            m_sparse_buckets_data.reserve(numeric_cast<size_type>(
+                    nb_sparse_buckets, "Deserialized nb_sparse_buckets is too big."));
+            for (slz_size_type ibucket = 0; ibucket < nb_sparse_buckets; ibucket++) {
+                m_sparse_buckets_data.emplace_back(
+                        sparse_array::deserialize_hash_compatible(
+                                deserializer, static_cast<Allocator &>(*this)));
+            }
+
+            if (!m_sparse_buckets_data.empty()) {
+                m_sparse_buckets_data.back().set_as_last();
+                m_sparse_buckets = m_sparse_buckets_data.data();
+            }
+
+            this->max_load_factor(max_load_factor);
+            if (load_factor() > this->max_load_factor()) {
+                throw std::runtime_error(
+                        "Invalid max_load_factor. Check that the serializer and "
+                        "deserializer support "
+                        "floats correctly as they can be converted implicitely to ints.");
+            }
+        }
+    }
+
+public:
+    static const size_type DEFAULT_INIT_BUCKET_COUNT = 0;
+    static constexpr float DEFAULT_MAX_LOAD_FACTOR = 0.5f;
+
+    /**
+   * Protocol version currenlty used for serialization.
+   */
+    static const slz_size_type SERIALIZATION_PROTOCOL_VERSION = 1;
+
+    /**
+   * Return an always valid pointer to an static empty bucket_entry with
+   * last_bucket() == true.
+   */
+    sparse_array *static_empty_sparse_bucket_ptr() {
+        static sparse_array empty_sparse_bucket(true);
+        return &empty_sparse_bucket;
+    }
+
+private:
+    sparse_buckets_container m_sparse_buckets_data;
+
+    /**
+   * Points to m_sparse_buckets_data.data() if !m_sparse_buckets_data.empty()
+   * otherwise points to static_empty_sparse_bucket_ptr. This variable is useful
+   * to avoid the cost of checking if m_sparse_buckets_data is empty when trying
+   * to find an element.
+   *
+   * TODO Remove m_sparse_buckets_data and only use a pointer instead of a
+   * pointer+vector to save some space in the sparse_hash object.
+   */
+    sparse_array *m_sparse_buckets;
+
+    size_type m_bucket_count;
+    size_type m_nb_elements;
+    size_type m_nb_deleted_buckets;
+
+    /**
+   * Maximum that m_nb_elements can reach before a rehash occurs automatically
+   * to grow the hash table.
+   */
+    size_type m_load_threshold_rehash;
+
+    /**
+   * Maximum that m_nb_elements + m_nb_deleted_buckets can reach before cleaning
+   * up the buckets marked as deleted.
+   */
+    size_type m_load_threshold_clear_deleted;
+    float m_max_load_factor;
+};
+
+}  // namespace detail_sparse_hash
+}  // namespace rdf4cpp::rdf::storage::util::tsl
+
+#endif

--- a/src/rdf4cpp/rdf/storage/util/tsl/sparse_map.h
+++ b/src/rdf4cpp/rdf/storage/util/tsl/sparse_map.h
@@ -1,0 +1,800 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017 Thibaut Goetghebuer-Planchon <tessil@gmx.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef RDF4CPP_TSL_SPARSE_MAP_H
+#define RDF4CPP_TSL_SPARSE_MAP_H
+
+#include <cstddef>
+#include <functional>
+#include <initializer_list>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+#include "sparse_hash.h"
+
+namespace rdf4cpp::rdf::storage::util::tsl {
+
+/**
+ * Implementation of a sparse hash map using open-addressing with quadratic
+ * probing. The goal on the hash map is to be the most memory efficient
+ * possible, even at low load factor, while keeping reasonable performances.
+ *
+ * `GrowthPolicy` defines how the map grows and consequently how a hash value is
+ * mapped to a bucket. By default the map uses
+ * `tsl::sh::power_of_two_growth_policy`. This policy keeps the number of
+ * buckets to a power of two and uses a mask to map the hash to a bucket instead
+ * of the slow modulo. Other growth policies are available and you may define
+ * your own growth policy, check `tsl::sh::power_of_two_growth_policy` for the
+ * interface.
+ *
+ * `ExceptionSafety` defines the exception guarantee provided by the class. By
+ * default only the basic exception safety is guaranteed which mean that all
+ * resources used by the hash map will be freed (no memory leaks) but the hash
+ * map may end-up in an undefined state if an exception is thrown (undefined
+ * here means that some elements may be missing). This can ONLY happen on rehash
+ * (either on insert or if `rehash` is called explicitly) and will occur if the
+ * Allocator can't allocate memory (`std::bad_alloc`) or if the copy constructor
+ * (when a nothrow move constructor is not available) throws an exception. This
+ * can be avoided by calling `reserve` beforehand. This basic guarantee is
+ * similar to the one of `google::sparse_hash_map` and `spp::sparse_hash_map`.
+ * It is possible to ask for the strong exception guarantee with
+ * `tsl::sh::exception_safety::strong`, the drawback is that the map will be
+ * slower on rehashes and will also need more memory on rehashes.
+ *
+ * `Sparsity` defines how much the hash set will compromise between insertion
+ * speed and memory usage. A high sparsity means less memory usage but longer
+ * insertion times, and vice-versa for low sparsity. The default
+ * `tsl::sh::sparsity::medium` sparsity offers a good compromise. It doesn't
+ * change the lookup speed.
+ *
+ * `Key` and `T` must be nothrow move constructible and/or copy constructible.
+ *
+ * If the destructor of `Key` or `T` throws an exception, the behaviour of the
+ * class is undefined.
+ *
+ * Iterators invalidation:
+ *  - clear, operator=, reserve, rehash: always invalidate the iterators.
+ *  - insert, emplace, emplace_hint, operator[]: if there is an effective
+ * insert, invalidate the iterators.
+ *  - erase: always invalidate the iterators.
+ */
+template<class Key, class T, class Hash = std::hash<Key>,
+         class KeyEqual = std::equal_to<Key>,
+         class Allocator = std::allocator<std::pair<Key, T>>,
+         class GrowthPolicy = tsl::sh::power_of_two_growth_policy<2>,
+         tsl::sh::exception_safety ExceptionSafety =
+                 tsl::sh::exception_safety::basic,
+         tsl::sh::sparsity Sparsity = tsl::sh::sparsity::medium>
+class sparse_map {
+private:
+    template<typename U>
+    using has_is_transparent = tsl::detail_sparse_hash::has_is_transparent<U>;
+
+    class KeySelect {
+    public:
+        using key_type = Key;
+
+        const key_type &operator()(
+                const std::pair<Key, T> &key_value) const noexcept {
+            return key_value.first;
+        }
+
+        key_type &operator()(std::pair<Key, T> &key_value) noexcept {
+            return key_value.first;
+        }
+    };
+
+    class ValueSelect {
+    public:
+        using value_type = T;
+
+        const value_type &operator()(
+                const std::pair<Key, T> &key_value) const noexcept {
+            return key_value.second;
+        }
+
+        value_type &operator()(std::pair<Key, T> &key_value) noexcept {
+            return key_value.second;
+        }
+    };
+
+    using ht = detail_sparse_hash::sparse_hash<
+            std::pair<Key, T>, KeySelect, ValueSelect, Hash, KeyEqual, Allocator,
+            GrowthPolicy, ExceptionSafety, Sparsity, tsl::sh::probing::quadratic>;
+
+public:
+    using key_type = typename ht::key_type;
+    using mapped_type = T;
+    using value_type = typename ht::value_type;
+    using size_type = typename ht::size_type;
+    using difference_type = typename ht::difference_type;
+    using hasher = typename ht::hasher;
+    using key_equal = typename ht::key_equal;
+    using allocator_type = typename ht::allocator_type;
+    using reference = typename ht::reference;
+    using const_reference = typename ht::const_reference;
+    using pointer = typename ht::pointer;
+    using const_pointer = typename ht::const_pointer;
+    using iterator = typename ht::iterator;
+    using const_iterator = typename ht::const_iterator;
+
+public:
+    /*
+   * Constructors
+   */
+    sparse_map() : sparse_map(ht::DEFAULT_INIT_BUCKET_COUNT) {}
+
+    explicit sparse_map(size_type bucket_count, const Hash &hash = Hash(),
+                        const KeyEqual &equal = KeyEqual(),
+                        const Allocator &alloc = Allocator())
+        : m_ht(bucket_count, hash, equal, alloc, ht::DEFAULT_MAX_LOAD_FACTOR) {}
+
+    sparse_map(size_type bucket_count, const Allocator &alloc)
+        : sparse_map(bucket_count, Hash(), KeyEqual(), alloc) {}
+
+    sparse_map(size_type bucket_count, const Hash &hash, const Allocator &alloc)
+        : sparse_map(bucket_count, hash, KeyEqual(), alloc) {}
+
+    explicit sparse_map(const Allocator &alloc)
+        : sparse_map(ht::DEFAULT_INIT_BUCKET_COUNT, alloc) {}
+
+    template<class InputIt>
+    sparse_map(InputIt first, InputIt last,
+               size_type bucket_count = ht::DEFAULT_INIT_BUCKET_COUNT,
+               const Hash &hash = Hash(), const KeyEqual &equal = KeyEqual(),
+               const Allocator &alloc = Allocator())
+        : sparse_map(bucket_count, hash, equal, alloc) {
+        insert(first, last);
+    }
+
+    template<class InputIt>
+    sparse_map(InputIt first, InputIt last, size_type bucket_count,
+               const Allocator &alloc)
+        : sparse_map(first, last, bucket_count, Hash(), KeyEqual(), alloc) {}
+
+    template<class InputIt>
+    sparse_map(InputIt first, InputIt last, size_type bucket_count,
+               const Hash &hash, const Allocator &alloc)
+        : sparse_map(first, last, bucket_count, hash, KeyEqual(), alloc) {}
+
+    sparse_map(std::initializer_list<value_type> init,
+               size_type bucket_count = ht::DEFAULT_INIT_BUCKET_COUNT,
+               const Hash &hash = Hash(), const KeyEqual &equal = KeyEqual(),
+               const Allocator &alloc = Allocator())
+        : sparse_map(init.begin(), init.end(), bucket_count, hash, equal, alloc) {
+    }
+
+    sparse_map(std::initializer_list<value_type> init, size_type bucket_count,
+               const Allocator &alloc)
+        : sparse_map(init.begin(), init.end(), bucket_count, Hash(), KeyEqual(),
+                     alloc) {}
+
+    sparse_map(std::initializer_list<value_type> init, size_type bucket_count,
+               const Hash &hash, const Allocator &alloc)
+        : sparse_map(init.begin(), init.end(), bucket_count, hash, KeyEqual(),
+                     alloc) {}
+
+    sparse_map &operator=(std::initializer_list<value_type> ilist) {
+        m_ht.clear();
+
+        m_ht.reserve(ilist.size());
+        m_ht.insert(ilist.begin(), ilist.end());
+
+        return *this;
+    }
+
+    allocator_type get_allocator() const { return m_ht.get_allocator(); }
+
+    /*
+   * Iterators
+   */
+    iterator begin() noexcept { return m_ht.begin(); }
+    const_iterator begin() const noexcept { return m_ht.begin(); }
+    const_iterator cbegin() const noexcept { return m_ht.cbegin(); }
+
+    iterator end() noexcept { return m_ht.end(); }
+    const_iterator end() const noexcept { return m_ht.end(); }
+    const_iterator cend() const noexcept { return m_ht.cend(); }
+
+    /*
+   * Capacity
+   */
+    bool empty() const noexcept { return m_ht.empty(); }
+    size_type size() const noexcept { return m_ht.size(); }
+    size_type max_size() const noexcept { return m_ht.max_size(); }
+
+    /*
+   * Modifiers
+   */
+    void clear() noexcept { m_ht.clear(); }
+
+    std::pair<iterator, bool> insert(const value_type &value) {
+        return m_ht.insert(value);
+    }
+
+    template<class P, typename std::enable_if<std::is_constructible<
+                              value_type, P &&>::value>::type * = nullptr>
+    std::pair<iterator, bool> insert(P &&value) {
+        return m_ht.emplace(std::forward<P>(value));
+    }
+
+    std::pair<iterator, bool> insert(value_type &&value) {
+        return m_ht.insert(std::move(value));
+    }
+
+    iterator insert(const_iterator hint, const value_type &value) {
+        return m_ht.insert_hint(hint, value);
+    }
+
+    template<class P, typename std::enable_if<std::is_constructible<
+                              value_type, P &&>::value>::type * = nullptr>
+    iterator insert(const_iterator hint, P &&value) {
+        return m_ht.emplace_hint(hint, std::forward<P>(value));
+    }
+
+    iterator insert(const_iterator hint, value_type &&value) {
+        return m_ht.insert_hint(hint, std::move(value));
+    }
+
+    template<class InputIt>
+    void insert(InputIt first, InputIt last) {
+        m_ht.insert(first, last);
+    }
+
+    void insert(std::initializer_list<value_type> ilist) {
+        m_ht.insert(ilist.begin(), ilist.end());
+    }
+
+    template<class M>
+    std::pair<iterator, bool> insert_or_assign(const key_type &k, M &&obj) {
+        return m_ht.insert_or_assign(k, std::forward<M>(obj));
+    }
+
+    template<class M>
+    std::pair<iterator, bool> insert_or_assign(key_type &&k, M &&obj) {
+        return m_ht.insert_or_assign(std::move(k), std::forward<M>(obj));
+    }
+
+    template<class M>
+    iterator insert_or_assign(const_iterator hint, const key_type &k, M &&obj) {
+        return m_ht.insert_or_assign(hint, k, std::forward<M>(obj));
+    }
+
+    template<class M>
+    iterator insert_or_assign(const_iterator hint, key_type &&k, M &&obj) {
+        return m_ht.insert_or_assign(hint, std::move(k), std::forward<M>(obj));
+    }
+
+    /**
+   * Due to the way elements are stored, emplace will need to move or copy the
+   * key-value once. The method is equivalent to
+   * `insert(value_type(std::forward<Args>(args)...));`.
+   *
+   * Mainly here for compatibility with the `std::unordered_map` interface.
+   */
+    template<class... Args>
+    std::pair<iterator, bool> emplace(Args &&...args) {
+        return m_ht.emplace(std::forward<Args>(args)...);
+    }
+
+    /**
+   * Due to the way elements are stored, emplace_hint will need to move or copy
+   * the key-value once. The method is equivalent to `insert(hint,
+   * value_type(std::forward<Args>(args)...));`.
+   *
+   * Mainly here for compatibility with the `std::unordered_map` interface.
+   */
+    template<class... Args>
+    iterator emplace_hint(const_iterator hint, Args &&...args) {
+        return m_ht.emplace_hint(hint, std::forward<Args>(args)...);
+    }
+
+    template<class... Args>
+    std::pair<iterator, bool> try_emplace(const key_type &k, Args &&...args) {
+        return m_ht.try_emplace(k, std::forward<Args>(args)...);
+    }
+
+    template<class... Args>
+    std::pair<iterator, bool> try_emplace(key_type &&k, Args &&...args) {
+        return m_ht.try_emplace(std::move(k), std::forward<Args>(args)...);
+    }
+
+    template<class... Args>
+    iterator try_emplace(const_iterator hint, const key_type &k, Args &&...args) {
+        return m_ht.try_emplace_hint(hint, k, std::forward<Args>(args)...);
+    }
+
+    template<class... Args>
+    iterator try_emplace(const_iterator hint, key_type &&k, Args &&...args) {
+        return m_ht.try_emplace_hint(hint, std::move(k),
+                                     std::forward<Args>(args)...);
+    }
+
+    iterator erase(iterator pos) { return m_ht.erase(pos); }
+    iterator erase(const_iterator pos) { return m_ht.erase(pos); }
+    iterator erase(const_iterator first, const_iterator last) {
+        return m_ht.erase(first, last);
+    }
+    size_type erase(const key_type &key) { return m_ht.erase(key); }
+
+    /**
+   * Use the hash value `precalculated_hash` instead of hashing the key. The
+   * hash value should be the same as `hash_function()(key)`, otherwise the
+   * behaviour is undefined. Useful to speed-up the lookup if you already have
+   * the hash.
+   */
+    size_type erase(const key_type &key, std::size_t precalculated_hash) {
+        return m_ht.erase(key, precalculated_hash);
+    }
+
+    /**
+   * This overload only participates in the overload resolution if the typedef
+   * `KeyEqual::is_transparent` exists. If so, `K` must be hashable and
+   * comparable to `Key`.
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    size_type erase(const K &key) {
+        return m_ht.erase(key);
+    }
+
+    /**
+   * @copydoc erase(const K& key)
+   *
+   * Use the hash value `precalculated_hash` instead of hashing the key. The
+   * hash value should be the same as `hash_function()(key)`, otherwise the
+   * behaviour is undefined. Useful to speed-up the lookup if you already have
+   * the hash.
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    size_type erase(const K &key, std::size_t precalculated_hash) {
+        return m_ht.erase(key, precalculated_hash);
+    }
+
+    void swap(sparse_map &other) { other.m_ht.swap(m_ht); }
+
+    /*
+   * Lookup
+   */
+    T &at(const Key &key) { return m_ht.at(key); }
+
+    /**
+   * Use the hash value `precalculated_hash` instead of hashing the key. The
+   * hash value should be the same as `hash_function()(key)`, otherwise the
+   * behaviour is undefined. Useful to speed-up the lookup if you already have
+   * the hash.
+   */
+    T &at(const Key &key, std::size_t precalculated_hash) {
+        return m_ht.at(key, precalculated_hash);
+    }
+
+    const T &at(const Key &key) const { return m_ht.at(key); }
+
+    /**
+   * @copydoc at(const Key& key, std::size_t precalculated_hash)
+   */
+    const T &at(const Key &key, std::size_t precalculated_hash) const {
+        return m_ht.at(key, precalculated_hash);
+    }
+
+    /**
+   * This overload only participates in the overload resolution if the typedef
+   * `KeyEqual::is_transparent` exists. If so, `K` must be hashable and
+   * comparable to `Key`.
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    T &at(const K &key) {
+        return m_ht.at(key);
+    }
+
+    /**
+   * @copydoc at(const K& key)
+   *
+   * Use the hash value `precalculated_hash` instead of hashing the key. The
+   * hash value should be the same as `hash_function()(key)`, otherwise the
+   * behaviour is undefined. Useful to speed-up the lookup if you already have
+   * the hash.
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    T &at(const K &key, std::size_t precalculated_hash) {
+        return m_ht.at(key, precalculated_hash);
+    }
+
+    /**
+   * @copydoc at(const K& key)
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    const T &at(const K &key) const {
+        return m_ht.at(key);
+    }
+
+    /**
+   * @copydoc at(const K& key, std::size_t precalculated_hash)
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    const T &at(const K &key, std::size_t precalculated_hash) const {
+        return m_ht.at(key, precalculated_hash);
+    }
+
+    T &operator[](const Key &key) { return m_ht[key]; }
+    T &operator[](Key &&key) { return m_ht[std::move(key)]; }
+
+    size_type count(const Key &key) const { return m_ht.count(key); }
+
+    /**
+   * Use the hash value `precalculated_hash` instead of hashing the key. The
+   * hash value should be the same as `hash_function()(key)`, otherwise the
+   * behaviour is undefined. Useful to speed-up the lookup if you already have
+   * the hash.
+   */
+    size_type count(const Key &key, std::size_t precalculated_hash) const {
+        return m_ht.count(key, precalculated_hash);
+    }
+
+    /**
+   * This overload only participates in the overload resolution if the typedef
+   * `KeyEqual::is_transparent` exists. If so, `K` must be hashable and
+   * comparable to `Key`.
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    size_type count(const K &key) const {
+        return m_ht.count(key);
+    }
+
+    /**
+   * @copydoc count(const K& key) const
+   *
+   * Use the hash value `precalculated_hash` instead of hashing the key. The
+   * hash value should be the same as `hash_function()(key)`, otherwise the
+   * behaviour is undefined. Useful to speed-up the lookup if you already have
+   * the hash.
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    size_type count(const K &key, std::size_t precalculated_hash) const {
+        return m_ht.count(key, precalculated_hash);
+    }
+
+    iterator find(const Key &key) { return m_ht.find(key); }
+
+    /**
+   * Use the hash value `precalculated_hash` instead of hashing the key. The
+   * hash value should be the same as `hash_function()(key)`, otherwise the
+   * behaviour is undefined. Useful to speed-up the lookup if you already have
+   * the hash.
+   */
+    iterator find(const Key &key, std::size_t precalculated_hash) {
+        return m_ht.find(key, precalculated_hash);
+    }
+
+    const_iterator find(const Key &key) const { return m_ht.find(key); }
+
+    /**
+   * @copydoc find(const Key& key, std::size_t precalculated_hash)
+   */
+    const_iterator find(const Key &key, std::size_t precalculated_hash) const {
+        return m_ht.find(key, precalculated_hash);
+    }
+
+    /**
+   * This overload only participates in the overload resolution if the typedef
+   * `KeyEqual::is_transparent` exists. If so, `K` must be hashable and
+   * comparable to `Key`.
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    iterator find(const K &key) {
+        return m_ht.find(key);
+    }
+
+    /**
+   * @copydoc find(const K& key)
+   *
+   * Use the hash value `precalculated_hash` instead of hashing the key. The
+   * hash value should be the same as `hash_function()(key)`, otherwise the
+   * behaviour is undefined. Useful to speed-up the lookup if you already have
+   * the hash.
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    iterator find(const K &key, std::size_t precalculated_hash) {
+        return m_ht.find(key, precalculated_hash);
+    }
+
+    /**
+   * @copydoc find(const K& key)
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    const_iterator find(const K &key) const {
+        return m_ht.find(key);
+    }
+
+    /**
+   * @copydoc find(const K& key)
+   *
+   * Use the hash value `precalculated_hash` instead of hashing the key. The
+   * hash value should be the same as `hash_function()(key)`, otherwise the
+   * behaviour is undefined. Useful to speed-up the lookup if you already have
+   * the hash.
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    const_iterator find(const K &key, std::size_t precalculated_hash) const {
+        return m_ht.find(key, precalculated_hash);
+    }
+
+    bool contains(const Key &key) const { return m_ht.contains(key); }
+
+    /**
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+    bool contains(const Key &key, std::size_t precalculated_hash) const {
+        return m_ht.contains(key, precalculated_hash);
+    }
+
+    /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent exists. If so, K must be hashable and comparable
+   * to Key.
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    bool contains(const K &key) const {
+        return m_ht.contains(key);
+    }
+
+    /**
+   * @copydoc contains(const K& key) const
+   *
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    bool contains(const K &key, std::size_t precalculated_hash) const {
+        return m_ht.contains(key, precalculated_hash);
+    }
+
+    std::pair<iterator, iterator> equal_range(const Key &key) {
+        return m_ht.equal_range(key);
+    }
+
+    /**
+   * Use the hash value `precalculated_hash` instead of hashing the key. The
+   * hash value should be the same as `hash_function()(key)`, otherwise the
+   * behaviour is undefined. Useful to speed-up the lookup if you already have
+   * the hash.
+   */
+    std::pair<iterator, iterator> equal_range(const Key &key,
+                                              std::size_t precalculated_hash) {
+        return m_ht.equal_range(key, precalculated_hash);
+    }
+
+    std::pair<const_iterator, const_iterator> equal_range(const Key &key) const {
+        return m_ht.equal_range(key);
+    }
+
+    /**
+   * @copydoc equal_range(const Key& key, std::size_t precalculated_hash)
+   */
+    std::pair<const_iterator, const_iterator> equal_range(
+            const Key &key, std::size_t precalculated_hash) const {
+        return m_ht.equal_range(key, precalculated_hash);
+    }
+
+    /**
+   * This overload only participates in the overload resolution if the typedef
+   * `KeyEqual::is_transparent` exists. If so, `K` must be hashable and
+   * comparable to `Key`.
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    std::pair<iterator, iterator> equal_range(const K &key) {
+        return m_ht.equal_range(key);
+    }
+
+    /**
+   * @copydoc equal_range(const K& key)
+   *
+   * Use the hash value `precalculated_hash` instead of hashing the key. The
+   * hash value should be the same as `hash_function()(key)`, otherwise the
+   * behaviour is undefined. Useful to speed-up the lookup if you already have
+   * the hash.
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    std::pair<iterator, iterator> equal_range(const K &key,
+                                              std::size_t precalculated_hash) {
+        return m_ht.equal_range(key, precalculated_hash);
+    }
+
+    /**
+   * @copydoc equal_range(const K& key)
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    std::pair<const_iterator, const_iterator> equal_range(const K &key) const {
+        return m_ht.equal_range(key);
+    }
+
+    /**
+   * @copydoc equal_range(const K& key, std::size_t precalculated_hash)
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    std::pair<const_iterator, const_iterator> equal_range(
+            const K &key, std::size_t precalculated_hash) const {
+        return m_ht.equal_range(key, precalculated_hash);
+    }
+
+    /*
+   * Bucket interface
+   */
+    size_type bucket_count() const { return m_ht.bucket_count(); }
+    size_type max_bucket_count() const { return m_ht.max_bucket_count(); }
+
+    /*
+   *  Hash policy
+   */
+    float load_factor() const { return m_ht.load_factor(); }
+    float max_load_factor() const { return m_ht.max_load_factor(); }
+    void max_load_factor(float ml) { m_ht.max_load_factor(ml); }
+
+    void rehash(size_type count) { m_ht.rehash(count); }
+    void reserve(size_type count) { m_ht.reserve(count); }
+
+    /*
+   * Observers
+   */
+    hasher hash_function() const { return m_ht.hash_function(); }
+    key_equal key_eq() const { return m_ht.key_eq(); }
+
+    /*
+   * Other
+   */
+
+    /**
+   * Convert a `const_iterator` to an `iterator`.
+   */
+    iterator mutable_iterator(const_iterator pos) {
+        return m_ht.mutable_iterator(pos);
+    }
+
+    /**
+   * Serialize the map through the `serializer` parameter.
+   *
+   * The `serializer` parameter must be a function object that supports the
+   * following call:
+   *  - `template<typename U> void operator()(const U& value);` where the types
+   * `std::uint64_t`, `float` and `std::pair<Key, T>` must be supported for U.
+   *
+   * The implementation leaves binary compatibility (endianness, IEEE 754 for
+   * floats, ...) of the types it serializes in the hands of the `Serializer`
+   * function object if compatibility is required.
+   */
+    template<class Serializer>
+    void serialize(Serializer &serializer) const {
+        m_ht.serialize(serializer);
+    }
+
+    /**
+   * Deserialize a previously serialized map through the `deserializer`
+   * parameter.
+   *
+   * The `deserializer` parameter must be a function object that supports the
+   * following calls:
+   *  - `template<typename U> U operator()();` where the types `std::uint64_t`,
+   * `float` and `std::pair<Key, T>` must be supported for U.
+   *
+   * If the deserialized hash map type is hash compatible with the serialized
+   * map, the deserialization process can be sped up by setting
+   * `hash_compatible` to true. To be hash compatible, the Hash, KeyEqual and
+   * GrowthPolicy must behave the same way than the ones used on the serialized
+   * map. The `std::size_t` must also be of the same size as the one on the
+   * platform used to serialize the map. If these criteria are not met, the
+   * behaviour is undefined with `hash_compatible` sets to true.
+   *
+   * The behaviour is undefined if the type `Key` and `T` of the `sparse_map`
+   * are not the same as the types used during serialization.
+   *
+   * The implementation leaves binary compatibility (endianness, IEEE 754 for
+   * floats, size of int, ...) of the types it deserializes in the hands of the
+   * `Deserializer` function object if compatibility is required.
+   */
+    template<class Deserializer>
+    static sparse_map deserialize(Deserializer &deserializer,
+                                  bool hash_compatible = false) {
+        sparse_map map(0);
+        map.m_ht.deserialize(deserializer, hash_compatible);
+
+        return map;
+    }
+
+    friend bool operator==(const sparse_map &lhs, const sparse_map &rhs) {
+        if (lhs.size() != rhs.size()) {
+            return false;
+        }
+
+        for (const auto &element_lhs : lhs) {
+            const auto it_element_rhs = rhs.find(element_lhs.first);
+            if (it_element_rhs == rhs.cend() ||
+                element_lhs.second != it_element_rhs->second) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    friend bool operator!=(const sparse_map &lhs, const sparse_map &rhs) {
+        return !operator==(lhs, rhs);
+    }
+
+    friend void swap(sparse_map &lhs, sparse_map &rhs) { lhs.swap(rhs); }
+
+private:
+    ht m_ht;
+};
+
+/**
+ * Same as `tsl::sparse_map<Key, T, Hash, KeyEqual, Allocator,
+ * tsl::sh::prime_growth_policy>`.
+ */
+template<class Key, class T, class Hash = std::hash<Key>,
+         class KeyEqual = std::equal_to<Key>,
+         class Allocator = std::allocator<std::pair<Key, T>>>
+using sparse_pg_map =
+        sparse_map<Key, T, Hash, KeyEqual, Allocator, tsl::sh::prime_growth_policy>;
+
+}  // end namespace rdf4cpp::rdf::storage::util::tsl
+
+#endif

--- a/src/rdf4cpp/rdf/storage/util/tsl/sparse_set.h
+++ b/src/rdf4cpp/rdf/storage/util/tsl/sparse_set.h
@@ -1,0 +1,655 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017 Thibaut Goetghebuer-Planchon <tessil@gmx.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef RDF4CPP_TSL_SPARSE_SET_H
+#define RDF4CPP_TSL_SPARSE_SET_H
+
+#include <cstddef>
+#include <functional>
+#include <initializer_list>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+#include "sparse_hash.h"
+
+namespace rdf4cpp::rdf::storage::util::tsl {
+
+/**
+ * Implementation of a sparse hash set using open-addressing with quadratic
+ * probing. The goal on the hash set is to be the most memory efficient
+ * possible, even at low load factor, while keeping reasonable performances.
+ *
+ * `GrowthPolicy` defines how the set grows and consequently how a hash value is
+ * mapped to a bucket. By default the set uses
+ * `tsl::sh::power_of_two_growth_policy`. This policy keeps the number of
+ * buckets to a power of two and uses a mask to map the hash to a bucket instead
+ * of the slow modulo. Other growth policies are available and you may define
+ * your own growth policy, check `tsl::sh::power_of_two_growth_policy` for the
+ * interface.
+ *
+ * `ExceptionSafety` defines the exception guarantee provided by the class. By
+ * default only the basic exception safety is guaranteed which mean that all
+ * resources used by the hash set will be freed (no memory leaks) but the hash
+ * set may end-up in an undefined state if an exception is thrown (undefined
+ * here means that some elements may be missing). This can ONLY happen on rehash
+ * (either on insert or if `rehash` is called explicitly) and will occur if the
+ * Allocator can't allocate memory (`std::bad_alloc`) or if the copy constructor
+ * (when a nothrow move constructor is not available) throws an exception. This
+ * can be avoided by calling `reserve` beforehand. This basic guarantee is
+ * similar to the one of `google::sparse_hash_map` and `spp::sparse_hash_map`.
+ * It is possible to ask for the strong exception guarantee with
+ * `tsl::sh::exception_safety::strong`, the drawback is that the set will be
+ * slower on rehashes and will also need more memory on rehashes.
+ *
+ * `Sparsity` defines how much the hash set will compromise between insertion
+ * speed and memory usage. A high sparsity means less memory usage but longer
+ * insertion times, and vice-versa for low sparsity. The default
+ * `tsl::sh::sparsity::medium` sparsity offers a good compromise. It doesn't
+ * change the lookup speed.
+ *
+ * `Key` must be nothrow move constructible and/or copy constructible.
+ *
+ * If the destructor of `Key` throws an exception, the behaviour of the class is
+ * undefined.
+ *
+ * Iterators invalidation:
+ *  - clear, operator=, reserve, rehash: always invalidate the iterators.
+ *  - insert, emplace, emplace_hint: if there is an effective insert, invalidate
+ * the iterators.
+ *  - erase: always invalidate the iterators.
+ */
+template<class Key, class Hash = std::hash<Key>,
+         class KeyEqual = std::equal_to<Key>,
+         class Allocator = std::allocator<Key>,
+         class GrowthPolicy = tsl::sh::power_of_two_growth_policy<2>,
+         tsl::sh::exception_safety ExceptionSafety =
+                 tsl::sh::exception_safety::basic,
+         tsl::sh::sparsity Sparsity = tsl::sh::sparsity::medium>
+class sparse_set {
+private:
+    template<typename U>
+    using has_is_transparent = tsl::detail_sparse_hash::has_is_transparent<U>;
+
+    class KeySelect {
+    public:
+        using key_type = Key;
+
+        const key_type &operator()(const Key &key) const noexcept { return key; }
+
+        key_type &operator()(Key &key) noexcept { return key; }
+    };
+
+    using ht =
+            detail_sparse_hash::sparse_hash<Key, KeySelect, void, Hash, KeyEqual,
+                                            Allocator, GrowthPolicy, ExceptionSafety,
+                                            Sparsity, tsl::sh::probing::quadratic>;
+
+public:
+    using key_type = typename ht::key_type;
+    using value_type = typename ht::value_type;
+    using size_type = typename ht::size_type;
+    using difference_type = typename ht::difference_type;
+    using hasher = typename ht::hasher;
+    using key_equal = typename ht::key_equal;
+    using allocator_type = typename ht::allocator_type;
+    using reference = typename ht::reference;
+    using const_reference = typename ht::const_reference;
+    using pointer = typename ht::pointer;
+    using const_pointer = typename ht::const_pointer;
+    using iterator = typename ht::iterator;
+    using const_iterator = typename ht::const_iterator;
+
+    /*
+   * Constructors
+   */
+    sparse_set() : sparse_set(ht::DEFAULT_INIT_BUCKET_COUNT) {}
+
+    explicit sparse_set(size_type bucket_count, const Hash &hash = Hash(),
+                        const KeyEqual &equal = KeyEqual(),
+                        const Allocator &alloc = Allocator())
+        : m_ht(bucket_count, hash, equal, alloc, ht::DEFAULT_MAX_LOAD_FACTOR) {}
+
+    sparse_set(size_type bucket_count, const Allocator &alloc)
+        : sparse_set(bucket_count, Hash(), KeyEqual(), alloc) {}
+
+    sparse_set(size_type bucket_count, const Hash &hash, const Allocator &alloc)
+        : sparse_set(bucket_count, hash, KeyEqual(), alloc) {}
+
+    explicit sparse_set(const Allocator &alloc)
+        : sparse_set(ht::DEFAULT_INIT_BUCKET_COUNT, alloc) {}
+
+    template<class InputIt>
+    sparse_set(InputIt first, InputIt last,
+               size_type bucket_count = ht::DEFAULT_INIT_BUCKET_COUNT,
+               const Hash &hash = Hash(), const KeyEqual &equal = KeyEqual(),
+               const Allocator &alloc = Allocator())
+        : sparse_set(bucket_count, hash, equal, alloc) {
+        insert(first, last);
+    }
+
+    template<class InputIt>
+    sparse_set(InputIt first, InputIt last, size_type bucket_count,
+               const Allocator &alloc)
+        : sparse_set(first, last, bucket_count, Hash(), KeyEqual(), alloc) {}
+
+    template<class InputIt>
+    sparse_set(InputIt first, InputIt last, size_type bucket_count,
+               const Hash &hash, const Allocator &alloc)
+        : sparse_set(first, last, bucket_count, hash, KeyEqual(), alloc) {}
+
+    sparse_set(std::initializer_list<value_type> init,
+               size_type bucket_count = ht::DEFAULT_INIT_BUCKET_COUNT,
+               const Hash &hash = Hash(), const KeyEqual &equal = KeyEqual(),
+               const Allocator &alloc = Allocator())
+        : sparse_set(init.begin(), init.end(), bucket_count, hash, equal, alloc) {
+    }
+
+    sparse_set(std::initializer_list<value_type> init, size_type bucket_count,
+               const Allocator &alloc)
+        : sparse_set(init.begin(), init.end(), bucket_count, Hash(), KeyEqual(),
+                     alloc) {}
+
+    sparse_set(std::initializer_list<value_type> init, size_type bucket_count,
+               const Hash &hash, const Allocator &alloc)
+        : sparse_set(init.begin(), init.end(), bucket_count, hash, KeyEqual(),
+                     alloc) {}
+
+    sparse_set &operator=(std::initializer_list<value_type> ilist) {
+        m_ht.clear();
+
+        m_ht.reserve(ilist.size());
+        m_ht.insert(ilist.begin(), ilist.end());
+
+        return *this;
+    }
+
+    allocator_type get_allocator() const { return m_ht.get_allocator(); }
+
+    /*
+   * Iterators
+   */
+    iterator begin() noexcept { return m_ht.begin(); }
+    const_iterator begin() const noexcept { return m_ht.begin(); }
+    const_iterator cbegin() const noexcept { return m_ht.cbegin(); }
+
+    iterator end() noexcept { return m_ht.end(); }
+    const_iterator end() const noexcept { return m_ht.end(); }
+    const_iterator cend() const noexcept { return m_ht.cend(); }
+
+    /*
+   * Capacity
+   */
+    bool empty() const noexcept { return m_ht.empty(); }
+    size_type size() const noexcept { return m_ht.size(); }
+    size_type max_size() const noexcept { return m_ht.max_size(); }
+
+    /*
+   * Modifiers
+   */
+    void clear() noexcept { m_ht.clear(); }
+
+    std::pair<iterator, bool> insert(const value_type &value) {
+        return m_ht.insert(value);
+    }
+
+    std::pair<iterator, bool> insert(value_type &&value) {
+        return m_ht.insert(std::move(value));
+    }
+
+    iterator insert(const_iterator hint, const value_type &value) {
+        return m_ht.insert_hint(hint, value);
+    }
+
+    iterator insert(const_iterator hint, value_type &&value) {
+        return m_ht.insert_hint(hint, std::move(value));
+    }
+
+    template<class InputIt>
+    void insert(InputIt first, InputIt last) {
+        m_ht.insert(first, last);
+    }
+
+    void insert(std::initializer_list<value_type> ilist) {
+        m_ht.insert(ilist.begin(), ilist.end());
+    }
+
+    /**
+   * Due to the way elements are stored, emplace will need to move or copy the
+   * key-value once. The method is equivalent to
+   * `insert(value_type(std::forward<Args>(args)...));`.
+   *
+   * Mainly here for compatibility with the `std::unordered_map` interface.
+   */
+    template<class... Args>
+    std::pair<iterator, bool> emplace(Args &&...args) {
+        return m_ht.emplace(std::forward<Args>(args)...);
+    }
+
+    /**
+   * Due to the way elements are stored, emplace_hint will need to move or copy
+   * the key-value once. The method is equivalent to `insert(hint,
+   * value_type(std::forward<Args>(args)...));`.
+   *
+   * Mainly here for compatibility with the `std::unordered_map` interface.
+   */
+    template<class... Args>
+    iterator emplace_hint(const_iterator hint, Args &&...args) {
+        return m_ht.emplace_hint(hint, std::forward<Args>(args)...);
+    }
+
+    iterator erase(iterator pos) { return m_ht.erase(pos); }
+    iterator erase(const_iterator pos) { return m_ht.erase(pos); }
+    iterator erase(const_iterator first, const_iterator last) {
+        return m_ht.erase(first, last);
+    }
+    size_type erase(const key_type &key) { return m_ht.erase(key); }
+
+    /**
+   * Use the hash value `precalculated_hash` instead of hashing the key. The
+   * hash value should be the same as `hash_function()(key)`, otherwise the
+   * behaviour is undefined. Useful to speed-up the lookup if you already have
+   * the hash.
+   */
+    size_type erase(const key_type &key, std::size_t precalculated_hash) {
+        return m_ht.erase(key, precalculated_hash);
+    }
+
+    /**
+   * This overload only participates in the overload resolution if the typedef
+   * `KeyEqual::is_transparent` exists. If so, `K` must be hashable and
+   * comparable to `Key`.
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    size_type erase(const K &key) {
+        return m_ht.erase(key);
+    }
+
+    /**
+   * @copydoc erase(const K& key)
+   *
+   * Use the hash value `precalculated_hash` instead of hashing the key. The
+   * hash value should be the same as `hash_function()(key)`, otherwise the
+   * behaviour is undefined. Useful to speed-up the lookup if you already have
+   * the hash.
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    size_type erase(const K &key, std::size_t precalculated_hash) {
+        return m_ht.erase(key, precalculated_hash);
+    }
+
+    void swap(sparse_set &other) { other.m_ht.swap(m_ht); }
+
+    /*
+   * Lookup
+   */
+    size_type count(const Key &key) const { return m_ht.count(key); }
+
+    /**
+   * Use the hash value `precalculated_hash` instead of hashing the key. The
+   * hash value should be the same as `hash_function()(key)`, otherwise the
+   * behaviour is undefined. Useful to speed-up the lookup if you already have
+   * the hash.
+   */
+    size_type count(const Key &key, std::size_t precalculated_hash) const {
+        return m_ht.count(key, precalculated_hash);
+    }
+
+    /**
+   * This overload only participates in the overload resolution if the typedef
+   * `KeyEqual::is_transparent` exists. If so, `K` must be hashable and
+   * comparable to `Key`.
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    size_type count(const K &key) const {
+        return m_ht.count(key);
+    }
+
+    /**
+   * @copydoc count(const K& key) const
+   *
+   * Use the hash value `precalculated_hash` instead of hashing the key. The
+   * hash value should be the same as `hash_function()(key)`, otherwise the
+   * behaviour is undefined. Useful to speed-up the lookup if you already have
+   * the hash.
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    size_type count(const K &key, std::size_t precalculated_hash) const {
+        return m_ht.count(key, precalculated_hash);
+    }
+
+    iterator find(const Key &key) { return m_ht.find(key); }
+
+    /**
+   * Use the hash value `precalculated_hash` instead of hashing the key. The
+   * hash value should be the same as `hash_function()(key)`, otherwise the
+   * behaviour is undefined. Useful to speed-up the lookup if you already have
+   * the hash.
+   */
+    iterator find(const Key &key, std::size_t precalculated_hash) {
+        return m_ht.find(key, precalculated_hash);
+    }
+
+    const_iterator find(const Key &key) const { return m_ht.find(key); }
+
+    /**
+   * @copydoc find(const Key& key, std::size_t precalculated_hash)
+   */
+    const_iterator find(const Key &key, std::size_t precalculated_hash) const {
+        return m_ht.find(key, precalculated_hash);
+    }
+
+    /**
+   * This overload only participates in the overload resolution if the typedef
+   * `KeyEqual::is_transparent` exists. If so, `K` must be hashable and
+   * comparable to `Key`.
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    iterator find(const K &key) {
+        return m_ht.find(key);
+    }
+
+    /**
+   * @copydoc find(const K& key)
+   *
+   * Use the hash value `precalculated_hash` instead of hashing the key. The
+   * hash value should be the same as `hash_function()(key)`, otherwise the
+   * behaviour is undefined. Useful to speed-up the lookup if you already have
+   * the hash.
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    iterator find(const K &key, std::size_t precalculated_hash) {
+        return m_ht.find(key, precalculated_hash);
+    }
+
+    /**
+   * @copydoc find(const K& key)
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    const_iterator find(const K &key) const {
+        return m_ht.find(key);
+    }
+
+    /**
+   * @copydoc find(const K& key)
+   *
+   * Use the hash value `precalculated_hash` instead of hashing the key. The
+   * hash value should be the same as `hash_function()(key)`, otherwise the
+   * behaviour is undefined. Useful to speed-up the lookup if you already have
+   * the hash.
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    const_iterator find(const K &key, std::size_t precalculated_hash) const {
+        return m_ht.find(key, precalculated_hash);
+    }
+
+    bool contains(const Key &key) const { return m_ht.contains(key); }
+
+    /**
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+    bool contains(const Key &key, std::size_t precalculated_hash) const {
+        return m_ht.contains(key, precalculated_hash);
+    }
+
+    /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent exists. If so, K must be hashable and comparable
+   * to Key.
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    bool contains(const K &key) const {
+        return m_ht.contains(key);
+    }
+
+    /**
+   * @copydoc contains(const K& key) const
+   *
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    bool contains(const K &key, std::size_t precalculated_hash) const {
+        return m_ht.contains(key, precalculated_hash);
+    }
+
+    std::pair<iterator, iterator> equal_range(const Key &key) {
+        return m_ht.equal_range(key);
+    }
+
+    /**
+   * Use the hash value `precalculated_hash` instead of hashing the key. The
+   * hash value should be the same as `hash_function()(key)`, otherwise the
+   * behaviour is undefined. Useful to speed-up the lookup if you already have
+   * the hash.
+   */
+    std::pair<iterator, iterator> equal_range(const Key &key,
+                                              std::size_t precalculated_hash) {
+        return m_ht.equal_range(key, precalculated_hash);
+    }
+
+    std::pair<const_iterator, const_iterator> equal_range(const Key &key) const {
+        return m_ht.equal_range(key);
+    }
+
+    /**
+   * @copydoc equal_range(const Key& key, std::size_t precalculated_hash)
+   */
+    std::pair<const_iterator, const_iterator> equal_range(
+            const Key &key, std::size_t precalculated_hash) const {
+        return m_ht.equal_range(key, precalculated_hash);
+    }
+
+    /**
+   * This overload only participates in the overload resolution if the typedef
+   * `KeyEqual::is_transparent` exists. If so, `K` must be hashable and
+   * comparable to `Key`.
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    std::pair<iterator, iterator> equal_range(const K &key) {
+        return m_ht.equal_range(key);
+    }
+
+    /**
+   * @copydoc equal_range(const K& key)
+   *
+   * Use the hash value `precalculated_hash` instead of hashing the key. The
+   * hash value should be the same as `hash_function()(key)`, otherwise the
+   * behaviour is undefined. Useful to speed-up the lookup if you already have
+   * the hash.
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    std::pair<iterator, iterator> equal_range(const K &key,
+                                              std::size_t precalculated_hash) {
+        return m_ht.equal_range(key, precalculated_hash);
+    }
+
+    /**
+   * @copydoc equal_range(const K& key)
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    std::pair<const_iterator, const_iterator> equal_range(const K &key) const {
+        return m_ht.equal_range(key);
+    }
+
+    /**
+   * @copydoc equal_range(const K& key, std::size_t precalculated_hash)
+   */
+    template<
+            class K, class KE = KeyEqual,
+            typename std::enable_if<has_is_transparent<KE>::value>::type * = nullptr>
+    std::pair<const_iterator, const_iterator> equal_range(
+            const K &key, std::size_t precalculated_hash) const {
+        return m_ht.equal_range(key, precalculated_hash);
+    }
+
+    /*
+   * Bucket interface
+   */
+    size_type bucket_count() const { return m_ht.bucket_count(); }
+    size_type max_bucket_count() const { return m_ht.max_bucket_count(); }
+
+    /*
+   *  Hash policy
+   */
+    float load_factor() const { return m_ht.load_factor(); }
+    float max_load_factor() const { return m_ht.max_load_factor(); }
+    void max_load_factor(float ml) { m_ht.max_load_factor(ml); }
+
+    void rehash(size_type count) { m_ht.rehash(count); }
+    void reserve(size_type count) { m_ht.reserve(count); }
+
+    /*
+   * Observers
+   */
+    hasher hash_function() const { return m_ht.hash_function(); }
+    key_equal key_eq() const { return m_ht.key_eq(); }
+
+    /*
+   * Other
+   */
+
+    /**
+   * Convert a `const_iterator` to an `iterator`.
+   */
+    iterator mutable_iterator(const_iterator pos) {
+        return m_ht.mutable_iterator(pos);
+    }
+
+    /**
+   * Serialize the set through the `serializer` parameter.
+   *
+   * The `serializer` parameter must be a function object that supports the
+   * following call:
+   *  - `void operator()(const U& value);` where the types `std::uint64_t`,
+   * `float` and `Key` must be supported for U.
+   *
+   * The implementation leaves binary compatibility (endianness, IEEE 754 for
+   * floats, ...) of the types it serializes in the hands of the `Serializer`
+   * function object if compatibility is required.
+   */
+    template<class Serializer>
+    void serialize(Serializer &serializer) const {
+        m_ht.serialize(serializer);
+    }
+
+    /**
+   * Deserialize a previously serialized set through the `deserializer`
+   * parameter.
+   *
+   * The `deserializer` parameter must be a function object that supports the
+   * following calls:
+   *  - `template<typename U> U operator()();` where the types `std::uint64_t`,
+   * `float` and `Key` must be supported for U.
+   *
+   * If the deserialized hash set type is hash compatible with the serialized
+   * set, the deserialization process can be sped up by setting
+   * `hash_compatible` to true. To be hash compatible, the Hash, KeyEqual and
+   * GrowthPolicy must behave the same way than the ones used on the serialized
+   * set. The `std::size_t` must also be of the same size as the one on the
+   * platform used to serialize the set. If these criteria are not met, the
+   * behaviour is undefined with `hash_compatible` sets to true.
+   *
+   * The behaviour is undefined if the type `Key` of the `sparse_set` is not the
+   * same as the type used during serialization.
+   *
+   * The implementation leaves binary compatibility (endianness, IEEE 754 for
+   * floats, size of int, ...) of the types it deserializes in the hands of the
+   * `Deserializer` function object if compatibility is required.
+   */
+    template<class Deserializer>
+    static sparse_set deserialize(Deserializer &deserializer,
+                                  bool hash_compatible = false) {
+        sparse_set set(0);
+        set.m_ht.deserialize(deserializer, hash_compatible);
+
+        return set;
+    }
+
+    friend bool operator==(const sparse_set &lhs, const sparse_set &rhs) {
+        if (lhs.size() != rhs.size()) {
+            return false;
+        }
+
+        for (const auto &element_lhs : lhs) {
+            const auto it_element_rhs = rhs.find(element_lhs);
+            if (it_element_rhs == rhs.cend()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    friend bool operator!=(const sparse_set &lhs, const sparse_set &rhs) {
+        return !operator==(lhs, rhs);
+    }
+
+    friend void swap(sparse_set &lhs, sparse_set &rhs) { lhs.swap(rhs); }
+
+private:
+    ht m_ht;
+};
+
+/**
+ * Same as `tsl::sparse_set<Key, Hash, KeyEqual, Allocator,
+ * tsl::sh::prime_growth_policy>`.
+ */
+template<class Key, class Hash = std::hash<Key>,
+         class KeyEqual = std::equal_to<Key>,
+         class Allocator = std::allocator<Key>>
+using sparse_pg_set =
+        sparse_set<Key, Hash, KeyEqual, Allocator, tsl::sh::prime_growth_policy>;
+
+}  // end namespace rdf4cpp::rdf::storage::util::tsl
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,15 @@ set_property(TARGET tests_Literal PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_Literal COMMAND tests_Literal)
 
 
+add_executable(tests_Node_comparison nodes/tests_Node_comparison.cpp)
+target_link_libraries(tests_Node_comparison
+        doctest
+        rdf4cpp
+        )
+set_property(TARGET tests_Node_comparison PROPERTY CXX_STANDARD 20)
+add_test(NAME tests_Node_comparison COMMAND tests_Node_comparison)
+
+
 # include(${doctest_SOURCE_DIR}/scripts/cmake/doctest.cmake)
 # doctest_discover_tests(tests_hello_test)
 

--- a/tests/nodes/tests_Node_comparison.cpp
+++ b/tests/nodes/tests_Node_comparison.cpp
@@ -1,0 +1,19 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+
+#include <doctest/doctest.h>
+#include <rdf4cpp/rdf.hpp>
+
+using namespace rdf4cpp::rdf;
+
+TEST_CASE("Ordering") {
+    IRI iri1 = IRI{"http://www.example.org/test2"};
+    IRI iri2 = IRI{"http://www.example.org/test1"};
+    IRI iri3 = IRI{"http://www.example.org/oest"};
+    Literal lit1 = Literal{"testlit1"};
+    Literal lit2 = Literal{"testlit2"};
+    CHECK(iri2 < iri1);
+    CHECK(iri3 < iri1);
+    CHECK(iri3 < iri2);
+    CHECK(iri1 < lit1);
+    CHECK(lit1 < lit2);
+}


### PR DESCRIPTION
ReferenceNodeStorageBackend is currently quite slow. 

This PR uses a `tsl::sparse_map` instead of `std::map`. For hashing `Node` backend types, robin-hood-hashing is used. Where possible, the code was simplified. 

This improves the time for parsing 10M triples from 58s to 16s. 

It also fixes a bug when serializing string literals containing the character `'\'`.