### PR TITLE
Feature: Additional Parser functionality needed for tentris 

### DIFF
--- a/src/rdf4cpp/rdf/parser/IStreamQuadIterator.cpp
+++ b/src/rdf4cpp/rdf/parser/IStreamQuadIterator.cpp
@@ -15,10 +15,12 @@ IStreamQuadIterator::IStreamQuadIterator(std::default_sentinel_t) noexcept
     : impl{nullptr} {
 }
 
-IStreamQuadIterator::IStreamQuadIterator(std::istream &istream, ParsingFlags flags, storage::node::NodeStorage node_storage) noexcept
-    : impl{std::make_unique<Impl>(istream, flags.contains(ParsingFlag::Strict), std::move(node_storage))} {
+IStreamQuadIterator::IStreamQuadIterator(std::istream &istream, ParsingFlags flags, prefix_storage_type prefixes, storage::node::NodeStorage node_storage) noexcept
+    : impl{std::make_unique<Impl>(istream, flags.contains(ParsingFlag::Strict), std::move(prefixes), std::move(node_storage))} {
     ++*this;
 }
+
+IStreamQuadIterator::IStreamQuadIterator(IStreamQuadIterator &&other) noexcept = default;
 
 IStreamQuadIterator::~IStreamQuadIterator() noexcept = default;
 
@@ -45,7 +47,5 @@ bool IStreamQuadIterator::operator==(IStreamQuadIterator const &other) const noe
 bool IStreamQuadIterator::operator!=(IStreamQuadIterator const &other) const noexcept {
     return !(*this == other);
 }
-IStreamQuadIterator::IStreamQuadIterator(IStreamQuadIterator &&other) noexcept = default;
-
 
 }  // namespace rdf4cpp::rdf::parser

--- a/src/rdf4cpp/rdf/parser/IStreamQuadIterator.cpp
+++ b/src/rdf4cpp/rdf/parser/IStreamQuadIterator.cpp
@@ -16,7 +16,7 @@ IStreamQuadIterator::IStreamQuadIterator(std::default_sentinel_t) noexcept
 }
 
 IStreamQuadIterator::IStreamQuadIterator(std::istream &istream, ParsingFlags flags, prefix_storage_type prefixes, storage::node::NodeStorage node_storage) noexcept
