### PR TITLE
Feature: literal comparisons

### DIFF
--- a/src/rdf4cpp/rdf/Literal.cpp
+++ b/src/rdf4cpp/rdf/Literal.cpp
@@ -376,7 +376,7 @@ std::weak_ordering Literal::compare_with_extensions(Literal const &other) const 
 }
 
 util::TriBool Literal::eq(Literal const &other) const {
-    return util::partial_ordering_eq(this->compare(other), std::weak_ordering::equivalent);
+    return util::partial_weak_ordering_eq(this->compare(other), std::weak_ordering::equivalent);
 }
 
 util::TriBool Literal::operator==(Literal const &other) const {
@@ -384,7 +384,7 @@ util::TriBool Literal::operator==(Literal const &other) const {
 }
 
 util::TriBool Literal::ne(Literal const &other) const {
-    return !util::partial_ordering_eq(this->compare(other), std::weak_ordering::equivalent);
+    return !util::partial_weak_ordering_eq(this->compare(other), std::weak_ordering::equivalent);
 }
 
 util::TriBool Literal::operator!=(Literal const &other) const {
@@ -392,7 +392,7 @@ util::TriBool Literal::operator!=(Literal const &other) const {
 }
 
 util::TriBool Literal::lt(Literal const &other) const {
-    return util::partial_ordering_eq(this->compare(other), std::weak_ordering::less);
+    return util::partial_weak_ordering_eq(this->compare(other), std::weak_ordering::less);
 }
 
 util::TriBool Literal::operator<(Literal const &other) const {
@@ -400,7 +400,7 @@ util::TriBool Literal::operator<(Literal const &other) const {
 }
 
 util::TriBool Literal::le(Literal const &other) const {
-    return !util::partial_ordering_eq(this->compare(other), std::weak_ordering::greater);
+    return !util::partial_weak_ordering_eq(this->compare(other), std::weak_ordering::greater);
 }
 
 util::TriBool Literal::operator<=(Literal const &other) const {
@@ -408,7 +408,7 @@ util::TriBool Literal::operator<=(Literal const &other) const {
 }
 
 util::TriBool Literal::gt(Literal const &other) const {
-    return util::partial_ordering_eq(this->compare(other), std::weak_ordering::greater);
+    return util::partial_weak_ordering_eq(this->compare(other), std::weak_ordering::greater);
 }
 
 util::TriBool Literal::operator>(Literal const &other) const {
@@ -416,7 +416,7 @@ util::TriBool Literal::operator>(Literal const &other) const {
 }
 
 util::TriBool Literal::ge(Literal const &other) const {
-    return !util::partial_ordering_eq(this->compare(other), std::weak_ordering::less);
+    return !util::partial_weak_ordering_eq(this->compare(other), std::weak_ordering::less);
 }
 
 util::TriBool Literal::operator>=(Literal const &other) const {

--- a/src/rdf4cpp/rdf/Literal.hpp
+++ b/src/rdf4cpp/rdf/Literal.hpp
@@ -178,9 +178,12 @@ public:
      * The comparison function with SPARQL operator extensions.
      *
      * @return similar to `compare` but:
-     *      - if the values ore equal return the type ordering instead
-     *      - if the values are not comparable return equivalent (this makes this only a weak_ordering and not strong)
-     *      - if exactly one of the literals is null order the null literal before the other
+     *      - values of an incomparable type are all considered equivalent
+     *      - a null literal is the smallest possible value of all types
+     *      - the type ordering replaces the value ordering in the following cases
+     *          - the values are equal
+     *          - at least one of the value's types is not comparable
+     *          - there is no viable conversion to a common type to check for equality
      */
     [[nodiscard]] std::weak_ordering compare_with_extensions(Literal const &other) const;
 

--- a/src/rdf4cpp/rdf/Literal.hpp
+++ b/src/rdf4cpp/rdf/Literal.hpp
@@ -58,6 +58,16 @@ private:
      */
     Literal logical_binop_impl(std::array<std::array<TriStateBool, 3>, 3> const &logic_table, Literal const &other, NodeStorage &node_storage = NodeStorage::default_instance()) const;
 
+    /**
+     * @brief the implementation of the value comparison function
+     *
+     * @param other the literal to compare to
+     * @param out_type_ordering optional out parameter to receive the type ordering
+     *      (this saves 2 calls to the backend in the comparison function with extensions)
+     * @return the partial ordering of the values of this and other
+     */
+    std::partial_ordering compare_impl(Literal const &other, std::partial_ordering *out_type_ordering) const;
+
 protected:
     explicit Literal(Node::NodeBackendHandle handle);
 
@@ -145,9 +155,32 @@ public:
     [[nodiscard]] bool is_iri() const;
     [[nodiscard]] bool is_numeric() const;
 
-    bool operator==(const Literal &other) const;
+    /**
+     * The default (value-only) comparison function
+     * without sparql operator extensions.
+     *
+     * @return the value ordering of this and other
+     */
+    [[nodiscard]] std::partial_ordering compare(Literal const &other) const;
 
-    std::partial_ordering operator<=>(const Literal &other) const;
+    /**
+     * A convenient (and equivalent) alternative to compare.
+     */
+    std::partial_ordering operator<=>(Literal const &other) const;
+
+    /**
+     * @return returns true if: *this <=> other == equivalent
+     * @note this only exists to hide operator== of base class Node
+     */
+    bool operator==(Literal const &other) const;
+
+    /**
+     * The comparison function with sparql operator extensions.
+     *
+     * @return similar to `compare` but if the values of this and other are equal it instead
+     *      returns the type ordering for the data types of this and other.
+     */
+    [[nodiscard]] std::partial_ordering compare_with_extensions(Literal const &other) const;
 
     Literal add(Literal const &other, NodeStorage &node_storage = NodeStorage::default_instance()) const;
     Literal operator+(Literal const &other) const;

--- a/src/rdf4cpp/rdf/Literal.hpp
+++ b/src/rdf4cpp/rdf/Literal.hpp
@@ -66,7 +66,7 @@ private:
      *      (this saves 2 calls to the backend in the comparison function with extensions)
      * @return the partial ordering of the values of this and other
      */
-    std::partial_ordering compare_impl(Literal const &other, std::partial_ordering *out_type_ordering) const;
+    std::partial_ordering compare_impl(Literal const &other, std::strong_ordering *out_type_ordering = nullptr) const;
 
 protected:
     explicit Literal(Node::NodeBackendHandle handle);
@@ -157,7 +157,7 @@ public:
 
     /**
      * The default (value-only) comparison function
-     * without sparql operator extensions.
+     * without SPARQL operator extensions.
      *
      * @return the value ordering of this and other
      */
@@ -175,12 +175,14 @@ public:
     bool operator==(Literal const &other) const;
 
     /**
-     * The comparison function with sparql operator extensions.
+     * The comparison function with SPARQL operator extensions.
      *
-     * @return similar to `compare` but if the values of this and other are equal it instead
-     *      returns the type ordering for the data types of this and other.
+     * @return similar to `compare` but:
+     *      - if the values ore equal return the type ordering instead
+     *      - if the values are not comparable return equivalent (this makes this only a weak_ordering and not strong)
+     *      - if exactly one of the literals is null order the null literal before the other
      */
-    [[nodiscard]] std::partial_ordering compare_with_extensions(Literal const &other) const;
+    [[nodiscard]] std::weak_ordering compare_with_extensions(Literal const &other) const;
 
     Literal add(Literal const &other, NodeStorage &node_storage = NodeStorage::default_instance()) const;
     Literal operator+(Literal const &other) const;

--- a/src/rdf4cpp/rdf/Literal.hpp
+++ b/src/rdf4cpp/rdf/Literal.hpp
@@ -44,9 +44,15 @@ private:
      * @brief the implementation of the value comparison function
      *
      * @param other the literal to compare to
-     * @param out_alternative_ordering optional out parameter to receive the type ordering
-     *      (this saves 2 calls to the backend in the comparison function with extensions)
-     * @return the partial ordering of the values of this and other
+     * @param out_alternative_ordering optional out parameter to receive an alternative ordering (for ordering extensions).
+     *      Note: If present it is expected to be defaulted to std::strong_ordering::equivalent.
+     *      It is populated based on the following rules:
+     *          - (null, non-null) => less
+     *          - (non-null, null) => greater
+     *          - (non-null, non-null) and equal type => lexical form ordering
+     *          - (non-null, non-null) and different type => type ordering
+     *
+     * @return the ordering of the values of this and other; if there is a value ordering
      */
     std::partial_ordering compare_impl(Literal const &other, std::strong_ordering *out_alternative_ordering = nullptr) const;
 protected:

--- a/src/rdf4cpp/rdf/Literal.hpp
+++ b/src/rdf4cpp/rdf/Literal.hpp
@@ -44,11 +44,11 @@ private:
      * @brief the implementation of the value comparison function
      *
      * @param other the literal to compare to
-     * @param out_type_ordering optional out parameter to receive the type ordering
+     * @param out_alternative_ordering optional out parameter to receive the type ordering
      *      (this saves 2 calls to the backend in the comparison function with extensions)
      * @return the partial ordering of the values of this and other
      */
-    std::partial_ordering compare_impl(Literal const &other, std::strong_ordering *out_type_ordering = nullptr) const;
+    std::partial_ordering compare_impl(Literal const &other, std::strong_ordering *out_alternative_ordering = nullptr) const;
 protected:
     explicit Literal(Node::NodeBackendHandle handle);
 

--- a/src/rdf4cpp/rdf/Node.cpp
+++ b/src/rdf4cpp/rdf/Node.cpp
@@ -45,7 +45,6 @@ Node Node::to_node_storage(Node::NodeStorage &node_storage) const {
 
 Node::operator std::string() const {
     switch (handle_.type()) {
-
         case RDFNodeType::IRI:
             return handle_.iri_backend().n_string();
         case RDFNodeType::BNode:
@@ -73,19 +72,19 @@ bool Node::is_iri() const noexcept {
     return handle_.is_iri();
 }
 
-std::strong_ordering Node::operator<=>(const Node &other) const noexcept {
+std::weak_ordering Node::operator<=>(const Node &other) const noexcept {
     if (this->handle_ == other.handle_){
         return std::strong_ordering::equivalent;
     }
 
+    if (this->null() && other.null()) {
+        return this->handle_.type() <=> other.handle_.type();
+    }
+
     // unbound
-    if (this->null()){
-        if (other.null()){
-            return std::strong_ordering::equivalent;
-        } else {
-            return std::strong_ordering::less;
-        }
-    } else if(other.null()){
+    if (this->null()) {
+        return std::strong_ordering::less;
+    } else if (other.null()) {
         return std::strong_ordering::greater;
     }
 
@@ -99,7 +98,7 @@ std::strong_ordering Node::operator<=>(const Node &other) const noexcept {
             case RDFNodeType::BNode:
                 return this->handle_.bnode_backend() <=> other.handle_.bnode_backend();
             case RDFNodeType::Literal:
-                return this->handle_.literal_backend() <=> other.handle_.literal_backend();
+                return Literal{this->handle_}.compare_with_extensions(Literal{other.handle_});
             case RDFNodeType::Variable:
                 return this->handle_.variable_backend() <=> other.handle_.variable_backend();
             default:{
@@ -111,38 +110,7 @@ std::strong_ordering Node::operator<=>(const Node &other) const noexcept {
 }
 
 bool Node::operator==(const Node &other) const noexcept {
-    if (this->handle_ == other.handle_){
-        return true;
-    }
-
-    if (this->null()){
-        if (other.null()){
-            return true;
-        } else {
-            return false;
-        }
-    } else if(other.null()){
-        return true;
-    }
-
-    if (this->handle_.type() != other.handle_.type()){
-        return false;
-    } else {
-        switch (this->handle_.type()) {
-            case RDFNodeType::IRI:
-                return this->handle_.iri_backend() == other.handle_.iri_backend();
-            case RDFNodeType::BNode:
-                return this->handle_.bnode_backend() == other.handle_.bnode_backend();
-            case RDFNodeType::Literal:
-                return this->handle_.literal_backend() == other.handle_.literal_backend();
-            case RDFNodeType::Variable:
-                return this->handle_.variable_backend() == other.handle_.variable_backend();
-            default:{
-                assert(false); // this will never be reached because RDFNodeType has only 4 values.
-                return false;
-            }
-        }
-    }
+    return *this <=> other == std::strong_ordering::equivalent;
 }
 
 Node::operator BlankNode() const {

--- a/src/rdf4cpp/rdf/Node.hpp
+++ b/src/rdf4cpp/rdf/Node.hpp
@@ -83,7 +83,7 @@ public:
 
     bool operator==(const Node &other) const noexcept;
 
-    std::strong_ordering operator<=>(const Node &other) const noexcept;
+    std::weak_ordering operator<=>(const Node &other) const noexcept;
 
     /**
      * Conversion to BlankNode is only safe if `(is_blank_node() == true)`

--- a/src/rdf4cpp/rdf/datatypes/LiteralDatatype.hpp
+++ b/src/rdf4cpp/rdf/datatypes/LiteralDatatype.hpp
@@ -45,6 +45,11 @@ concept LogicalLiteralDatatype = LiteralDatatype<LiteralDatatypeImpl> && require
                                                                          };
 
 template<typename LiteralDatatypeImpl>
+concept ComparableLiteralDatatype = LiteralDatatype<LiteralDatatypeImpl> && requires (typename LiteralDatatypeImpl::cpp_type const &lhs, typename LiteralDatatypeImpl::cpp_type const &rhs) {
+                                                                                { LiteralDatatypeImpl::compare(lhs, rhs) } -> std::convertible_to<std::partial_ordering>;
+                                                                            };
+
+template<typename LiteralDatatypeImpl>
 concept PromotableLiteralDatatype = LiteralDatatype<LiteralDatatypeImpl> && requires(typename LiteralDatatypeImpl::cpp_type const &value) {
                                                                                 requires LiteralDatatype<typename LiteralDatatypeImpl::promoted>;
                                                                                 typename LiteralDatatypeImpl::promoted_cpp_type;

--- a/src/rdf4cpp/rdf/datatypes/registry/DatatypeConversion.hpp
+++ b/src/rdf4cpp/rdf/datatypes/registry/DatatypeConversion.hpp
@@ -71,6 +71,12 @@ consteval ConversionLayer auto make_conversion_layer_impl(LayerAcc const &table_
         static_assert((NumericLiteralDatatype<Type> && NumericLiteralDatatype<typename next::converted>) || (!NumericLiteralDatatype<Type> && !NumericLiteralDatatype<typename next::converted>),
                       "conversion must preserve numericity");
 
+        // conversion must preserve comparability, so:
+        // ComparableLiteralDatatype<Type> <-> ComparableLiteralDatatype<typename next::converted>
+        // The reasoning is the same as in the static_assert for numericity.
+        static_assert((ComparableLiteralDatatype<Type> && ComparableLiteralDatatype<typename next::converted>) || (!ComparableLiteralDatatype<Type> && !ComparableLiteralDatatype<typename next::converted>),
+                      "conversion must preserve comparability");
+
         if constexpr (BaseType::identifier == Type::identifier) {
             struct FirstConversion {
                 using source_type = Type;

--- a/src/rdf4cpp/rdf/datatypes/registry/LiteralDatatypeImpl.hpp
+++ b/src/rdf4cpp/rdf/datatypes/registry/LiteralDatatypeImpl.hpp
@@ -169,7 +169,19 @@ struct Logical {
     }
 };
 
-}  // namespace capabilities
+/**
+ * The capability to be compared, e.g. with operator<=>
+ */
+template<ConstexprString type_iri>
+struct Comparable {
+    using cpp_type = typename DatatypeMapping<type_iri>::cpp_datatype;
+
+    inline static std::partial_ordering compare(cpp_type const &lhs, cpp_type const &rhs) {
+        return lhs <=> rhs;
+    }
+};
+
+} // namespace capabilities
 
 /**
  * An automatically registering LiteralDatatype with given capabilities.

--- a/src/rdf4cpp/rdf/datatypes/xsd/Boolean.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Boolean.hpp
@@ -63,7 +63,8 @@ namespace rdf4cpp::rdf::datatypes::xsd {
  * Implementation of xsd::boolean
  */
 using Boolean = registry::LiteralDatatypeImpl<registry::xsd_boolean,
-                                              registry::capabilities::Logical>;
+                                              registry::capabilities::Logical,
+                                              registry::capabilities::Comparable>;
 }  // namespace rdf4cpp::rdf::datatypes::xsd
 
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/Decimal.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Decimal.hpp
@@ -105,6 +105,7 @@ namespace rdf4cpp::rdf::datatypes::xsd {
 using Decimal = registry::LiteralDatatypeImpl<registry::xsd_decimal,
                                               registry::capabilities::Logical,
                                               registry::capabilities::Numeric,
+                                              registry::capabilities::Comparable,
                                               registry::capabilities::Promotable>;
 }  // namespace rdf4cpp::rdf::datatypes::xsd
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/Float.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Float.hpp
@@ -77,7 +77,8 @@ namespace rdf4cpp::rdf::datatypes::xsd {
  */
 using Float = registry::LiteralDatatypeImpl<registry::xsd_float,
                                             registry::capabilities::Logical,
-                                            registry::capabilities::Numeric>;
+                                            registry::capabilities::Numeric,
+                                            registry::capabilities::Comparable>;
 }  // namespace rdf4cpp::rdf::datatypes::xsd
 
 #endif  //RDF4CPP_XSD_FLOAT_HPP

--- a/src/rdf4cpp/rdf/datatypes/xsd/Int.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Int.hpp
@@ -79,6 +79,7 @@ namespace rdf4cpp::rdf::datatypes::xsd {
 using Int = registry::LiteralDatatypeImpl<registry::xsd_int,
                                           registry::capabilities::Logical,
                                           registry::capabilities::Numeric,
+                                          registry::capabilities::Comparable,
                                           registry::capabilities::Subtype>;
 }  // namespace rdf4cpp::rdf::datatypes::xsd
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/Integer.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Integer.hpp
@@ -80,6 +80,7 @@ namespace rdf4cpp::rdf::datatypes::xsd {
 using Integer = registry::LiteralDatatypeImpl<registry::xsd_integer,
                                               registry::capabilities::Logical,
                                               registry::capabilities::Numeric,
+                                              registry::capabilities::Comparable,
                                               registry::capabilities::Subtype>;
 }  // namespace rdf4cpp::rdf::datatypes::xsd
 #endif  //RDF4CPP_XSD_INTEGER_HPP

--- a/src/rdf4cpp/rdf/datatypes/xsd/String.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/String.hpp
@@ -41,7 +41,8 @@ namespace rdf4cpp::rdf::datatypes::xsd {
  * Implementation of xsd::string
  */
 using String = registry::LiteralDatatypeImpl<registry::xsd_string,
-                                             registry::capabilities::Logical>;
+                                             registry::capabilities::Logical,
+                                             registry::capabilities::Comparable>;
 }  // namespace rdf4cpp::rdf::datatypes::xsd
 
 #endif  //RDF4CPP_XSD_STRING_HPP

--- a/src/rdf4cpp/rdf/util/TriBool.hpp
+++ b/src/rdf4cpp/rdf/util/TriBool.hpp
@@ -5,9 +5,13 @@
 
 namespace rdf4cpp::rdf::util {
 
+/**
+ * @brief Represents a boolean with three states
+ * the states are: Err (= the error/undefined state), False, True
+ */
 struct TriBool {
 private:
-    enum struct Value {
+    enum struct Value : int8_t {
         Err = -1,
         False = 0,
         True = 1
@@ -25,11 +29,18 @@ public:
     static TriBool const False;
     static TriBool const Err;
 
+    /**
+     * @brief implicit conversion from bool; maps true -> TriBool::True and false -> TriBool::False
+     */
     constexpr TriBool(bool const b) : value{ static_cast<std::underlying_type_t<Value>>(b) } {}
 
     constexpr bool operator==(TriBool const &) const noexcept = default;
     constexpr bool operator!=(TriBool const &) const noexcept = default;
 
+    /**
+     * @brief implicit conversion to bool
+     * @return true if *this == TriBool::True; otherwise false
+     */
     constexpr operator bool() const noexcept {
         return this->value == Value::True;
     }
@@ -77,19 +88,23 @@ public:
     friend constexpr TriBool operator||(bool const l, TriBool const r) noexcept {
         return TriBool{l} || r;
     }
-
-    static constexpr TriBool partial_ordering_eq(std::partial_ordering const l, std::weak_ordering const r) {
-        if (l == std::partial_ordering::unordered) {
-            return TriBool::Err;
-        }
-
-        return l == r;
-    }
 };
 
 inline constexpr TriBool TriBool::True{TriBool::Value::True};
 inline constexpr TriBool TriBool::False{TriBool::Value::False};
 inline constexpr TriBool TriBool::Err{TriBool::Value::Err};
+
+/**
+ * @brief Checks whether the value of the partial_ordering (l) is equal to the value of the weak ordering (r)
+ * @return TriBool::Err if l is unordered; otherwise return l == r
+ */
+constexpr TriBool partial_ordering_eq(std::partial_ordering const l, std::weak_ordering const r) {
+    if (l == std::partial_ordering::unordered) {
+        return TriBool::Err;
+    }
+
+    return l == r;
+}
 
 } // namespace rdf4cpp::rdf::util
 

--- a/src/rdf4cpp/rdf/util/TriBool.hpp
+++ b/src/rdf4cpp/rdf/util/TriBool.hpp
@@ -1,0 +1,96 @@
+#ifndef RDF4CPP_UTIL_TRIBOOL_HPP
+#define RDF4CPP_UTIL_TRIBOOL_HPP
+
+#include <array>
+
+namespace rdf4cpp::rdf::util {
+
+struct TriBool {
+private:
+    enum struct Value {
+        Err = -1,
+        False = 0,
+        True = 1
+    };
+
+    Value value;
+
+    [[nodiscard]] constexpr size_t into_logic_table_index() const noexcept {
+        return static_cast<std::underlying_type_t<Value>>(this->value) + 1;
+    }
+
+    constexpr TriBool(Value const value) : value{value} {}
+public:
+    static TriBool const True;
+    static TriBool const False;
+    static TriBool const Err;
+
+    constexpr TriBool(bool const b) : value{ static_cast<std::underlying_type_t<Value>>(b) } {}
+
+    constexpr bool operator==(TriBool const &) const noexcept = default;
+    constexpr bool operator!=(TriBool const &) const noexcept = default;
+
+    constexpr operator bool() const noexcept {
+        return this->value == Value::True;
+    }
+
+    friend constexpr TriBool operator!(TriBool const b) noexcept {
+        constexpr std::array<Value, 3> not_logic_table{
+             /* Err         False        True */
+                Value::Err, Value::True, Value::False};
+
+        return not_logic_table[b.into_logic_table_index()];
+    }
+
+    friend constexpr TriBool operator&&(TriBool const l, TriBool const r) noexcept {
+        constexpr std::array<std::array<Value, 3>, 3> and_logic_table{
+                /* lhs \ rhs               Err           False         True */
+                /* Err       */ std::array{Value::Err,   Value::False, Value::Err},
+                /* False     */ std::array{Value::False, Value::False, Value::False},
+                /* True      */ std::array{Value::Err,   Value::False, Value::True}};
+
+        return and_logic_table[l.into_logic_table_index()][r.into_logic_table_index()];
+    }
+
+    friend constexpr TriBool operator&&(TriBool const l, bool const r) noexcept {
+        return l && TriBool{r};
+    }
+
+    friend constexpr TriBool operator&&(bool const l, TriBool const r) noexcept {
+        return TriBool{l} && r;
+    }
+
+    friend constexpr TriBool operator||(TriBool const l, TriBool const r) noexcept {
+        constexpr std::array<std::array<Value, 3>, 3> or_logic_table{
+                /* lhs \ rhs               Err          False         True */
+                /* Err       */ std::array{Value::Err,  Value::Err,   Value::True},
+                /* False     */ std::array{Value::Err,  Value::False, Value::True},
+                /* True      */ std::array{Value::True, Value::True,  Value::True}};
+
+        return or_logic_table[l.into_logic_table_index()][r.into_logic_table_index()];
+    }
+
+    friend constexpr TriBool operator||(TriBool const l, bool const r) noexcept {
+        return l || TriBool{r};
+    }
+
+    friend constexpr TriBool operator||(bool const l, TriBool const r) noexcept {
+        return TriBool{l} || r;
+    }
+
+    static constexpr TriBool partial_ordering_eq(std::partial_ordering const l, std::weak_ordering const r) {
+        if (l == std::partial_ordering::unordered) {
+            return TriBool::Err;
+        }
+
+        return l == r;
+    }
+};
+
+inline constexpr TriBool TriBool::True{TriBool::Value::True};
+inline constexpr TriBool TriBool::False{TriBool::Value::False};
+inline constexpr TriBool TriBool::Err{TriBool::Value::Err};
+
+} // namespace rdf4cpp::rdf::util
+
+#endif // RDF4CPP_UTIL_TRIBOOL_HPP

--- a/src/rdf4cpp/rdf/util/TriBool.hpp
+++ b/src/rdf4cpp/rdf/util/TriBool.hpp
@@ -23,7 +23,7 @@ private:
         return static_cast<std::underlying_type_t<Value>>(this->value) + 1;
     }
 
-    constexpr TriBool(Value const value) : value{value} {}
+    constexpr TriBool(Value const value) noexcept : value{value} {}
 public:
     static TriBool const True;
     static TriBool const False;
@@ -32,7 +32,7 @@ public:
     /**
      * @brief implicit conversion from bool; maps true -> TriBool::True and false -> TriBool::False
      */
-    constexpr TriBool(bool const b) : value{ static_cast<std::underlying_type_t<Value>>(b) } {}
+    constexpr TriBool(bool const b) noexcept : value{static_cast<std::underlying_type_t<Value>>(b)} {}
 
     constexpr bool operator==(TriBool const &) const noexcept = default;
     constexpr bool operator!=(TriBool const &) const noexcept = default;
@@ -98,7 +98,7 @@ inline constexpr TriBool TriBool::Err{TriBool::Value::Err};
  * @brief Checks whether the value of the partial_ordering (l) is equal to the value of the weak ordering (r)
  * @return TriBool::Err if l is unordered; otherwise return l == r
  */
-constexpr TriBool partial_ordering_eq(std::partial_ordering const l, std::weak_ordering const r) {
+constexpr TriBool partial_weak_ordering_eq(std::partial_ordering const l, std::weak_ordering const r) noexcept {
     if (l == std::partial_ordering::unordered) {
         return TriBool::Err;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -103,6 +103,13 @@ target_link_libraries(tests_Integer
 set_property(TARGET tests_Integer PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_Integer COMMAND tests_Integer)
 
+add_executable(tests_TriBool util/tests_TriBool.cpp)
+target_link_libraries(tests_TriBool
+        doctest
+        rdf4cpp
+        )
+set_property(TARGET tests_TriBool PROPERTY CXX_STANDARD 20)
+add_test(NAME tests_TriBool COMMAND tests_TriBool)
 
 # copy files for testing to the binary folder
 # file(COPY foldername DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/datatype/tests_Boolean.cpp
+++ b/tests/datatype/tests_Boolean.cpp
@@ -11,6 +11,7 @@ TEST_CASE("boolean capabilities") {
     static_assert(!datatypes::NumericLiteralDatatype<datatypes::xsd::Boolean>);
     static_assert(!datatypes::PromotableLiteralDatatype<datatypes::xsd::Boolean>);
     static_assert(!datatypes::SubtypedLiteralDatatype<datatypes::xsd::Boolean>);
+    static_assert(datatypes::ComparableLiteralDatatype<datatypes::xsd::Boolean>);
 }
 
 TEST_CASE("Datatype Boolean") {

--- a/tests/datatype/tests_Decimal.cpp
+++ b/tests/datatype/tests_Decimal.cpp
@@ -12,6 +12,7 @@ TEST_CASE("decimal capabilities") {
     static_assert(datatypes::PromotableLiteralDatatype<datatypes::xsd::Decimal>);
     static_assert(datatypes::xsd::Decimal::promotion_rank == 1);
     static_assert(!datatypes::SubtypedLiteralDatatype<datatypes::xsd::Decimal>);
+    static_assert(datatypes::ComparableLiteralDatatype<datatypes::xsd::Decimal>);
 }
 
 TEST_CASE("Datatype Decimal") {

--- a/tests/datatype/tests_Float.cpp
+++ b/tests/datatype/tests_Float.cpp
@@ -11,4 +11,5 @@ TEST_CASE("float capabilities") {
     static_assert(datatypes::LogicalLiteralDatatype<datatypes::xsd::Float>);
     static_assert(!datatypes::PromotableLiteralDatatype<datatypes::xsd::Float>); // float is end of promotion hierarchy for now, so not promotable
     static_assert(!datatypes::SubtypedLiteralDatatype<datatypes::xsd::Float>);
+    static_assert(datatypes::ComparableLiteralDatatype<datatypes::xsd::Float>);
 }

--- a/tests/datatype/tests_Integer.cpp
+++ b/tests/datatype/tests_Integer.cpp
@@ -12,6 +12,7 @@ TEST_CASE("integer capabilities") {
     static_assert(!datatypes::PromotableLiteralDatatype<datatypes::xsd::Integer>);
     static_assert(datatypes::SubtypedLiteralDatatype<datatypes::xsd::Integer>);
     static_assert(datatypes::xsd::Integer::subtype_rank == 1);
+    static_assert(datatypes::ComparableLiteralDatatype<datatypes::xsd::Integer>);
 }
 
 TEST_CASE("Datatype Integer") {

--- a/tests/datatype/tests_String.cpp
+++ b/tests/datatype/tests_String.cpp
@@ -11,6 +11,7 @@ TEST_CASE("string capabilities") {
     static_assert(!datatypes::NumericLiteralDatatype<datatypes::xsd::String>);
     static_assert(!datatypes::PromotableLiteralDatatype<datatypes::xsd::String>);
     static_assert(!datatypes::SubtypedLiteralDatatype<datatypes::xsd::String>);
+    static_assert(datatypes::ComparableLiteralDatatype<datatypes::xsd::String>);
 }
 
 TEST_CASE("Datatype String") {

--- a/tests/nodes/tests_Literal_ops.cpp
+++ b/tests/nodes/tests_Literal_ops.cpp
@@ -244,13 +244,13 @@ namespace rdf4cpp::rdf::datatypes::xsd {
  *          |  : B is a subtype of A
  *          B
  */
-using A = registry::LiteralDatatypeImpl<registry::A, registry::capabilities::Numeric, registry::capabilities::Promotable>;
-using B = registry::LiteralDatatypeImpl<registry::B, registry::capabilities::Numeric, registry::capabilities::Subtype>;
-using B2 = registry::LiteralDatatypeImpl<registry::B2, registry::capabilities::Numeric, registry::capabilities::Subtype, registry::capabilities::Promotable>;
-using C = registry::LiteralDatatypeImpl<registry::C, registry::capabilities::Numeric, registry::capabilities::Subtype>;
+using A = registry::LiteralDatatypeImpl<registry::A, registry::capabilities::Numeric, registry::capabilities::Comparable, registry::capabilities::Promotable>;
+using B = registry::LiteralDatatypeImpl<registry::B, registry::capabilities::Numeric, registry::capabilities::Comparable, registry::capabilities::Subtype>;
+using B2 = registry::LiteralDatatypeImpl<registry::B2, registry::capabilities::Numeric, registry::capabilities::Comparable, registry::capabilities::Subtype, registry::capabilities::Promotable>;
+using C = registry::LiteralDatatypeImpl<registry::C, registry::capabilities::Numeric, registry::capabilities::Comparable, registry::capabilities::Subtype>;
 
-using Z = registry::LiteralDatatypeImpl<registry::Z, registry::capabilities::Numeric>;
-using Y = registry::LiteralDatatypeImpl<registry::Y, registry::capabilities::Numeric, registry::capabilities::Subtype>;
+using Z = registry::LiteralDatatypeImpl<registry::Z, registry::capabilities::Numeric, registry::capabilities::Comparable>;
+using Y = registry::LiteralDatatypeImpl<registry::Y, registry::capabilities::Numeric, registry::capabilities::Comparable, registry::capabilities::Subtype>;
 
 }  // namespace rdf4cpp::rdf::datatypes::xsd
 

--- a/tests/nodes/tests_Node_comparison.cpp
+++ b/tests/nodes/tests_Node_comparison.cpp
@@ -5,6 +5,38 @@
 
 using namespace rdf4cpp::rdf;
 
+namespace rdf4cpp::rdf::datatypes::registry {
+
+constexpr static registry::ConstexprString Incomparable{"Incomparable"};
+
+// Z
+template<>
+struct DatatypeMapping<Incomparable> {
+    using cpp_datatype = double;
+};
+
+template<>
+inline capabilities::Default<Incomparable>::cpp_type capabilities::Default<Incomparable>::from_string(std::string_view s) {
+    double value;
+    auto const parse_res = std::from_chars(s.data(), s.data() + s.size(), value);
+
+    if (parse_res.ptr != s.data() + s.size()) {
+        throw std::runtime_error("XSD Parsing Error");
+    } else {
+        return value;
+    }
+}
+
+} // rdf4cpp::rdf::datatypes::registry
+
+namespace rdf4cpp::rdf::datatypes::xsd {
+
+using Incomparable = registry::LiteralDatatypeImpl<registry::Incomparable>;
+
+} // rdf4cpp::rdf::datatypes::xsd
+
+
+
 TEST_SUITE("comparisions") {
     using namespace datatypes::xsd;
 
@@ -22,30 +54,68 @@ TEST_SUITE("comparisions") {
     }
 
     TEST_CASE("filter compare tests") {
-        CHECK(Literal::make<String>("hello") <=> Literal::make<Int>(5) == std::partial_ordering::unordered);
-        CHECK(Literal::make<Int>(1) < Literal::make<Integer>(10));
-        CHECK(Literal::make<Float>(1.2f) > Literal::make<Integer>(0));
-        CHECK(Literal::make<Float>(1.f) == Literal::make<Decimal>(1.0));
+        SUBCASE("nulls") {
+            CHECK(Literal{} <=> Literal{} == std::partial_ordering::equivalent);
+            CHECK(Literal{} <=> Literal::make<Int>(1) == std::partial_ordering::unordered);
+            CHECK(Literal::make<Decimal>(1.0) <=> Literal{} == std::partial_ordering::unordered);
+        }
+
+        SUBCASE("inconvertibility") {
+            CHECK(Literal::make<String>("hello") <=> Literal::make<Int>(5) == std::partial_ordering::unordered);
+            CHECK(Literal::make<Float>(1.f) <=> Literal::make<String>("world") == std::partial_ordering::unordered);
+        }
+
+        SUBCASE("incomparability") {
+            CHECK(Literal::make<Incomparable>(1) <=> Literal::make<Incomparable>(1) == std::partial_ordering::unordered);
+            CHECK(Literal::make<Int>(1) <=> Literal::make<Incomparable>(1) == std::partial_ordering::unordered);
+            CHECK(Literal::make<Incomparable>(1) <=> Literal::make<Int>(1) == std::partial_ordering::unordered);
+        }
+
+        SUBCASE("conversion") {
+            CHECK(Literal::make<Int>(1) <=> Literal::make<Integer>(10) == std::partial_ordering::less);
+            CHECK(Literal::make<Integer>(0) <=> Literal::make<Float>(1.2f) == std::partial_ordering::less);
+            CHECK(Literal::make<Float>(1.f) <=> Literal::make<Decimal>(1.0) == std::partial_ordering::equivalent);
+        }
     }
 
     TEST_CASE("order by compare tests") {
-        CHECK(Literal::make<String>("hello").compare_with_extensions(Literal::make<Int>(1)) == std::partial_ordering::unordered);
+        // Incomparable <=> Incomparable
+        SUBCASE("incomparability") {
+            CHECK(Literal::make<Incomparable>(5).compare_with_extensions(Literal::make<Incomparable>(10)) == std::weak_ordering::equivalent);
 
-        SUBCASE("test ordering extensions") {
-            // decimal < float < int < integer
+            // reason: "http://www.w3.org/2001/XMLSchema#float" > "Incomparable" (with ascii lexicographical compare)
+            CHECK(Literal::make<Float>(10.f).compare_with_extensions(Literal::make<Incomparable>(1)) == std::weak_ordering::greater);
 
-            CHECK(Literal::make<Decimal>(1.0).compare_with_extensions(Literal::make<Float>(1)) == std::partial_ordering::less);
-            CHECK(Literal::make<Decimal>(1.0).compare_with_extensions(Literal::make<Int>(1)) == std::partial_ordering::less);
-            CHECK(Literal::make<Decimal>(1.0).compare_with_extensions(Literal::make<Integer>(1)) == std::partial_ordering::less);
+            // reason: "Incomparable" < "http://www.w3.org/2001/XMLSchema#decimal" (with ascii lexicographical compare)
+            CHECK(Literal::make<Incomparable>(1).compare_with_extensions(Literal::make<Decimal>(10.0)) == std::weak_ordering::less);
+        }
 
-            CHECK(Literal::make<Float>(1.f).compare_with_extensions(Literal::make<Int>(1)) == std::partial_ordering::less);
-            CHECK(Literal::make<Float>(1.f).compare_with_extensions(Literal::make<Integer>(1)) == std::partial_ordering::less);
+        SUBCASE("nulls") {
+            CHECK(Literal{}.compare_with_extensions(Literal{}) == std::weak_ordering::equivalent);
 
-            CHECK(Literal::make<Int>(1).compare_with_extensions(Literal::make<Integer>(1)) == std::partial_ordering::less);
+            // null <=> other (expecting null < any other a)
+            CHECK(Literal{}.compare_with_extensions(Literal::make<Int>(1)) == std::weak_ordering::less);
+            CHECK(Literal::make<String>("123").compare_with_extensions(Literal{}) == std::weak_ordering::greater);
+        }
+
+        SUBCASE("test type ordering extensions") {
+            // expected: decimal < float < int < integer < string
+
+            CHECK(Literal::make<Decimal>(1.0).compare_with_extensions(Literal::make<Float>(1)) == std::weak_ordering::less);
+            CHECK(Literal::make<Decimal>(1.0).compare_with_extensions(Literal::make<Int>(1)) == std::weak_ordering::less);
+            CHECK(Literal::make<Decimal>(1.0).compare_with_extensions(Literal::make<Integer>(1)) == std::weak_ordering::less);
+            CHECK(Literal::make<Decimal>(1.0).compare_with_extensions(Literal::make<String>("hello")) == std::weak_ordering::less);
+
+            CHECK(Literal::make<Float>(1.f).compare_with_extensions(Literal::make<Int>(1)) == std::weak_ordering::less);
+            CHECK(Literal::make<Float>(1.f).compare_with_extensions(Literal::make<Integer>(1)) == std::weak_ordering::less);
+            CHECK(Literal::make<Float>(1.f).compare_with_extensions(Literal::make<String>("hello")) == std::weak_ordering::less);
+
+            CHECK(Literal::make<Int>(1).compare_with_extensions(Literal::make<Integer>(1)) == std::weak_ordering::less);
+            CHECK(Literal::make<Int>(1).compare_with_extensions(Literal::make<String>("hello")) == std::weak_ordering::less);
         }
 
         SUBCASE("test ordering extensions ignored when not equal") {
-            CHECK(Literal::make<Float>(2.f).compare_with_extensions(Literal::make<Integer>(1)) == std::partial_ordering::greater);
+            CHECK(Literal::make<Float>(2.f).compare_with_extensions(Literal::make<Integer>(1)) == std::weak_ordering::greater);
         }
     }
 }

--- a/tests/nodes/tests_Node_comparison.cpp
+++ b/tests/nodes/tests_Node_comparison.cpp
@@ -5,15 +5,47 @@
 
 using namespace rdf4cpp::rdf;
 
-TEST_CASE("Ordering") {
-    IRI iri1 = IRI{"http://www.example.org/test2"};
-    IRI iri2 = IRI{"http://www.example.org/test1"};
-    IRI iri3 = IRI{"http://www.example.org/oest"};
-    Literal lit1 = Literal{"testlit1"};
-    Literal lit2 = Literal{"testlit2"};
-    CHECK(iri2 < iri1);
-    CHECK(iri3 < iri1);
-    CHECK(iri3 < iri2);
-    CHECK(iri1 < lit1);
-    CHECK(lit1 < lit2);
+TEST_SUITE("comparisions") {
+    using namespace datatypes::xsd;
+
+    TEST_CASE("Ordering") {
+        IRI iri1 = IRI{"http://www.example.org/test2"};
+        IRI iri2 = IRI{"http://www.example.org/test1"};
+        IRI iri3 = IRI{"http://www.example.org/oest"};
+        Literal lit1 = Literal::make<String>("testlit1");
+        Literal lit2 = Literal::make<String>("testlit2");
+        CHECK(iri2 < iri1);
+        CHECK(iri3 < iri1);
+        CHECK(iri3 < iri2);
+        CHECK(iri1 < lit1);
+        CHECK(lit1 < lit2);
+    }
+
+    TEST_CASE("filter compare tests") {
+        CHECK(Literal::make<String>("hello") <=> Literal::make<Int>(5) == std::partial_ordering::unordered);
+        CHECK(Literal::make<Int>(1) < Literal::make<Integer>(10));
+        CHECK(Literal::make<Float>(1.2f) > Literal::make<Integer>(0));
+        CHECK(Literal::make<Float>(1.f) == Literal::make<Decimal>(1.0));
+    }
+
+    TEST_CASE("order by compare tests") {
+        CHECK(Literal::make<String>("hello").compare_with_extensions(Literal::make<Int>(1)) == std::partial_ordering::unordered);
+
+        SUBCASE("test ordering extensions") {
+            // decimal < float < int < integer
+
+            CHECK(Literal::make<Decimal>(1.0).compare_with_extensions(Literal::make<Float>(1)) == std::partial_ordering::less);
+            CHECK(Literal::make<Decimal>(1.0).compare_with_extensions(Literal::make<Int>(1)) == std::partial_ordering::less);
+            CHECK(Literal::make<Decimal>(1.0).compare_with_extensions(Literal::make<Integer>(1)) == std::partial_ordering::less);
+
+            CHECK(Literal::make<Float>(1.f).compare_with_extensions(Literal::make<Int>(1)) == std::partial_ordering::less);
+            CHECK(Literal::make<Float>(1.f).compare_with_extensions(Literal::make<Integer>(1)) == std::partial_ordering::less);
+
+            CHECK(Literal::make<Int>(1).compare_with_extensions(Literal::make<Integer>(1)) == std::partial_ordering::less);
+        }
+
+        SUBCASE("test ordering extensions ignored when not equal") {
+            CHECK(Literal::make<Float>(2.f).compare_with_extensions(Literal::make<Integer>(1)) == std::partial_ordering::greater);
+        }
+    }
 }

--- a/tests/nodes/tests_Node_comparison.cpp
+++ b/tests/nodes/tests_Node_comparison.cpp
@@ -1,5 +1,8 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 
+#include <set>
+#include <unordered_set>
+
 #include <doctest/doctest.h>
 #include <rdf4cpp/rdf.hpp>
 
@@ -117,5 +120,54 @@ TEST_SUITE("comparisions") {
         SUBCASE("test ordering extensions ignored when not equal") {
             CHECK(Literal::make<Float>(2.f).compare_with_extensions(Literal::make<Integer>(1)) == std::weak_ordering::greater);
         }
+    }
+
+    TEST_CASE("std::set") {
+        Literal const lit = Literal::make<Int>(5);
+        Literal const lit2 = Literal::make<Int>(5); // duplicate to check if it's filtered out
+        Literal const lit3 = Literal::make<Integer>(10);
+        Literal const lit4 = Literal::make<String>("hello world");
+        IRI const iri{"some random iri"};
+        IRI const null_iri{};
+        Node const node{};
+        BlankNode const blank_node{"some_random_id"};
+        query::Variable const variable{"a_variable"};
+
+        std::set<Node> const s{
+                lit, iri, node, lit2, blank_node, null_iri, lit3, variable, lit4};
+
+        std::vector<Node> const v{s.begin(), s.end()};
+
+        // lexical order of types, and null smallest
+        // and null Node has type BNode
+        std::vector<Node> const expected{node, null_iri, blank_node, iri, lit, lit3, lit4, variable};
+
+        CHECK(v == expected);
+    }
+
+    TEST_CASE("std::unordered_set") {
+        Literal const lit = Literal::make<Int>(5);
+        Literal const lit2 = Literal::make<Int>(5); // duplicate to check if it's filtered out
+        Literal const lit3 = Literal::make<Integer>(10);
+        Literal const lit4 = Literal::make<String>("hello world");
+        IRI const iri{"some random iri"};
+        IRI const null_iri{};
+        Node const node{};
+        BlankNode const blank_node{"some_random_id"};
+        query::Variable const variable{"a_variable"};
+
+        std::unordered_set<Node> s{
+                iri, null_iri, lit, lit2, lit3, lit4, node, blank_node, variable};
+
+        CHECK(s.size() == 8);
+        CHECK(s.contains(lit));
+        CHECK(s.contains(lit2));
+        CHECK(s.contains(lit3));
+        CHECK(s.contains(lit4));
+        CHECK(s.contains(iri));
+        CHECK(s.contains(null_iri));
+        CHECK(s.contains(node));
+        CHECK(s.contains(blank_node));
+        CHECK(s.contains(variable));
     }
 }

--- a/tests/nodes/tests_Node_comparison.cpp
+++ b/tests/nodes/tests_Node_comparison.cpp
@@ -84,7 +84,7 @@ TEST_SUITE("comparisions") {
     TEST_CASE("order by compare tests") {
         // Incomparable <=> Incomparable
         SUBCASE("incomparability") {
-            CHECK(Literal::make<Incomparable>(5).compare_with_extensions(Literal::make<Incomparable>(10)) == std::weak_ordering::equivalent);
+            CHECK(Literal::make<Incomparable>(5).compare_with_extensions(Literal::make<Incomparable>(10)) == std::weak_ordering::greater);
 
             // reason: "http://www.w3.org/2001/XMLSchema#float" > "Incomparable" (with ascii lexicographical compare)
             CHECK(Literal::make<Float>(10.f).compare_with_extensions(Literal::make<Incomparable>(1)) == std::weak_ordering::greater);

--- a/tests/util/tests_TriBool.cpp
+++ b/tests/util/tests_TriBool.cpp
@@ -1,0 +1,115 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+
+#include <doctest/doctest.h>
+#include <rdf4cpp/rdf.hpp>
+
+using rdf4cpp::rdf::util::TriBool;
+
+TEST_SUITE("TriBool") {
+
+    TEST_CASE("TriBool operators") {
+        TriBool const tt = TriBool::True;
+        TriBool const tf = TriBool::False;
+        TriBool const te = TriBool::Err;
+
+        SUBCASE("and") {
+            CHECK((tt && tt) == TriBool::True);
+            CHECK((tt && tf) == TriBool::False);
+            CHECK((tf && tt) == TriBool::False);
+            CHECK((tf && tf) == TriBool::False);
+            CHECK((tt && te) == TriBool::Err);
+            CHECK((te && tt) == TriBool::Err);
+            CHECK((tf && te) == TriBool::False);
+            CHECK((te && tf) == TriBool::False);
+            CHECK((te && te) == TriBool::Err);
+        }
+
+        SUBCASE("or") {
+            CHECK((tt || tt) == TriBool::True);
+            CHECK((tt || tf) == TriBool::True);
+            CHECK((tf || tt) == TriBool::True);
+            CHECK((tf || tf) == TriBool::False);
+            CHECK((tt || te) == TriBool::True);
+            CHECK((te || tt) == TriBool::True);
+            CHECK((tf || te) == TriBool::Err);
+            CHECK((te || tf) == TriBool::Err);
+            CHECK((te || te) == TriBool::Err);
+        }
+
+        SUBCASE("not") {
+            CHECK(!tt == TriBool::False);
+            CHECK(!tf == TriBool::True);
+            CHECK(!te == TriBool::Err);
+        }
+    }
+
+
+    TEST_CASE("TriBool bool interop") {
+        TriBool const tt = true;
+        TriBool const tf = false;
+        TriBool const te = TriBool::Err;
+
+        SUBCASE("converting constructor") {
+            CHECK(tt == TriBool::True);
+            CHECK(tf == TriBool::False);
+        }
+
+        SUBCASE("operator bool") {
+            if (tt) {
+                // expected
+            } else {
+                FAIL_CHECK("wrong conversion true -> bool");
+            }
+
+            if (!tf) {
+                // expected
+            } else {
+                FAIL_CHECK("wrong conversion false -> bool");
+            }
+
+            if (te) {
+                FAIL_CHECK("wrong conversion err -> bool");
+            } else if (!te) {
+                FAIL_CHECK("wrong conversion err -> bool");
+            } else {
+                // expected
+            }
+        }
+
+        SUBCASE("logic operators") {
+            SUBCASE("and") {
+                CHECK((tt && true) == TriBool::True);
+                CHECK((true && tt) == TriBool::True);
+                CHECK((tt && false) == TriBool::False);
+                CHECK((false && tt) == TriBool::False);
+
+                CHECK((tf && true) == TriBool::False);
+                CHECK((true && tf) == TriBool::False);
+                CHECK((tf && false) == TriBool::False);
+                CHECK((false && tf) == TriBool::False);
+
+                CHECK((te && true) == TriBool::Err);
+                CHECK((true && te) == TriBool::Err);
+                CHECK((te && false) == TriBool::False);
+                CHECK((false && te) == TriBool::False);
+            }
+
+            SUBCASE("or") {
+                CHECK((tt || true) == TriBool::True);
+                CHECK((true || tt) == TriBool::True);
+                CHECK((tt || false) == TriBool::True);
+                CHECK((false || tt) == TriBool::True);
+
+                CHECK((tf || true) == TriBool::True);
+                CHECK((true || tf) == TriBool::True);
+                CHECK((tf || false) == TriBool::False);
+                CHECK((false || tf) == TriBool::False);
+
+                CHECK((te || true) == TriBool::True);
+                CHECK((true || te) == TriBool::True);
+                CHECK((te || false) == TriBool::Err);
+                CHECK((false || te) == TriBool::Err);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Initial draft for literal comparisons.
I marked this as a draft because there are some things to be discussed first:

- [x] correct filter compare behaviour?
  - [x] should filters also always return less-than instead of unordered for null <=> non-null value? -> no
- [x] correct order by compare behaviour?
- [x] return value of compare operators (should it be a Literal instead?)  => TriStateBool and ordering
- [x] see #55 as this creates problems here as well
- [x] comparison operators with TriStateBools
  - [x] find suitable modelling for TriStateBool
    - enum struct doesn't work; does not support `operator bool()` because must be memberfunction
- [x] fix #61 