### PR TITLE
Fix: eliminate unecessary overhead of literal construction from template make

### DIFF
--- a/src/rdf4cpp/rdf/IRI.cpp
+++ b/src/rdf4cpp/rdf/IRI.cpp
@@ -50,5 +50,9 @@ std::ostream &operator<<(std::ostream &os, const IRI &iri) {
 std::string_view IRI::identifier() const {
     return handle_.iri_backend().identifier;
 }
+IRI::IRI(datatypes::registry::DatatypeIDView id, Node::NodeStorage &node_storage) noexcept
+    : IRI{IRI::from_datatype_id(id, node_storage)}
+{
+}
 
 }  // namespace rdf4cpp::rdf

--- a/src/rdf4cpp/rdf/IRI.hpp
+++ b/src/rdf4cpp/rdf/IRI.hpp
@@ -16,6 +16,12 @@ private:
      * Constructs the corresponding IRI from a given datatype id and places it into node_storage if
      * it does not exist already.
      */
+    explicit IRI(datatypes::registry::DatatypeIDView id, NodeStorage &node_storage = NodeStorage::default_instance()) noexcept;
+
+    /**
+     * Constructs the corresponding IRI from a given datatype id and places it into node_storage if
+     * it does not exist already.
+     */
     static IRI from_datatype_id(datatypes::registry::DatatypeIDView id, NodeStorage &node_storage = NodeStorage::default_instance()) noexcept;
 
     /**
@@ -23,6 +29,8 @@ private:
      * index the registry and yields the correct result.
      */
     [[nodiscard]] datatypes::registry::DatatypeIDView to_datatype_id() const noexcept;
+
+
 
 public:
     explicit IRI(Node::NodeBackendHandle handle) noexcept;

--- a/src/rdf4cpp/rdf/Literal.hpp
+++ b/src/rdf4cpp/rdf/Literal.hpp
@@ -124,8 +124,8 @@ public:
      * @return literal instance representing compatible_value
      */
     template<datatypes::LiteralDatatype LiteralDatatype_t>
-    inline static Literal make(typename LiteralDatatype_t::cpp_type compatible_value,
-                               NodeStorage &node_storage = NodeStorage::default_instance()) {
+    static Literal make(typename LiteralDatatype_t::cpp_type compatible_value,
+                        NodeStorage &node_storage = NodeStorage::default_instance()) {
 
         if constexpr (std::is_same_v<LiteralDatatype_t, datatypes::rdf::LangString>) {
             return Literal::make_lang_tagged_unchecked(compatible_value.lexical_form,
@@ -133,7 +133,7 @@ public:
                                                        node_storage);
         } else {
             return Literal::make_typed_unchecked(LiteralDatatype_t::to_string(compatible_value),
-                                                 IRI{LiteralDatatype_t::identifier, node_storage},
+                                                 IRI{LiteralDatatype_t::datatype_id, node_storage},
                                                  node_storage);
         }
     }
@@ -278,7 +278,7 @@ public:
         if constexpr (std::is_same_v<LiteralDatatype_t, datatypes::rdf::LangString>) {
             auto const &lit = this->handle_.literal_backend();
 
-            return datatypes::registry::LangStringRepr {
+            return datatypes::registry::LangStringRepr{
                     .lexical_form = std::string{lit.lexical_form},
                     .language_tag = std::string{lit.language_tag}};
         } else {

--- a/src/rdf4cpp/rdf/Literal.hpp
+++ b/src/rdf4cpp/rdf/Literal.hpp
@@ -69,6 +69,21 @@ private:
      */
     [[nodiscard]] bool is_fixed_not_numeric() const noexcept;
 
+    /**
+     * Creates a simple Literal directly without any safety checks
+     */
+    static Literal make_simple_unchecked(std::string_view lexical_form, NodeStorage &node_storage);
+
+    /**
+     * Creates a typed Literal without doing any safety checks or canonicalization.
+     */
+    static Literal make_typed_unchecked(std::string_view lexical_form, IRI const &datatype, NodeStorage &node_storage);
+
+    /**
+     * Creates a language-tagged Literal directly without any safety checks
+     */
+    static Literal make_lang_tagged_unchecked(std::string_view lexical_form, std::string_view lang, NodeStorage &node_storage);
+
 protected:
     explicit Literal(Node::NodeBackendHandle handle);
 
@@ -113,13 +128,13 @@ public:
                                NodeStorage &node_storage = NodeStorage::default_instance()) {
 
         if constexpr (std::is_same_v<LiteralDatatype_t, datatypes::rdf::LangString>) {
-            return Literal{compatible_value.lexical_form,
-                           compatible_value.language_tag,
-                           node_storage};
+            return Literal::make_lang_tagged_unchecked(compatible_value.lexical_form,
+                                                       compatible_value.language_tag,
+                                                       node_storage);
         } else {
-            return Literal{LiteralDatatype_t::to_string(compatible_value),
-                           IRI{LiteralDatatype_t::identifier, node_storage},
-                           node_storage};
+            return Literal::make_typed_unchecked(LiteralDatatype_t::to_string(compatible_value),
+                                                 IRI{LiteralDatatype_t::identifier, node_storage},
+                                                 node_storage);
         }
     }
 


### PR DESCRIPTION
`Literal::make<>()` had a bug where it would call `Literal::make` which would then unecessarily canonicalize the literal a second time, which is expensive.