-    : impl{std::make_unique<Impl>(istream, flags.contains(ParsingFlag::Strict), std::move(prefixes), std::move(node_storage))} {
+    : impl{std::make_unique<Impl>(istream, flags, std::move(prefixes), std::move(node_storage))} {
     ++*this;
 }
 

--- a/src/rdf4cpp/rdf/parser/IStreamQuadIterator.hpp
+++ b/src/rdf4cpp/rdf/parser/IStreamQuadIterator.hpp
@@ -9,6 +9,8 @@
 #include <rdf4cpp/rdf/Quad.hpp>
 #include <rdf4cpp/rdf/parser/ParsingError.hpp>
 #include <rdf4cpp/rdf/parser/ParsingFlags.hpp>
+#include <rdf4cpp/rdf/storage/util/robin-hood-hashing/robin_hood_hash.hpp>
+#include <rdf4cpp/rdf/storage/util/tsl/sparse_map.h>
 
 namespace rdf4cpp::rdf::parser {
 
@@ -41,6 +43,12 @@ struct IStreamQuadIterator {
     using iterator_category = std::input_iterator_tag;
     using istream_type = std::istream;
 
+    using prefix_storage_type = rdf4cpp::rdf::storage::util::tsl::sparse_map<
+            std::string,
+            std::string,
+            rdf4cpp::rdf::storage::util::robin_hood::hash<std::string_view>,
+            std::equal_to<>>;
+
 private:
     struct Impl;
 
@@ -63,7 +71,9 @@ public:
     IStreamQuadIterator(IStreamQuadIterator const &) = delete;
     IStreamQuadIterator(IStreamQuadIterator &&) noexcept ;
 
-    explicit IStreamQuadIterator(std::istream &istream, ParsingFlags flags = ParsingFlags::none(), storage::node::NodeStorage node_storage = storage::node::NodeStorage::default_instance()) noexcept;
+    explicit IStreamQuadIterator(std::istream &istream, ParsingFlags flags = ParsingFlags::none(),
+                                 prefix_storage_type prefixes = {},
+                                 storage::node::NodeStorage node_storage = storage::node::NodeStorage::default_instance()) noexcept;
     ~IStreamQuadIterator() noexcept;
 
     reference operator*() const noexcept;

--- a/src/rdf4cpp/rdf/parser/ParsingFlags.hpp
+++ b/src/rdf4cpp/rdf/parser/ParsingFlags.hpp
@@ -8,6 +8,7 @@ namespace rdf4cpp::rdf::parser {
 
 enum struct ParsingFlag : uint8_t {
     Strict = 1 << 0,
+    NoParsePrefix = 1 << 1,
 };
 
 struct ParsingFlags {

--- a/src/rdf4cpp/rdf/parser/private/IStreamQuadIteratorSerdImpl.cpp
+++ b/src/rdf4cpp/rdf/parser/private/IStreamQuadIteratorSerdImpl.cpp
@@ -185,13 +185,33 @@ SerdStatus IStreamQuadIterator::Impl::on_error(void *voided_self, SerdError cons
 
 SerdStatus IStreamQuadIterator::Impl::on_base(void *voided_self, const SerdNode *uri) noexcept {
     auto *self = reinterpret_cast<Impl *>(voided_self);
-    self->prefixes.emplace("", node_into_string_view(uri));
+
+    if (self->no_parse_prefixes) {
+        self->last_error = ParsingError{
+                .error_type = ParsingError::Type::BadSyntax,
+                .line = serd_reader_get_current_line(self->reader.get()),
+                .col = serd_reader_get_current_col(self->reader.get()),
+                .message = "Encountered base while parsing. hint: prefix parsing is currently deactivated. note: position may not be accurate and instead point to the end of the line."};
+    } else {
+        self->prefixes.emplace("", node_into_string_view(uri));
+    }
+
     return SERD_SUCCESS;
 }
 
 SerdStatus IStreamQuadIterator::Impl::on_prefix(void *voided_self, SerdNode const *name, SerdNode const *uri) noexcept {
     auto *self = reinterpret_cast<Impl *>(voided_self);
-    self->prefixes.emplace(node_into_string_view(name), node_into_string_view(uri));
+
+    if (self->no_parse_prefixes) {
+        self->last_error = ParsingError{
+                .error_type = ParsingError::Type::BadSyntax,
+                .line = serd_reader_get_current_line(self->reader.get()),
+                .col = serd_reader_get_current_col(self->reader.get()),
+                .message = "Encountered prefix while parsing. hint: prefix parsing is currently deactivated. note: position may not be accurate and instead point to the end of the line."};
+    } else {
+        self->prefixes.emplace(node_into_string_view(name), node_into_string_view(uri));
+    }
+
     return SERD_SUCCESS;
 }
 
@@ -281,13 +301,14 @@ SerdStatus IStreamQuadIterator::Impl::on_stmt(void *voided_self,
     return SERD_SUCCESS;
 }
 
-IStreamQuadIterator::Impl::Impl(std::istream &istream, bool strict, PrefixMap prefixes, storage::node::NodeStorage node_storage) noexcept
+IStreamQuadIterator::Impl::Impl(std::istream &istream, ParsingFlags flags, PrefixMap prefixes, storage::node::NodeStorage node_storage) noexcept
     : istream{std::ref(istream)},
       node_storage{std::move(node_storage)},
       reader{serd_reader_new(SerdSyntax::SERD_TURTLE, this, nullptr, &Impl::on_base, &Impl::on_prefix, &Impl::on_stmt, nullptr)},
-      prefixes{std::move(prefixes)} {
+      prefixes{std::move(prefixes)},
+      no_parse_prefixes{flags.contains(ParsingFlag::NoParsePrefix)} {
 
-    serd_reader_set_strict(this->reader.get(), strict);
+    serd_reader_set_strict(this->reader.get(), flags.contains(ParsingFlag::Strict));
     serd_reader_set_error_sink(this->reader.get(), &Impl::on_error, this);
     serd_reader_start_source_stream(this->reader.get(), &util::istream_read, &util::istream_is_ok, &this->istream.get(), nullptr, 4096);
 }
@@ -301,17 +322,22 @@ std::optional<nonstd::expected<Quad, ParsingError>> IStreamQuadIterator::Impl::n
         this->last_error = std::nullopt;
         SerdStatus const st = serd_reader_read_chunk(this->reader.get());
 
-        if (st != SerdStatus::SERD_SUCCESS && quad_buffer.empty()) {
-            // was not able to read stmt, prefix or base
+        if (quad_buffer.empty()) {
+            if (st != SerdStatus::SERD_SUCCESS) {
+                // was not able to read stmt, prefix or base
 
-            if (!this->last_error.has_value()) {
-                // did not receive error either => must be eof
-                this->end_flag = true;
-                return std::nullopt;  // eof reached
+                if (!this->last_error.has_value()) {
+                    // did not receive error either => must be eof
+                    this->end_flag = true;
+                    return std::nullopt;  // eof reached
+                }
+
+                serd_reader_skip_error(this->reader.get());
+                return nonstd::make_unexpected(*this->last_error);
+            } else if (this->last_error.has_value()) {
+                // non-fatal, artificially inserted error
+                return nonstd::make_unexpected(*this->last_error);
             }
-
-            serd_reader_skip_error(this->reader.get());
-            return nonstd::make_unexpected(*this->last_error);
         }
     }
 

--- a/src/rdf4cpp/rdf/parser/private/IStreamQuadIteratorSerdImpl.cpp
+++ b/src/rdf4cpp/rdf/parser/private/IStreamQuadIteratorSerdImpl.cpp
@@ -281,10 +281,11 @@ SerdStatus IStreamQuadIterator::Impl::on_stmt(void *voided_self,
     return SERD_SUCCESS;
 }
 
-IStreamQuadIterator::Impl::Impl(std::istream &istream, bool strict, storage::node::NodeStorage node_storage) noexcept
+IStreamQuadIterator::Impl::Impl(std::istream &istream, bool strict, PrefixMap prefixes, storage::node::NodeStorage node_storage) noexcept
     : istream{std::ref(istream)},
       node_storage{std::move(node_storage)},
-      reader{serd_reader_new(SerdSyntax::SERD_TURTLE, this, nullptr, &Impl::on_base, &Impl::on_prefix, &Impl::on_stmt, nullptr)} {
+      reader{serd_reader_new(SerdSyntax::SERD_TURTLE, this, nullptr, &Impl::on_base, &Impl::on_prefix, &Impl::on_stmt, nullptr)},
+      prefixes{std::move(prefixes)} {
 
     serd_reader_set_strict(this->reader.get(), strict);
     serd_reader_set_error_sink(this->reader.get(), &Impl::on_error, this);

--- a/src/rdf4cpp/rdf/parser/private/IStreamQuadIteratorSerdImpl.hpp
+++ b/src/rdf4cpp/rdf/parser/private/IStreamQuadIteratorSerdImpl.hpp
@@ -20,11 +20,7 @@ namespace rdf4cpp::rdf::parser {
 
 struct IStreamQuadIterator::Impl {
 private:
-    using PrefixMap = rdf4cpp::rdf::storage::util::tsl::sparse_map<
-            std::string,
-            std::string,
-            rdf4cpp::rdf::storage::util::robin_hood::hash<std::string_view>,
-            std::equal_to<>>;
+    using PrefixMap = IStreamQuadIterator::prefix_storage_type;
 
     struct SerdReaderDelete {
         inline void operator()(SerdReader *rdr) const noexcept {
@@ -61,7 +57,7 @@ private:
     static SerdStatus on_stmt(void *voided_self, SerdStatementFlags, SerdNode const *graph, SerdNode const *subj, SerdNode const *pred, SerdNode const *obj, SerdNode const *obj_datatype, SerdNode const *obj_lang) noexcept;
 
 public:
-    Impl(std::istream &istream, bool strict, storage::node::NodeStorage node_storage) noexcept;
+    Impl(std::istream &istream, bool strict, PrefixMap prefixes, storage::node::NodeStorage node_storage) noexcept;
 
     /**
      * @return true if this will no longer yield values

--- a/src/rdf4cpp/rdf/parser/private/IStreamQuadIteratorSerdImpl.hpp
+++ b/src/rdf4cpp/rdf/parser/private/IStreamQuadIteratorSerdImpl.hpp
@@ -40,6 +40,7 @@ private:
     std::deque<Quad> quad_buffer;
     std::optional<ParsingError> last_error;
     bool end_flag = false;
+    bool no_parse_prefixes;
 
 private:
     static std::string_view node_into_string_view(SerdNode const *node) noexcept;
@@ -57,7 +58,7 @@ private:
     static SerdStatus on_stmt(void *voided_self, SerdStatementFlags, SerdNode const *graph, SerdNode const *subj, SerdNode const *pred, SerdNode const *obj, SerdNode const *obj_datatype, SerdNode const *obj_lang) noexcept;
 
 public:
-    Impl(std::istream &istream, bool strict, PrefixMap prefixes, storage::node::NodeStorage node_storage) noexcept;
+    Impl(std::istream &istream, ParsingFlags flags, PrefixMap prefixes, storage::node::NodeStorage node_storage) noexcept;
 
     /**
      * @return true if this will no longer yield values

--- a/tests/parser/tests_IStreamQuadIterator.cpp
+++ b/tests/parser/tests_IStreamQuadIterator.cpp
@@ -230,4 +230,20 @@ TEST_SUITE("IStreamQuadIterator") {
         ++qit;
         CHECK(qit == IStreamQuadIterator{});
     }
+
+    TEST_CASE("manually added prefix") {
+        constexpr char const *triples = "<http://data.semanticweb.org/workshop/admire/2012/paper/12> prefix:predicate \"search\"^^<http://www.w3.org/2001/XMLSchema#string> .\n";
+
+        std::istringstream iss{triples};
+        IStreamQuadIterator qit{iss, ParsingFlags::none(), { {"prefix", "https://hello.com#"} }};
+
+        CHECK(qit != IStreamQuadIterator{});
+        CHECK(qit->has_value());
+        CHECK(qit->value() == Quad{IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/12"},
+                                   IRI{"https://hello.com#predicate"},
+                                   Literal{"search"}});
+
+        ++qit;
+        CHECK(qit == IStreamQuadIterator{});
+    }
 }

--- a/tests/parser/tests_IStreamQuadIterator.cpp
+++ b/tests/parser/tests_IStreamQuadIterator.cpp
@@ -246,4 +246,38 @@ TEST_SUITE("IStreamQuadIterator") {
         ++qit;
         CHECK(qit == IStreamQuadIterator{});
     }
+
+    TEST_CASE("no prefix parsing") {
+        constexpr char const *triples = "@base <http://invalid-url.org> .\n"
+                                        "@prefix xsd: <http://some-random-url.de#> .\n"
+                                        "<http://data.semanticweb.org/workshop/admire/2012/paper/12> <http://purl.org/dc/elements/1.1/subject> \"search\" .\n"
+                                        "xsd:subject xsd:predicate \"aaaaa\" .\n";
+
+        std::istringstream iss{triples};
+        IStreamQuadIterator qit{iss, ParsingFlag::NoParsePrefix};
+
+        CHECK(qit != IStreamQuadIterator{});
+        CHECK(!qit->has_value());
+        std::cout << qit->error() << std::endl;
+
+        ++qit;
+        CHECK(qit != IStreamQuadIterator{});
+        CHECK(!qit->has_value());
+        std::cout << qit->error() << std::endl;
+
+        ++qit;
+        CHECK(qit != IStreamQuadIterator{});
+        CHECK(qit->has_value());
+        CHECK(qit->value() == Quad{IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/12"},
+                                   IRI{"http://purl.org/dc/elements/1.1/subject"},
+                                   Literal{"search"}});
+
+        ++qit;
+        CHECK(qit != IStreamQuadIterator{});
+        CHECK(!qit->has_value());
+        std::cout << qit->error() << std::endl;
+
+        ++qit;
+        CHECK(qit == IStreamQuadIterator{});
+    }
 }


### PR DESCRIPTION
This PR adds two features to IStreamQuadIterator

1. The ability to provide custom prefixes during construction
```c++
std::istream is{...};
IStreamQuadIterator qit{is, ParsingFlags::none(), {{"xsd", "http://some_url.org"}, {"asd", "http://other.com"}}};
```

2. The ability to disable prefix parsing
```c++
std::istringstream iss{"@prefix xsd: <http://some_url.org#>"};
IStreamQuadIterator qit{is, ParsingFlag::NoParsePrefix, {{"xsd", "http://some_url.org"}, {"asd", "http://other.com"}}};
assert(qit->has_exception());
```

Note:
The interface to provide prefixes is not quite optimal since it suffers from two limitations:
1. The constructor cannot take template arguments since the type is pimpl. Therefore no ranges.
2. Something like `qit.add_prefix("a", "b")` wouldn't work since the iterator starts on the first triple, and therefore the prefix wouldnt work for the first triple. Fixing this would require breaking the interface and it would make it weird to use.