### PR TITLE
Feature: node inlining

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,8 +105,6 @@ add_library(rdf4cpp
         src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedLong.cpp
         src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedShort.cpp
         src/rdf4cpp/rdf/datatypes/xsd/integers/non_positive/NegativeInteger.cpp
-        src/rdf4cpp/rdf/datatypes/xsd/integers/non_positive/NegativeInteger.cpp
-        src/rdf4cpp/rdf/datatypes/xsd/integers/non_positive/NonPositiveInteger.cpp
         src/rdf4cpp/rdf/datatypes/xsd/integers/non_positive/NonPositiveInteger.cpp
         src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Byte.cpp
         src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Int.cpp

--- a/src/rdf4cpp/rdf/Literal.cpp
+++ b/src/rdf4cpp/rdf/Literal.cpp
@@ -46,7 +46,7 @@ util::CowString Literal::lexical_form() const noexcept {
 }
 
 Literal Literal::as_lexical_form(NodeStorage &node_storage) const {
-    return Literal::make<datatypes::xsd::String>(std::string{this->lexical_form()}, node_storage);
+    return Literal::make<datatypes::xsd::String>(this->lexical_form().into_owned(), node_storage);
 }
 
 std::string_view Literal::language_tag() const noexcept {

--- a/src/rdf4cpp/rdf/Literal.cpp
+++ b/src/rdf4cpp/rdf/Literal.cpp
@@ -32,17 +32,17 @@ IRI Literal::datatype() const noexcept {
                                  handle_.node_storage_id()}};
 }
 
-std::string Literal::lexical_form() const noexcept {
+util::CowString Literal::lexical_form() const noexcept {
     if (this->is_inlined()) {
         auto const *entry = datatypes::registry::DatatypeRegistry::get_entry(this->datatype_id());
         assert(entry != nullptr);
         assert(entry->inlining_ops.has_value());
 
         auto const inlined_value = this->handle_.node_id().literal_id().value;
-        return entry->to_string_fptr(entry->inlining_ops->from_inlined_fptr(inlined_value));
+        return util::CowString{util::ownership_tag::owned, entry->to_string_fptr(entry->inlining_ops->from_inlined_fptr(inlined_value))};
     }
 
-    return std::string{handle_.literal_backend().lexical_form};
+    return util::CowString{util::ownership_tag::borrowed, handle_.literal_backend().lexical_form};
 }
 
 Literal Literal::as_lexical_form(NodeStorage &node_storage) const {

--- a/src/rdf4cpp/rdf/Literal.hpp
+++ b/src/rdf4cpp/rdf/Literal.hpp
@@ -83,6 +83,7 @@ private:
      */
     [[nodiscard]] static Literal make_lang_tagged_unchecked(std::string_view lexical_form, std::string_view lang, NodeStorage &node_storage) noexcept;
 
+    [[nodiscard]] static Literal make_inlined_unchecked(uint64_t inlined_value, IRI const &datatype, NodeStorage &node_storage) noexcept;
 protected:
     explicit Literal(Node::NodeBackendHandle handle) noexcept;
 
@@ -125,6 +126,14 @@ public:
     template<datatypes::LiteralDatatype LiteralDatatype_t>
     static Literal make(typename LiteralDatatype_t::cpp_type compatible_value,
                         NodeStorage &node_storage = NodeStorage::default_instance()) noexcept {
+
+        if constexpr (datatypes::IsInlineable<LiteralDatatype_t>) {
+            if (LiteralDatatype_t::can_inline(compatible_value)) {
+                auto const inlined = LiteralDatatype_t::to_inlined(compatible_value);
+
+
+            }
+        }
 
         if constexpr (std::is_same_v<LiteralDatatype_t, datatypes::rdf::LangString>) {
             return Literal::make_lang_tagged_unchecked(compatible_value.lexical_form,
@@ -310,9 +319,13 @@ public:
             return datatypes::registry::LangStringRepr{
                     .lexical_form = std::string{lit.lexical_form},
                     .language_tag = std::string{lit.language_tag}};
-        } else {
-            return LiteralDatatype_t::from_string(this->lexical_form());
+        } else if constexpr (datatypes::IsInlineable<LiteralDatatype_t>) {
+            if (this->handle_.is_inlined()) {
+                auto const inlined_value = this->handle_.node_id().literal_id().value;i
+            }
         }
+
+        return LiteralDatatype_t::from_string(this->lexical_form());
     }
 
     friend class Node;

--- a/src/rdf4cpp/rdf/Literal.hpp
+++ b/src/rdf4cpp/rdf/Literal.hpp
@@ -192,8 +192,7 @@ public:
      * E.g. For `"abc"^^xsd::string` the lexical form is `abc`
      * @return lexical form
      */
-     // TODO: find better return type, CowString does not work currently
-    [[nodiscard]] std::string lexical_form() const noexcept;
+    [[nodiscard]] util::CowString lexical_form() const noexcept;
 
     /**
      * Converts this into it's lexical form as xsd:string. See Literal::lexical_form for more details.

--- a/src/rdf4cpp/rdf/Literal.hpp
+++ b/src/rdf4cpp/rdf/Literal.hpp
@@ -83,7 +83,7 @@ private:
     /**
      * Creates a typed Literal without doing any safety checks or canonicalization.
      */
-    [[nodiscard]] static Literal make_typed_unchecked(std::string_view lexical_form, IRI const &datatype, NodeStorage &node_storage) noexcept;
+    [[nodiscard]] static Literal make_noninlined_typed_unchecked(std::string_view lexical_form, IRI const &datatype, NodeStorage &node_storage) noexcept;
 
     /**
      * Creates a language-tagged Literal directly without any safety checks
@@ -93,7 +93,12 @@ private:
     /**
      * Creates an inlined Literal without any safety checks
      */
-    [[nodiscard]] static Literal make_inlined_unchecked(uint64_t inlined_value, storage::node::identifier::LiteralType fixed_id, NodeStorage &node_storage) noexcept;
+    [[nodiscard]] static Literal make_inlined_typed_unchecked(uint64_t inlined_value, storage::node::identifier::LiteralType fixed_id, NodeStorage &node_storage) noexcept;
+
+    /**
+     * Creates an inlined Literal without any safety checks
+     */
+    [[nodiscard]] static Literal make_typed_unchecked(std::any const &value, datatypes::registry::DatatypeIDView datatype, datatypes::registry::DatatypeRegistry::DatatypeEntry const &entry, NodeStorage &node_storage) noexcept;
 protected:
     explicit Literal(Node::NodeBackendHandle handle) noexcept;
 
@@ -145,13 +150,13 @@ public:
 
         if constexpr (datatypes::IsInlineable<LiteralDatatype_t>) {
             if (auto const maybe_inlined = LiteralDatatype_t::try_into_inlined(compatible_value); maybe_inlined.has_value()) {
-                return Literal::make_inlined_unchecked(*maybe_inlined, LiteralDatatype_t::datatype_id.get_fixed(), node_storage);
+                return Literal::make_inlined_typed_unchecked(*maybe_inlined, LiteralDatatype_t::datatype_id.get_fixed(), node_storage);
             }
         }
 
-        return Literal::make_typed_unchecked(LiteralDatatype_t::to_string(compatible_value),
-                                             IRI{LiteralDatatype_t::datatype_id, node_storage},
-                                             node_storage);
+        return Literal::make_noninlined_typed_unchecked(LiteralDatatype_t::to_string(compatible_value),
+                                                        IRI{LiteralDatatype_t::datatype_id, node_storage},
+                                                        node_storage);
     }
 
     /**

--- a/src/rdf4cpp/rdf/Literal.hpp
+++ b/src/rdf4cpp/rdf/Literal.hpp
@@ -92,6 +92,9 @@ private:
 
     /**
      * Creates an inlined Literal without any safety checks
+     *
+     * @param inlined_value a valid inlined value for the given datatype (identified via a fixed_id) packed into the lower LiteralID::width bits of the integer
+     * @note inlined_values for a datatype can be obtained via Datatype::try_into_inlined(value) if the datatype is inlineable (see registry::capabilities::Inlineable)
      */
     [[nodiscard]] static Literal make_inlined_typed_unchecked(uint64_t inlined_value, storage::node::identifier::LiteralType fixed_id, NodeStorage &node_storage) noexcept;
 

--- a/src/rdf4cpp/rdf/Literal.hpp
+++ b/src/rdf4cpp/rdf/Literal.hpp
@@ -81,7 +81,7 @@ private:
     [[nodiscard]] static Literal make_simple_unchecked(std::string_view lexical_form, NodeStorage &node_storage) noexcept;
 
     /**
-     * Creates a typed Literal without doing any safety checks or canonicalization.
+     * Creates a non-inlined typed Literal without doing any safety checks or canonicalization.
      */
     [[nodiscard]] static Literal make_noninlined_typed_unchecked(std::string_view lexical_form, IRI const &datatype, NodeStorage &node_storage) noexcept;
 
@@ -96,7 +96,7 @@ private:
     [[nodiscard]] static Literal make_inlined_typed_unchecked(uint64_t inlined_value, storage::node::identifier::LiteralType fixed_id, NodeStorage &node_storage) noexcept;
 
     /**
-     * Creates an inlined Literal without any safety checks
+     * Creates an inlined or non-inlined typed Literal without any safety checks
      */
     [[nodiscard]] static Literal make_typed_unchecked(std::any const &value, datatypes::registry::DatatypeIDView datatype, datatypes::registry::DatatypeRegistry::DatatypeEntry const &entry, NodeStorage &node_storage) noexcept;
 protected:

--- a/src/rdf4cpp/rdf/Node.cpp
+++ b/src/rdf4cpp/rdf/Node.cpp
@@ -72,6 +72,10 @@ bool Node::is_iri() const noexcept {
     return handle_.is_iri();
 }
 
+bool Node::is_inlined() const noexcept {
+    return handle_.is_inlined();
+}
+
 std::weak_ordering Node::operator<=>(const Node &other) const noexcept {
     if (this->handle_ == other.handle_){
         return std::strong_ordering::equivalent;
@@ -157,5 +161,6 @@ Literal Node::ebv_as_literal([[maybe_unused]] NodeStorage &node_storage) const n
 
     return static_cast<Literal>(*this).ebv_as_literal(node_storage);
 }
+
 
 }  // namespace rdf4cpp::rdf

--- a/src/rdf4cpp/rdf/Node.hpp
+++ b/src/rdf4cpp/rdf/Node.hpp
@@ -82,6 +82,11 @@ public:
      */
     [[nodiscard]] bool is_iri() const noexcept;
 
+    /**
+     * @return if the current value of this node is stored inside the handle instead of the node storage
+     */
+    [[nodiscard]] bool is_inlined() const noexcept;
+
     bool operator==(const Node &other) const noexcept;
 
     std::weak_ordering operator<=>(const Node &other) const noexcept;

--- a/src/rdf4cpp/rdf/datatypes/LiteralDatatype.hpp
+++ b/src/rdf4cpp/rdf/datatypes/LiteralDatatype.hpp
@@ -1,6 +1,8 @@
 #ifndef RDF4CPP_LITERALDATATYPE_HPP
 #define RDF4CPP_LITERALDATATYPE_HPP
 
+#include <optional>
+
 #include <rdf4cpp/rdf/datatypes/registry/DatatypeID.hpp>
 #include <rdf4cpp/rdf/datatypes/registry/util/ConstexprString.hpp>
 #include <rdf4cpp/rdf/storage/node/identifier/LiteralType.hpp>
@@ -128,8 +130,10 @@ template<typename LiteralDatatypeImpl>
 concept FixedIdLiteralDatatype = LiteralDatatype<LiteralDatatypeImpl> && HasFixedId<LiteralDatatypeImpl>;
 
 template<typename LiteralDatatypeImpl>
-concept IsInlineable = requires {
+concept IsInlineable = requires (typename LiteralDatatypeImpl::cpp_type const &value, uint64_t inlined_value) {
                            { LiteralDatatypeImpl::is_inlineable } -> std::convertible_to<std::true_type>;
+                           { LiteralDatatypeImpl::try_into_inlined(value) } -> std::convertible_to<std::optional<uint64_t>>;
+                           { LiteralDatatypeImpl::from_inlined(inlined_value) } -> std::convertible_to<typename LiteralDatatypeImpl::cpp_type>;
                        };
 
 template<typename LiteralDatatypeImpl>

--- a/src/rdf4cpp/rdf/datatypes/LiteralDatatype.hpp
+++ b/src/rdf4cpp/rdf/datatypes/LiteralDatatype.hpp
@@ -127,5 +127,13 @@ concept HasFixedId = requires {
 template<typename LiteralDatatypeImpl>
 concept FixedIdLiteralDatatype = LiteralDatatype<LiteralDatatypeImpl> && HasFixedId<LiteralDatatypeImpl>;
 
+template<typename LiteralDatatypeImpl>
+concept IsInlineable = requires {
+                           { LiteralDatatypeImpl::is_inlineable } -> std::convertible_to<std::true_type>;
+                       };
+
+template<typename LiteralDatatypeImpl>
+concept InlineableLiteralDatatype = LiteralDatatype<LiteralDatatypeImpl> && IsInlineable<LiteralDatatypeImpl>;
+
 }  // namespace rdf4cpp::rdf::datatypes
 #endif  //RDF4CPP_LITERALDATATYPE_HPP

--- a/src/rdf4cpp/rdf/datatypes/registry/DatatypeRegistry.hpp
+++ b/src/rdf4cpp/rdf/datatypes/registry/DatatypeRegistry.hpp
@@ -32,7 +32,7 @@ public:
     using to_string_fptr_t = std::string (*)(const std::any &) noexcept;
     using ebv_fptr_t = bool (*)(std::any const &) noexcept;
     using can_inline_fptr_t = bool (*)(std::any const &) noexcept;
-    using to_inlined_fptr_t = uint64_t (*)(std::any const &) noexcept;
+    using try_into_inlined_fptr_t = std::optional<uint64_t> (*)(std::any const &) noexcept;
     using from_inlined_fptr_t = std::any (*)(uint64_t) noexcept;
 
     struct NumericOpResult {
@@ -89,8 +89,7 @@ public:
     };
 
     struct InliningOps {
-        can_inline_fptr_t can_inline_fptr;
-        to_inlined_fptr_t to_inlined_fptr;
+        try_into_inlined_fptr_t try_into_inlined_fptr;
         from_inlined_fptr_t from_inlined_fptr;
     };
 
@@ -611,13 +610,9 @@ inline DatatypeRegistry::NumericOpsImpl DatatypeRegistry::make_numeric_ops_impl(
 template<datatypes::InlineableLiteralDatatype LiteralDatatype_t>
 DatatypeRegistry::InliningOps DatatypeRegistry::make_inlining_ops() noexcept {
     return InliningOps {
-        .can_inline_fptr = [](std::any const &value) noexcept -> bool {
+        .try_into_inlined_fptr = [](std::any const &value) noexcept -> std::optional<uint64_t> {
             auto const &val = std::any_cast<typename LiteralDatatype_t::cpp_type>(value);
-            return LiteralDatatype_t::can_inline(val);
-        },
-        .to_inlined_fptr = [](std::any const &value) noexcept -> uint64_t {
-            auto const &val = std::any_cast<typename LiteralDatatype_t::cpp_type>(value);
-            return LiteralDatatype_t::to_inlined(val);
+            return LiteralDatatype_t::try_into_inlined(val);
         },
         .from_inlined_fptr = [](uint64_t inlined_value) noexcept -> std::any {
             return LiteralDatatype_t::from_inlined(inlined_value);

--- a/src/rdf4cpp/rdf/datatypes/registry/DatatypeRegistry.hpp
+++ b/src/rdf4cpp/rdf/datatypes/registry/DatatypeRegistry.hpp
@@ -90,8 +90,8 @@ public:
 
     struct InliningOps {
         can_inline_fptr_t can_inline_fptr;
-        from_inlined_fptr_t from_inlined_fptr;
         to_inlined_fptr_t to_inlined_fptr;
+        from_inlined_fptr_t from_inlined_fptr;
     };
 
     struct DatatypeEntry {
@@ -252,6 +252,12 @@ public:
      */
     inline static const registered_datatypes_t &registered_datatypes() noexcept {
         return DatatypeRegistry::get_mutable();
+    }
+
+    inline static std::optional<std::string_view> get_iri(DatatypeIDView const datatype_id) noexcept {
+        return find_map_entry(datatype_id, [](auto const &entry) noexcept -> std::string_view {
+            return entry.datatype_iri;
+        });
     }
 
     /**
@@ -606,11 +612,11 @@ template<datatypes::InlineableLiteralDatatype LiteralDatatype_t>
 DatatypeRegistry::InliningOps DatatypeRegistry::make_inlining_ops() noexcept {
     return InliningOps {
         .can_inline_fptr = [](std::any const &value) noexcept -> bool {
-            auto const &val = std::any_cast<LiteralDatatype_t::cpp_type>(value);
+            auto const &val = std::any_cast<typename LiteralDatatype_t::cpp_type>(value);
             return LiteralDatatype_t::can_inline(val);
         },
         .to_inlined_fptr = [](std::any const &value) noexcept -> uint64_t {
-            auto const &val = std::any_cast<LiteralDatatype_t::cpp_type>(value);
+            auto const &val = std::any_cast<typename LiteralDatatype_t::cpp_type>(value);
             return LiteralDatatype_t::to_inlined(val);
         },
         .from_inlined_fptr = [](uint64_t inlined_value) noexcept -> std::any {

--- a/src/rdf4cpp/rdf/datatypes/registry/LiteralDatatypeImpl.hpp
+++ b/src/rdf4cpp/rdf/datatypes/registry/LiteralDatatypeImpl.hpp
@@ -6,6 +6,8 @@
 #include <rdf4cpp/rdf/datatypes/registry/DatatypeRegistry.hpp>
 #include <rdf4cpp/rdf/datatypes/registry/FixedIdMappings.hpp>
 #include <rdf4cpp/rdf/datatypes/registry/util/ConstexprString.hpp>
+#include <rdf4cpp/rdf/datatypes/registry/util/Inlining.hpp>
+#include <rdf4cpp/rdf/storage/node/identifier/LiteralID.hpp>
 
 #include <cstddef>
 #include <sstream>
@@ -288,25 +290,42 @@ struct FixedId {
     static_assert(fixed_id.is_fixed(), "cannot treat non fixed id as fixed");
 };
 
+/**
+ * The capability for values to be inlined into the LiteralID part of the NodeID
+ */
 template<util::ConstexprString type_iri>
 struct Inlineable {
     using cpp_type = typename DatatypeMapping<type_iri>::cpp_datatype;
 
     static constexpr std::true_type is_inlineable{};
 
-    static bool can_inline([[maybe_unused]] cpp_type const &value) noexcept {
-        static_assert(detail::always_false_v<cpp_type>, "can_inline not implemented for inlineable type");
-        return {}; // silence gcc no-return warning
-    }
+    static std::optional<uint64_t> try_into_inlined([[maybe_unused]] cpp_type const &value) noexcept {
+        if constexpr (std::is_integral_v<cpp_type>) {
+            auto const inlined = util::pack<uint64_t>(value);
 
-    static uint64_t to_inlined([[maybe_unused]] cpp_type const &value) noexcept {
-        static_assert(detail::always_false_v<cpp_type>, "to_inlined not implemented for inlineable type");
-        return {}; // silence gcc no-return warning
+            if constexpr (sizeof(cpp_type) * 8 <= storage::node::identifier::LiteralID::width) {
+                // always fits
+                return inlined;
+            } else {
+                // check if no bits to the left of boundary set
+                if (inlined >> storage::node::identifier::LiteralID::width == 0) {
+                    return inlined;
+                }
+            }
+        } else {
+            static_assert(detail::always_false_v<cpp_type>, "to_inlined not implemented for inlineable type");
+        }
+
+        return std::nullopt;
     }
 
     static cpp_type from_inlined([[maybe_unused]] uint64_t inlined) noexcept {
-        static_assert(detail::always_false_v<cpp_type>, "from_inlined not implemented for inlineable type");
-        return {}; // silence gcc no-return warning
+        if constexpr (std::is_integral_v<cpp_type>) {
+            return util::unpack<cpp_type>(inlined);
+        } else {
+            static_assert(detail::always_false_v<cpp_type>, "from_inlined not implemented for inlineable type");
+            return {}; // silence gcc no-return warning
+        }
     }
 };
 

--- a/src/rdf4cpp/rdf/datatypes/registry/LiteralDatatypeImpl.hpp
+++ b/src/rdf4cpp/rdf/datatypes/registry/LiteralDatatypeImpl.hpp
@@ -291,7 +291,8 @@ struct FixedId {
 };
 
 /**
- * The capability for values to be inlined into the LiteralID part of the NodeID
+ * The capability for values to be inlined into the LiteralID part of the NodeID.
+ * @note this capability requires the FixedId capability, for more details see static_assert in LiteralDatatypeImpl
  */
 template<util::ConstexprString type_iri>
 struct Inlineable {

--- a/src/rdf4cpp/rdf/datatypes/registry/LiteralDatatypeImpl.hpp
+++ b/src/rdf4cpp/rdf/datatypes/registry/LiteralDatatypeImpl.hpp
@@ -288,6 +288,25 @@ struct FixedId {
     static_assert(fixed_id.is_fixed(), "cannot treat non fixed id as fixed");
 };
 
+template<util::ConstexprString type_iri>
+struct Inlineable {
+    using cpp_type = typename DatatypeMapping<type_iri>::cpp_datatype;
+
+    static constexpr std::true_type is_inlineable;
+
+    static bool can_inline(cpp_type const &value) noexcept {
+        static_assert(detail::always_false_v<cpp_type>);
+    }
+
+    static uint64_t to_inlined(cpp_type const &value) noexcept {
+        static_assert(detail::always_false_v<cpp_type>);
+    }
+
+    static cpp_type from_inlined(uint64_t inlined) noexcept {
+        static_assert(detail::always_false_v<cpp_type>);
+    }
+};
+
 } // namespace capabilities
 
 /**

--- a/src/rdf4cpp/rdf/datatypes/registry/LiteralDatatypeImpl.hpp
+++ b/src/rdf4cpp/rdf/datatypes/registry/LiteralDatatypeImpl.hpp
@@ -292,18 +292,21 @@ template<util::ConstexprString type_iri>
 struct Inlineable {
     using cpp_type = typename DatatypeMapping<type_iri>::cpp_datatype;
 
-    static constexpr std::true_type is_inlineable;
+    static constexpr std::true_type is_inlineable{};
 
-    static bool can_inline(cpp_type const &value) noexcept {
-        static_assert(detail::always_false_v<cpp_type>);
+    static bool can_inline([[maybe_unused]] cpp_type const &value) noexcept {
+        static_assert(detail::always_false_v<cpp_type>, "can_inline not implemented for inlineable type");
+        return {}; // silence gcc no-return warning
     }
 
-    static uint64_t to_inlined(cpp_type const &value) noexcept {
-        static_assert(detail::always_false_v<cpp_type>);
+    static uint64_t to_inlined([[maybe_unused]] cpp_type const &value) noexcept {
+        static_assert(detail::always_false_v<cpp_type>, "to_inlined not implemented for inlineable type");
+        return {}; // silence gcc no-return warning
     }
 
-    static cpp_type from_inlined(uint64_t inlined) noexcept {
-        static_assert(detail::always_false_v<cpp_type>);
+    static cpp_type from_inlined([[maybe_unused]] uint64_t inlined) noexcept {
+        static_assert(detail::always_false_v<cpp_type>, "from_inlined not implemented for inlineable type");
+        return {}; // silence gcc no-return warning
     }
 };
 
@@ -331,6 +334,11 @@ struct LiteralDatatypeImpl : capabilities::Default<type_iri>, Capabilities<type_
                   "Mismatch between declared and actual fixed id mapping state. "
                   "Hint: maybe you forgot declare the fixed id or to add the FixedId capability. "
                   "Note: this would cause inconsistency between registry and node storage");
+
+    static_assert(!IsInlineable<LiteralDatatypeImpl> || datatype_id.is_fixed(),
+                  "Inlineable datatypes are required to have a fixed id."
+                  "Hint: either make this datatype not inlineable or add a fixed id."
+                  "Note: inlineable datatypes with dynamic id would not be able to recover their IRI using the node storage handle.");
 private:
     static std::nullptr_t init() noexcept {
         DatatypeRegistry::add<LiteralDatatypeImpl>();

--- a/src/rdf4cpp/rdf/datatypes/registry/util/Inlining.hpp
+++ b/src/rdf4cpp/rdf/datatypes/registry/util/Inlining.hpp
@@ -125,7 +125,9 @@ constexpr std::optional<P> try_pack_integral(T value) noexcept {
 
         return pack<P>(value);
     } else {
-        if (auto const boundary = T{1} << (bits - 1); value >= boundary || value < -boundary) [[unlikely]] {
+        constexpr auto boundary = T{1} << (bits - 1);
+
+        if (value >= boundary || value < -boundary) [[unlikely]] {
             return std::nullopt;
         }
 

--- a/src/rdf4cpp/rdf/datatypes/registry/util/Inlining.hpp
+++ b/src/rdf4cpp/rdf/datatypes/registry/util/Inlining.hpp
@@ -82,13 +82,13 @@ constexpr T unpack(P packed_value) noexcept {
  */
 template<typename P, size_t bits, std::signed_integral T>
 constexpr P pack_signed(T value) noexcept {
-    // bits after boundary cannot hold any information
+    // bit at position bits - 1 must have the same value as every bit to the left of it
     assert(packing_detail::no_information_in_bits_after<bits - 1>(value));
 
-    // clear bits without information
     if constexpr (sizeof(T) * 8 > bits) {
-        P const clear_mask = (P{1} << bits) - 1;
-        value &= clear_mask;
+        // clear bits without information if necessary
+        P const keep_mask = (P{1} << bits) - 1;
+        value &= keep_mask;
     }
 
     return pack<P>(value);

--- a/src/rdf4cpp/rdf/datatypes/registry/util/Inlining.hpp
+++ b/src/rdf4cpp/rdf/datatypes/registry/util/Inlining.hpp
@@ -1,0 +1,48 @@
+#ifndef RDF4CPP_REGISTRY_UTIL_INLINING_HPP
+#define RDF4CPP_REGISTRY_UTIL_INLINING_HPP
+
+namespace rdf4cpp::rdf::datatypes::registry::util {
+
+/**
+ * @brief packs the bits of a value into the lower bits of a bigger type
+ * @tparam P bigger type to pack the bits into
+ * @tparam T smaller type to be packed
+ * @param value value to be packed
+ * @return the packed value
+ */
+template<typename P, typename T>
+constexpr P pack(T value) noexcept {
+    static_assert(sizeof(P) > sizeof(T));
+    static_assert(sizeof(P) % sizeof(T) == 0);
+
+    union {
+        std::array<T, sizeof(P) / sizeof(T)> source;
+        P target;
+    } reinterpret{ .source = {value} };
+
+    return reinterpret.target;
+}
+
+/**
+ * @brief reverse operation of pack
+ * @tparam T smaller type to be unpacked
+ * @tparam P bigger type that the value of T was packed into
+ * @param packed_value the packed value to unpack
+ * @return the unpacked value
+ */
+template<typename T, typename P>
+constexpr T unpack(P packed_value) noexcept {
+    static_assert(sizeof(P) > sizeof(T));
+    static_assert(sizeof(P) % sizeof(T) == 0);
+
+    union {
+        P source;
+        std::array<T, sizeof(P) / sizeof(T)> target;
+    } reinterpret{ .source = packed_value };
+
+    return reinterpret.target[0];
+}
+
+} // namespace rdf4cpp::rdf::datatypes::registry::util
+
+#endif  //RDF4CPP_REGISTRY_UTIL_INLINING_HPP

--- a/src/rdf4cpp/rdf/datatypes/registry/util/Inlining.hpp
+++ b/src/rdf4cpp/rdf/datatypes/registry/util/Inlining.hpp
@@ -1,6 +1,11 @@
 #ifndef RDF4CPP_REGISTRY_UTIL_INLINING_HPP
 #define RDF4CPP_REGISTRY_UTIL_INLINING_HPP
 
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cstddef>
+
 namespace rdf4cpp::rdf::datatypes::registry::util {
 
 namespace packing_detail {

--- a/src/rdf4cpp/rdf/datatypes/registry/util/Inlining.hpp
+++ b/src/rdf4cpp/rdf/datatypes/registry/util/Inlining.hpp
@@ -23,6 +23,11 @@ namespace packing_detail {
         P packed_value;
     };
 
+    /**
+     * @brief determines if the bit at position `bit` has the same value as every other higher bit after it
+     * @tparam bit last bit that is supposed to carry information
+     * @param value value to check
+     */
     template<size_t bit, typename T>
     constexpr bool no_information_in_bits_after(T value) noexcept {
         if constexpr (bit >= sizeof(T) * 8) {
@@ -67,6 +72,14 @@ constexpr T unpack(P packed_value) noexcept {
     return reinterpret.unpacked_value.value;
 }
 
+/**
+ * @brief packs the value of a signed integral type into the lower `bits` bits of P
+ * @tparam P type to pack into
+ * @tparam bits bits available in P for packing
+ * @tparam T to be packed type
+ * @param value to be packed value
+ * @return packed value
+ */
 template<typename P, size_t bits, std::signed_integral T>
 constexpr P pack_signed(T value) noexcept {
     // bits after boundary cannot hold any information
@@ -81,6 +94,9 @@ constexpr P pack_signed(T value) noexcept {
     return pack<P>(value);
 }
 
+/**
+ * @brief reverse operation of pack_signed
+ */
 template<std::signed_integral T, size_t bits, typename P>
 constexpr T unpack_signed(P packed_value) noexcept {
     auto const sign_ext_shift_amt = sizeof(T) * 8 - bits;
@@ -90,6 +106,14 @@ constexpr T unpack_signed(P packed_value) noexcept {
     return unpack<T>(packed_value) << sign_ext_shift_amt >> sign_ext_shift_amt;
 }
 
+/**
+ * @brief tries to pack any integral value into the lower `bits` bits of a value of type P
+ * @tparam P type to pack into
+ * @tparam bits bits available in P for packing
+ * @tparam T to be packed type
+ * @param value to be packed value
+ * @return the packed value if there was enough space to pack it, otherwise nullopt
+ */
 template<typename P, size_t bits, std::integral T>
 constexpr std::optional<P> try_pack_integral(T value) noexcept {
     if constexpr (sizeof(T) * 8 <= bits) {
@@ -109,6 +133,9 @@ constexpr std::optional<P> try_pack_integral(T value) noexcept {
     }
 }
 
+/**
+ * @brief reverse operation of pack_integral
+ */
 template<std::integral T, size_t bits, typename P>
 constexpr T unpack_integral(P packed_value) noexcept {
     if constexpr (sizeof(T) * 8 <= bits || std::unsigned_integral<T>) {

--- a/src/rdf4cpp/rdf/datatypes/registry/util/Inlining.hpp
+++ b/src/rdf4cpp/rdf/datatypes/registry/util/Inlining.hpp
@@ -10,25 +10,29 @@ namespace rdf4cpp::rdf::datatypes::registry::util {
 
 namespace packing_detail {
 
-    template<typename Source, typename Target>
+    template<typename P, typename T>
     union __attribute__((__packed__)) PackingHelper {
-        static constexpr size_t source_padding = sizeof(Target) > sizeof(Source) ? sizeof(Target) - sizeof(Source) : 0;
-        static constexpr size_t target_padding = sizeof(Source) > sizeof(Target) ? sizeof(Source) - sizeof(Target) : 0;
+        static_assert(sizeof(T) <= sizeof(P), "Packed into type must be at least as large as type to pack");
+        static constexpr size_t value_padding = sizeof(P) - sizeof(T);
 
         struct __attribute__((__packed__)) {
-            Source value;
-            std::array<std::byte, source_padding> pad{};
-        } source;
+            T value;
+            std::array<std::byte, value_padding> pad{};
+        } unpacked_value;
 
-        struct __attribute__((__packed__)) {
-            Target value;
-            std::array<std::byte, target_padding> pad{};
-        } target;
+        P packed_value;
     };
 
-    template<size_t N>
-    constexpr bool is_padding_empty(std::array<std::byte, N> const &pad) noexcept {
-        return std::all_of(pad.begin(), pad.end(), [](auto const byte) { return byte == std::byte{0}; });
+    template<size_t bit, typename T>
+    constexpr bool no_information_in_bits_after(T value) noexcept {
+        if constexpr (bit >= sizeof(T) * 8) {
+            return true;
+        } else {
+            auto const indicator_bit = (value >> bit) & 1;
+            auto const mask = ~((indicator_bit << (bit + 1)) - 1);
+
+            return value == (value | mask);
+        }
     }
 
 } // namespace packing_detail
@@ -42,9 +46,10 @@ namespace packing_detail {
  */
 template<typename P, typename T>
 constexpr P pack(T value) noexcept {
-    packing_detail::PackingHelper<T, P> reinterpret{ .source = { .value = value } };
-    assert(packing_detail::is_padding_empty(reinterpret.target.pad));
-    return reinterpret.target.value;
+    static_assert(sizeof(T) <= sizeof(P));
+
+    packing_detail::PackingHelper<P, T> reinterpret{ .unpacked_value = { .value = value } };
+    return reinterpret.packed_value;
 }
 
 /**
@@ -56,9 +61,61 @@ constexpr P pack(T value) noexcept {
  */
 template<typename T, typename P>
 constexpr T unpack(P packed_value) noexcept {
-    packing_detail::PackingHelper<P, T> reinterpret{ .source = { .value = packed_value } };
-    assert(packing_detail::is_padding_empty(reinterpret.target.pad));
-    return reinterpret.target.value;
+    static_assert(sizeof(T) <= sizeof(P));
+
+    packing_detail::PackingHelper<P, T> reinterpret{ .packed_value = packed_value };
+    return reinterpret.unpacked_value.value;
+}
+
+template<typename P, size_t bits, std::signed_integral T>
+constexpr P pack_signed(T value) noexcept {
+    // bits after boundary cannot hold any information
+    assert(packing_detail::no_information_in_bits_after<bits - 1>(value));
+
+    // clear bits without information
+    if constexpr (sizeof(T) * 8 > bits) {
+        P const clear_mask = (P{1} << bits) - 1;
+        value &= clear_mask;
+    }
+
+    return pack<P>(value);
+}
+
+template<std::signed_integral T, size_t bits, typename P>
+constexpr T unpack_signed(P packed_value) noexcept {
+    auto const sign_ext_shift_amt = sizeof(T) * 8 - bits;
+
+    // smear bit that indicates remaining/truncated bits to the left
+    // note: depends on arithmetic right shift (implementation defined)
+    return unpack<T>(packed_value) << sign_ext_shift_amt >> sign_ext_shift_amt;
+}
+
+template<typename P, size_t bits, std::integral T>
+constexpr std::optional<P> try_pack_integral(T value) noexcept {
+    if constexpr (sizeof(T) * 8 <= bits) {
+        return pack<P>(value);
+    } else if constexpr (std::unsigned_integral<T>) {
+        if (value >= (T{1} << bits)) [[unlikely]] {
+            return std::nullopt;
+        }
+
+        return pack<P>(value);
+    } else {
+        if (auto const boundary = T{1} << (bits - 1); value >= boundary || value < -boundary) [[unlikely]] {
+            return std::nullopt;
+        }
+
+        return pack_signed<P, bits>(value);
+    }
+}
+
+template<std::integral T, size_t bits, typename P>
+constexpr T unpack_integral(P packed_value) noexcept {
+    if constexpr (sizeof(T) * 8 <= bits || std::unsigned_integral<T>) {
+        return unpack<T>(packed_value);
+    } else {
+        return unpack_signed<T, bits>(packed_value);
+    }
 }
 
 } // namespace rdf4cpp::rdf::datatypes::registry::util

--- a/src/rdf4cpp/rdf/datatypes/xsd/Boolean.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Boolean.cpp
@@ -29,9 +29,20 @@ bool capabilities::Logical<xsd_boolean>::effective_boolean_value(cpp_type const 
     return value;
 }
 
+template<>
+std::optional<uint64_t> capabilities::Inlineable<xsd_boolean>::try_into_inlined(cpp_type const &value) noexcept {
+    return util::pack<uint64_t>(value);
+}
+
+template<>
+capabilities::Inlineable<xsd_boolean>::cpp_type capabilities::Inlineable<xsd_boolean>::from_inlined(uint64_t inlined) noexcept {
+    return util::unpack<bool>(inlined);
+}
+
 template struct LiteralDatatypeImpl<xsd_boolean,
                                     capabilities::Logical,
                                     capabilities::Comparable,
-                                    capabilities::FixedId>;
+                                    capabilities::FixedId,
+                                    capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry

--- a/src/rdf4cpp/rdf/datatypes/xsd/Boolean.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Boolean.hpp
@@ -26,10 +26,17 @@ std::string capabilities::Default<xsd_boolean>::to_string(const cpp_type &value)
 template<>
 bool capabilities::Logical<xsd_boolean>::effective_boolean_value(cpp_type const &value) noexcept;
 
+template<>
+std::optional<uint64_t> capabilities::Inlineable<xsd_boolean>::try_into_inlined(cpp_type const &value) noexcept;
+
+template<>
+capabilities::Inlineable<xsd_boolean>::cpp_type capabilities::Inlineable<xsd_boolean>::from_inlined(uint64_t inlined) noexcept;
+
 extern template struct LiteralDatatypeImpl<xsd_boolean,
                                            capabilities::Logical,
                                            capabilities::Comparable,
-                                           capabilities::FixedId>;
+                                           capabilities::FixedId,
+                                           capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry
 
@@ -39,7 +46,8 @@ namespace rdf4cpp::rdf::datatypes::xsd {
 struct Boolean : registry::LiteralDatatypeImpl<registry::xsd_boolean,
                                                registry::capabilities::Logical,
                                                registry::capabilities::Comparable,
-                                               registry::capabilities::FixedId> {};
+                                               registry::capabilities::FixedId,
+                                               registry::capabilities::Inlineable> {};
 
 }  // namespace rdf4cpp::rdf::datatypes::xsd
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/Double.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Double.cpp
@@ -25,9 +25,10 @@ std::optional<uint64_t> capabilities::Inlineable<xsd_double>::try_into_inlined(c
     static constexpr uint64_t drop_width = 64 - storage::node::identifier::LiteralID::width;
 
     auto const packed = util::pack<uint64_t>(value);
-    auto const shortened = packed >> drop_width;
+    auto const shortened = packed >> drop_width; // drop right bits of mantissa
 
     if (shortened << drop_width != packed) {
+        // dropped part contained information
         return std::nullopt;
     }
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/Double.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Double.cpp
@@ -20,10 +20,30 @@ bool capabilities::Logical<xsd_double>::effective_boolean_value(cpp_type const &
     return !std::isnan(value) && value != 0.0;
 }
 
+template<>
+std::optional<uint64_t> capabilities::Inlineable<xsd_double>::try_into_inlined(cpp_type const &value) noexcept {
+    static constexpr uint64_t drop_width = 64 - storage::node::identifier::LiteralID::width;
+
+    auto const packed = util::pack<uint64_t>(value);
+    auto const shortened = packed >> drop_width;
+
+    if (shortened << drop_width != packed) {
+        return std::nullopt;
+    }
+
+    return shortened;
+}
+
+template<>
+capabilities::Inlineable<xsd_double>::cpp_type capabilities::Inlineable<xsd_double>::from_inlined(uint64_t inlined) noexcept {
+    return util::unpack<double>(inlined << (64 - storage::node::identifier::LiteralID::width));
+}
+
 template struct LiteralDatatypeImpl<xsd_double,
                                     capabilities::Logical,
                                     capabilities::Numeric,
                                     capabilities::Comparable,
-                                    capabilities::FixedId>;
+                                    capabilities::FixedId,
+                                    capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry

--- a/src/rdf4cpp/rdf/datatypes/xsd/Double.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Double.cpp
@@ -25,7 +25,7 @@ std::optional<uint64_t> capabilities::Inlineable<xsd_double>::try_into_inlined(c
     static constexpr uint64_t drop_width = 64 - storage::node::identifier::LiteralID::width;
 
     auto const packed = util::pack<uint64_t>(value);
-    auto const shortened = packed >> drop_width; // drop right bits of mantissa
+    auto const shortened = packed >> drop_width; // drop right bits of mantissa (see https://en.wikipedia.org/wiki/Double-precision_floating-point_format)
 
     if (shortened << drop_width != packed) {
         // dropped part contained information

--- a/src/rdf4cpp/rdf/datatypes/xsd/Double.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Double.hpp
@@ -21,11 +21,18 @@ std::string capabilities::Default<xsd_double>::to_string(cpp_type const &value) 
 template<>
 bool capabilities::Logical<xsd_double>::effective_boolean_value(cpp_type const &value) noexcept;
 
+template<>
+std::optional<uint64_t> capabilities::Inlineable<xsd_double>::try_into_inlined(cpp_type const &value) noexcept;
+
+template<>
+capabilities::Inlineable<xsd_double>::cpp_type capabilities::Inlineable<xsd_double>::from_inlined(uint64_t inlined) noexcept;
+
 extern template struct LiteralDatatypeImpl<xsd_double,
                                            capabilities::Logical,
                                            capabilities::Numeric,
                                            capabilities::Comparable,
-                                           capabilities::FixedId>;
+                                           capabilities::FixedId,
+                                           capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry
 
@@ -36,7 +43,8 @@ struct Double : registry::LiteralDatatypeImpl<registry::xsd_double,
                                               registry::capabilities::Logical,
                                               registry::capabilities::Numeric,
                                               registry::capabilities::Comparable,
-                                              registry::capabilities::FixedId> {};
+                                              registry::capabilities::FixedId,
+                                              registry::capabilities::Inlineable> {};
 
 }  // namespace rdf4cpp::rdf::datatypes::xsd
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/Float.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Float.cpp
@@ -21,13 +21,22 @@ bool capabilities::Logical<xsd_float>::effective_boolean_value(cpp_type const &v
     return !std::isnan(value) && value != 0.f;
 }
 
+template<>
+std::optional<uint64_t> capabilities::Inlineable<xsd_float>::try_into_inlined(cpp_type const &value) noexcept {
+    return util::pack<uint64_t>(value);
+}
+
+template<>
+capabilities::Inlineable<xsd_float>::cpp_type capabilities::Inlineable<xsd_float>::from_inlined(uint64_t const inlined) noexcept {
+    return util::unpack<cpp_type>(inlined);
+}
+
 template struct LiteralDatatypeImpl<xsd_float,
                                     capabilities::Logical,
                                     capabilities::Numeric,
                                     capabilities::Comparable,
                                     capabilities::Promotable,
-                                    capabilities::FixedId>;
-
-template ConversionTable auto make_conversion_table_for<xsd::Float>();
+                                    capabilities::FixedId,
+                                    capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry

--- a/src/rdf4cpp/rdf/datatypes/xsd/Float.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Float.hpp
@@ -27,12 +27,19 @@ std::string capabilities::Default<xsd_float>::to_string(cpp_type const &value) n
 template<>
 bool capabilities::Logical<xsd_float>::effective_boolean_value(cpp_type const &value) noexcept;
 
+template<>
+std::optional<uint64_t> capabilities::Inlineable<xsd_float>::try_into_inlined(cpp_type const &value) noexcept;
+
+template<>
+capabilities::Inlineable<xsd_float>::cpp_type capabilities::Inlineable<xsd_float>::from_inlined(uint64_t inlined) noexcept;
+
 extern template struct LiteralDatatypeImpl<xsd_float,
                                            capabilities::Logical,
                                            capabilities::Numeric,
                                            capabilities::Comparable,
                                            capabilities::Promotable,
-                                           capabilities::FixedId>;
+                                           capabilities::FixedId,
+                                           capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry
 
@@ -44,7 +51,8 @@ struct Float : registry::LiteralDatatypeImpl<registry::xsd_float,
                                              registry::capabilities::Numeric,
                                              registry::capabilities::Comparable,
                                              registry::capabilities::Promotable,
-                                             registry::capabilities::FixedId> {};
+                                             registry::capabilities::FixedId,
+                                             registry::capabilities::Inlineable> {};
 
 }  // namespace rdf4cpp::rdf::datatypes::xsd
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/NonNegativeInteger.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/NonNegativeInteger.cpp
@@ -46,11 +46,26 @@ nonstd::expected<capabilities::Default<xsd_non_negative_integer>::cpp_type, Dyna
     return value;
 }
 
+template<>
+std::optional<uint64_t> capabilities::Inlineable<xsd_non_negative_integer>::try_into_inlined(cpp_type const &value) noexcept {
+    if (value >= (uint64_t{1} << storage::node::identifier::LiteralID::width)) {
+        return std::nullopt;
+    }
+
+    return util::try_pack_integral<uint64_t, storage::node::identifier::LiteralID::width>(static_cast<uint64_t>(value));
+}
+
+template<>
+capabilities::Inlineable<xsd_non_negative_integer>::cpp_type capabilities::Inlineable<xsd_non_negative_integer>::from_inlined(uint64_t inlined) noexcept {
+    return cpp_type{util::unpack_integral<uint64_t, storage::node::identifier::LiteralID::width>(inlined)};
+}
+
 template struct LiteralDatatypeImpl<xsd_non_negative_integer,
                                     capabilities::Logical,
                                     capabilities::NumericStub,
                                     capabilities::Comparable,
                                     capabilities::Subtype,
-                                    capabilities::FixedId>;
+                                    capabilities::FixedId,
+                                    capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/NonNegativeInteger.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/NonNegativeInteger.hpp
@@ -36,12 +36,19 @@ std::partial_ordering capabilities::Comparable<xsd_non_negative_integer>::compar
 template<>
 nonstd::expected<capabilities::Default<xsd_non_negative_integer>::cpp_type, DynamicError> capabilities::Subtype<xsd_non_negative_integer>::from_supertype(super_cpp_type const &value) noexcept;
 
+template<>
+std::optional<uint64_t> capabilities::Inlineable<xsd_non_negative_integer>::try_into_inlined(cpp_type const &value) noexcept;
+
+template<>
+capabilities::Inlineable<xsd_non_negative_integer>::cpp_type capabilities::Inlineable<xsd_non_negative_integer>::from_inlined(uint64_t inlined) noexcept;
+
 extern template struct LiteralDatatypeImpl<xsd_non_negative_integer,
                                            capabilities::Logical,
                                            capabilities::NumericStub,
                                            capabilities::Comparable,
                                            capabilities::Subtype,
-                                           capabilities::FixedId>;
+                                           capabilities::FixedId,
+                                           capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry
 
@@ -53,7 +60,8 @@ struct NonNegativeInteger : registry::LiteralDatatypeImpl<registry::xsd_non_nega
                                                           registry::capabilities::NumericStub,
                                                           registry::capabilities::Comparable,
                                                           registry::capabilities::Subtype,
-                                                          registry::capabilities::FixedId> {};
+                                                          registry::capabilities::FixedId,
+                                                          registry::capabilities::Inlineable> {};
 
 } // namespace rdf4cpp::rdf::datatypes::xsd
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/PositiveInteger.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/PositiveInteger.cpp
@@ -46,11 +46,27 @@ nonstd::expected<capabilities::Default<xsd_positive_integer>::cpp_type, DynamicE
     return value;
 }
 
+template<>
+std::optional<uint64_t> capabilities::Inlineable<xsd_positive_integer>::try_into_inlined(cpp_type const &value) noexcept {
+    auto const to_pack_value = value - 1;
+    if (to_pack_value >= (uint64_t{1} << storage::node::identifier::LiteralID::width)) {
+        return std::nullopt;
+    }
+
+    return util::try_pack_integral<uint64_t, storage::node::identifier::LiteralID::width>(static_cast<uint64_t>(to_pack_value));
+}
+
+template<>
+capabilities::Inlineable<xsd_positive_integer>::cpp_type capabilities::Inlineable<xsd_positive_integer>::from_inlined(uint64_t inlined) noexcept {
+    return cpp_type{util::unpack_integral<uint64_t, storage::node::identifier::LiteralID::width>(inlined)} + 1;
+}
+
 template struct LiteralDatatypeImpl<xsd_positive_integer,
                                     capabilities::Logical,
                                     capabilities::NumericStub,
                                     capabilities::Comparable,
                                     capabilities::Subtype,
-                                    capabilities::FixedId>;
+                                    capabilities::FixedId,
+                                    capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/PositiveInteger.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/PositiveInteger.hpp
@@ -37,12 +37,19 @@ std::partial_ordering capabilities::Comparable<xsd_positive_integer>::compare(cp
 template<>
 nonstd::expected<capabilities::Default<xsd_positive_integer>::cpp_type, DynamicError> capabilities::Subtype<xsd_positive_integer>::from_supertype(super_cpp_type const &value) noexcept;
 
+template<>
+std::optional<uint64_t> capabilities::Inlineable<xsd_positive_integer>::try_into_inlined(cpp_type const &value) noexcept;
+
+template<>
+capabilities::Inlineable<xsd_positive_integer>::cpp_type capabilities::Inlineable<xsd_positive_integer>::from_inlined(uint64_t inlined) noexcept;
+
 extern template struct LiteralDatatypeImpl<xsd_positive_integer,
                                            capabilities::Logical,
                                            capabilities::NumericStub,
                                            capabilities::Comparable,
                                            capabilities::Subtype,
-                                           capabilities::FixedId>;
+                                           capabilities::FixedId,
+                                           capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry
 
@@ -54,7 +61,8 @@ struct PositiveInteger : registry::LiteralDatatypeImpl<registry::xsd_positive_in
                                                        registry::capabilities::NumericStub,
                                                        registry::capabilities::Comparable,
                                                        registry::capabilities::Subtype,
-                                                       registry::capabilities::FixedId> {};
+                                                       registry::capabilities::FixedId,
+                                                       registry::capabilities::Inlineable> {};
 
 } // namespace rdf4cpp::rdf::datatypes::xsd
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedByte.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedByte.cpp
@@ -24,6 +24,7 @@ template struct LiteralDatatypeImpl<xsd_unsigned_byte,
                                     capabilities::NumericStub,
                                     capabilities::Subtype,
                                     capabilities::Comparable,
-                                    capabilities::FixedId>;
+                                    capabilities::FixedId,
+                                    capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedByte.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedByte.hpp
@@ -40,7 +40,8 @@ extern template struct LiteralDatatypeImpl<xsd_unsigned_byte,
                                            capabilities::NumericStub,
                                            capabilities::Subtype,
                                            capabilities::Comparable,
-                                           capabilities::FixedId>;
+                                           capabilities::FixedId,
+                                           capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry
 
@@ -52,7 +53,8 @@ struct UnsignedByte : registry::LiteralDatatypeImpl<registry::xsd_unsigned_byte,
                                                     registry::capabilities::NumericStub,
                                                     registry::capabilities::Subtype,
                                                     registry::capabilities::Comparable,
-                                                    registry::capabilities::FixedId> {};
+                                                    registry::capabilities::FixedId,
+                                                    registry::capabilities::Inlineable> {};
 
 }  // namespace rdf4cpp::rdf::datatypes::xsd
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedInt.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedInt.cpp
@@ -23,6 +23,7 @@ template struct LiteralDatatypeImpl<xsd_unsigned_int,
                                     capabilities::NumericStub,
                                     capabilities::Comparable,
                                     capabilities::Subtype,
-                                    capabilities::FixedId>;
+                                    capabilities::FixedId,
+                                    capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedInt.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedInt.hpp
@@ -40,7 +40,8 @@ extern template struct LiteralDatatypeImpl<xsd_unsigned_int,
                                            capabilities::NumericStub,
                                            capabilities::Comparable,
                                            capabilities::Subtype,
-                                           capabilities::FixedId>;
+                                           capabilities::FixedId,
+                                           capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry
 
@@ -52,7 +53,8 @@ struct UnsignedInt : registry::LiteralDatatypeImpl<registry::xsd_unsigned_int,
                                                    registry::capabilities::NumericStub,
                                                    registry::capabilities::Comparable,
                                                    registry::capabilities::Subtype,
-                                                   registry::capabilities::FixedId> {};
+                                                   registry::capabilities::FixedId,
+                                                   registry::capabilities::Inlineable> {};
 
 }  // namespace rdf4cpp::rdf::datatypes::xsd
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedLong.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedLong.cpp
@@ -32,6 +32,7 @@ template struct LiteralDatatypeImpl<xsd_unsigned_long,
                                     capabilities::NumericStub,
                                     capabilities::Subtype,
                                     capabilities::Comparable,
-                                    capabilities::FixedId>;
+                                    capabilities::FixedId,
+                                    capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedLong.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedLong.hpp
@@ -43,7 +43,8 @@ extern template struct LiteralDatatypeImpl<xsd_unsigned_long,
                                            capabilities::NumericStub,
                                            capabilities::Subtype,
                                            capabilities::Comparable,
-                                           capabilities::FixedId>;
+                                           capabilities::FixedId,
+                                           capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry
 
@@ -55,7 +56,8 @@ struct UnsignedLong : registry::LiteralDatatypeImpl<registry::xsd_unsigned_long,
                                                     registry::capabilities::NumericStub,
                                                     registry::capabilities::Subtype,
                                                     registry::capabilities::Comparable,
-                                                    registry::capabilities::FixedId> {};
+                                                    registry::capabilities::FixedId,
+                                                    registry::capabilities::Inlineable> {};
 
 }  // namespace rdf4cpp::rdf::datatypes::xsd
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedShort.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedShort.cpp
@@ -24,6 +24,7 @@ template struct LiteralDatatypeImpl<xsd_unsigned_short,
                                     capabilities::NumericStub,
                                     capabilities::Subtype,
                                     capabilities::Comparable,
-                                    capabilities::FixedId>;
+                                    capabilities::FixedId,
+                                    capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedShort.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedShort.hpp
@@ -40,7 +40,8 @@ extern template struct LiteralDatatypeImpl<xsd_unsigned_short,
                                            capabilities::NumericStub,
                                            capabilities::Subtype,
                                            capabilities::Comparable,
-                                           capabilities::FixedId>;
+                                           capabilities::FixedId,
+                                           capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry
 
@@ -52,7 +53,8 @@ struct UnsignedShort : registry::LiteralDatatypeImpl<registry::xsd_unsigned_shor
                                                      registry::capabilities::NumericStub,
                                                      registry::capabilities::Subtype,
                                                      registry::capabilities::Comparable,
-                                                     registry::capabilities::FixedId> {};
+                                                     registry::capabilities::FixedId,
+                                                     registry::capabilities::Inlineable> {};
 
 }  // namespace rdf4cpp::rdf::datatypes::xsd
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_positive/NegativeInteger.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_positive/NegativeInteger.cpp
@@ -46,11 +46,27 @@ nonstd::expected<capabilities::Default<xsd_negative_integer>::cpp_type, DynamicE
     return value;
 }
 
+template<>
+std::optional<uint64_t> capabilities::Inlineable<xsd_negative_integer>::try_into_inlined(cpp_type const &value) noexcept {
+    auto const to_pack_value = -value - 1;
+    if (to_pack_value >= (uint64_t{1} << storage::node::identifier::LiteralID::width)) {
+        return std::nullopt;
+    }
+
+    return util::try_pack_integral<uint64_t, storage::node::identifier::LiteralID::width>(static_cast<uint64_t>(to_pack_value));
+}
+
+template<>
+capabilities::Inlineable<xsd_negative_integer>::cpp_type capabilities::Inlineable<xsd_negative_integer>::from_inlined(uint64_t inlined) noexcept {
+    return -cpp_type{util::unpack_integral<uint64_t, storage::node::identifier::LiteralID::width>(inlined) + 1};
+}
+
 template struct LiteralDatatypeImpl<xsd_negative_integer,
                                     capabilities::Logical,
                                     capabilities::NumericStub,
                                     capabilities::Subtype,
                                     capabilities::Comparable,
-                                    capabilities::FixedId>;
+                                    capabilities::FixedId,
+                                    capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_positive/NegativeInteger.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_positive/NegativeInteger.hpp
@@ -40,12 +40,19 @@ std::partial_ordering capabilities::Comparable<xsd_negative_integer>::compare(cp
 template<>
 nonstd::expected<capabilities::Default<xsd_negative_integer>::cpp_type, DynamicError> capabilities::Subtype<xsd_negative_integer>::from_supertype(super_cpp_type const &value) noexcept;
 
+template<>
+std::optional<uint64_t> capabilities::Inlineable<xsd_negative_integer>::try_into_inlined(cpp_type const &value) noexcept;
+
+template<>
+capabilities::Inlineable<xsd_negative_integer>::cpp_type capabilities::Inlineable<xsd_negative_integer>::from_inlined(uint64_t inlined) noexcept;
+
 extern template struct LiteralDatatypeImpl<xsd_negative_integer,
                                            capabilities::Logical,
                                            capabilities::NumericStub,
                                            capabilities::Subtype,
                                            capabilities::Comparable,
-                                           capabilities::FixedId>;
+                                           capabilities::FixedId,
+                                           capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry
 
@@ -57,7 +64,8 @@ struct NegativeInteger : registry::LiteralDatatypeImpl<registry::xsd_negative_in
                                                        registry::capabilities::NumericStub,
                                                        registry::capabilities::Subtype,
                                                        registry::capabilities::Comparable,
-                                                       registry::capabilities::FixedId> {};
+                                                       registry::capabilities::FixedId,
+                                                       registry::capabilities::Inlineable> {};
 
 } //  rdf4cpp::rdf::datatypes::xsd
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_positive/NonPositiveInteger.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_positive/NonPositiveInteger.cpp
@@ -46,11 +46,27 @@ nonstd::expected<capabilities::Default<xsd_non_positive_integer>::cpp_type, Dyna
     return value;
 }
 
+template<>
+std::optional<uint64_t> capabilities::Inlineable<xsd_non_positive_integer>::try_into_inlined(cpp_type const &value) noexcept {
+    if (-value >= (uint64_t{1} << storage::node::identifier::LiteralID::width)) {
+        return std::nullopt;
+    }
+
+    return util::try_pack_integral<uint64_t, storage::node::identifier::LiteralID::width>(static_cast<uint64_t>(-value));
+}
+
+template<>
+capabilities::Inlineable<xsd_non_positive_integer>::cpp_type capabilities::Inlineable<xsd_non_positive_integer>::from_inlined(uint64_t inlined) noexcept {
+    return -cpp_type{util::unpack_integral<uint64_t, storage::node::identifier::LiteralID::width>(inlined)};
+}
+
+
 template struct LiteralDatatypeImpl<xsd_non_positive_integer,
                                     capabilities::Logical,
                                     capabilities::NumericStub,
                                     capabilities::Subtype,
                                     capabilities::Comparable,
-                                    capabilities::FixedId>;
+                                    capabilities::FixedId,
+                                    capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_positive/NonPositiveInteger.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_positive/NonPositiveInteger.hpp
@@ -37,12 +37,19 @@ std::partial_ordering capabilities::Comparable<xsd_non_positive_integer>::compar
 template<>
 nonstd::expected<capabilities::Default<xsd_non_positive_integer>::cpp_type, DynamicError> capabilities::Subtype<xsd_non_positive_integer>::from_supertype(super_cpp_type const &value) noexcept;
 
+template<>
+std::optional<uint64_t> capabilities::Inlineable<xsd_non_positive_integer>::try_into_inlined(cpp_type const &value) noexcept;
+
+template<>
+capabilities::Inlineable<xsd_non_positive_integer>::cpp_type capabilities::Inlineable<xsd_non_positive_integer>::from_inlined(uint64_t inlined) noexcept;
+
 extern template struct LiteralDatatypeImpl<xsd_non_positive_integer,
                                            capabilities::Logical,
                                            capabilities::NumericStub,
                                            capabilities::Subtype,
                                            capabilities::Comparable,
-                                           capabilities::FixedId>;
+                                           capabilities::FixedId,
+                                           capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry
 
@@ -54,7 +61,8 @@ struct NonPositiveInteger : registry::LiteralDatatypeImpl<registry::xsd_non_posi
                                                           registry::capabilities::NumericStub,
                                                           registry::capabilities::Subtype,
                                                           registry::capabilities::Comparable,
-                                                          registry::capabilities::FixedId> {};
+                                                          registry::capabilities::FixedId,
+                                                          registry::capabilities::Inlineable> {};
 
 } // namespace rdf4cpp::rdf::datatypes::xsd
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Byte.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Byte.cpp
@@ -24,6 +24,7 @@ template struct LiteralDatatypeImpl<xsd_byte,
                                     capabilities::NumericStub,
                                     capabilities::Subtype,
                                     capabilities::Comparable,
-                                    capabilities::FixedId>;
+                                    capabilities::FixedId,
+                                    capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Byte.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Byte.hpp
@@ -41,7 +41,8 @@ extern template struct LiteralDatatypeImpl<xsd_byte,
                                            capabilities::NumericStub,
                                            capabilities::Subtype,
                                            capabilities::Comparable,
-                                           capabilities::FixedId>;
+                                           capabilities::FixedId,
+                                           capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry
 
@@ -53,7 +54,8 @@ struct Byte : registry::LiteralDatatypeImpl<registry::xsd_byte,
                                             registry::capabilities::NumericStub,
                                             registry::capabilities::Subtype,
                                             registry::capabilities::Comparable,
-                                            registry::capabilities::FixedId> {};
+                                            registry::capabilities::FixedId,
+                                            registry::capabilities::Inlineable> {};
 
 }  // namespace rdf4cpp::rdf::datatypes::xsd
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Int.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Int.cpp
@@ -1,5 +1,6 @@
 #include <rdf4cpp/rdf/datatypes/xsd/integers/signed/Int.hpp>
 #include <rdf4cpp/rdf/datatypes/registry/util/CharConvExt.hpp>
+#include <rdf4cpp/rdf/datatypes/registry/util/Inlining.hpp>
 
 namespace rdf4cpp::rdf::datatypes::registry {
 
@@ -18,11 +19,27 @@ bool capabilities::Logical<xsd_int>::effective_boolean_value(cpp_type const &val
     return value != 0;
 }
 
+template<>
+bool capabilities::Inlineable<xsd_int>::can_inline(cpp_type const &) noexcept {
+    return true;
+}
+
+template<>
+uint64_t capabilities::Inlineable<xsd_int>::to_inlined(cpp_type const &value) noexcept {
+    return util::pack<uint64_t>(value);
+}
+
+template<>
+capabilities::Inlineable<xsd_int>::cpp_type capabilities::Inlineable<xsd_int>::from_inlined(uint64_t const inlined) noexcept {
+    return util::unpack<cpp_type>(inlined);
+}
+
 template struct LiteralDatatypeImpl<xsd_int,
                                     capabilities::Logical,
                                     capabilities::NumericStub,
                                     capabilities::Comparable,
                                     capabilities::Subtype,
-                                    capabilities::FixedId>;
+                                    capabilities::FixedId,
+                                    capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Int.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Int.cpp
@@ -19,21 +19,6 @@ bool capabilities::Logical<xsd_int>::effective_boolean_value(cpp_type const &val
     return value != 0;
 }
 
-template<>
-bool capabilities::Inlineable<xsd_int>::can_inline(cpp_type const &) noexcept {
-    return true;
-}
-
-template<>
-uint64_t capabilities::Inlineable<xsd_int>::to_inlined(cpp_type const &value) noexcept {
-    return util::pack<uint64_t>(value);
-}
-
-template<>
-capabilities::Inlineable<xsd_int>::cpp_type capabilities::Inlineable<xsd_int>::from_inlined(uint64_t const inlined) noexcept {
-    return util::unpack<cpp_type>(inlined);
-}
-
 template struct LiteralDatatypeImpl<xsd_int,
                                     capabilities::Logical,
                                     capabilities::NumericStub,

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Int.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Int.hpp
@@ -35,15 +35,6 @@ std::string capabilities::Default<xsd_int>::to_string(cpp_type const &value) noe
 template<>
 bool capabilities::Logical<xsd_int>::effective_boolean_value(cpp_type const &value) noexcept;
 
-template<>
-bool capabilities::Inlineable<xsd_int>::can_inline(cpp_type const &value) noexcept;
-
-template<>
-uint64_t capabilities::Inlineable<xsd_int>::to_inlined(cpp_type const &value) noexcept;
-
-template<>
-capabilities::Inlineable<xsd_int>::cpp_type capabilities::Inlineable<xsd_int>::from_inlined(uint64_t const inlined) noexcept;
-
 extern template struct LiteralDatatypeImpl<xsd_int,
                                            capabilities::Logical,
                                            capabilities::NumericStub,

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Int.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Int.hpp
@@ -35,12 +35,22 @@ std::string capabilities::Default<xsd_int>::to_string(cpp_type const &value) noe
 template<>
 bool capabilities::Logical<xsd_int>::effective_boolean_value(cpp_type const &value) noexcept;
 
+template<>
+bool capabilities::Inlineable<xsd_int>::can_inline(cpp_type const &value) noexcept;
+
+template<>
+uint64_t capabilities::Inlineable<xsd_int>::to_inlined(cpp_type const &value) noexcept;
+
+template<>
+capabilities::Inlineable<xsd_int>::cpp_type capabilities::Inlineable<xsd_int>::from_inlined(uint64_t const inlined) noexcept;
+
 extern template struct LiteralDatatypeImpl<xsd_int,
                                            capabilities::Logical,
                                            capabilities::NumericStub,
                                            capabilities::Comparable,
                                            capabilities::Subtype,
-                                           capabilities::FixedId>;
+                                           capabilities::FixedId,
+                                           capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry
 
@@ -52,7 +62,8 @@ struct Int : registry::LiteralDatatypeImpl<registry::xsd_int,
                                            registry::capabilities::NumericStub,
                                            registry::capabilities::Comparable,
                                            registry::capabilities::Subtype,
-                                           registry::capabilities::FixedId> {};
+                                           registry::capabilities::FixedId,
+                                           registry::capabilities::Inlineable> {};
 
 }  // namespace rdf4cpp::rdf::datatypes::xsd
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Integer.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Integer.cpp
@@ -44,11 +44,26 @@ std::partial_ordering capabilities::Comparable<xsd_integer>::compare(cpp_type co
     }
 }
 
+template<>
+std::optional<uint64_t> capabilities::Inlineable<xsd_integer>::try_into_inlined(cpp_type const &value) noexcept {
+    if (auto const boundary = 1l << (storage::node::identifier::LiteralID::width - 1); value >= boundary || value < -boundary) [[unlikely]] {
+        return std::nullopt;
+    }
+
+    return util::try_pack_integral<uint64_t, storage::node::identifier::LiteralID::width>(static_cast<int64_t>(value));
+}
+
+template<>
+capabilities::Inlineable<xsd_integer>::cpp_type capabilities::Inlineable<xsd_integer>::from_inlined(uint64_t inlined) noexcept {
+    return cpp_type{util::unpack_integral<int64_t, storage::node::identifier::LiteralID::width>(inlined)};
+}
+
 template struct LiteralDatatypeImpl<xsd_integer,
                                     capabilities::Logical,
                                     capabilities::Numeric,
                                     capabilities::Comparable,
                                     capabilities::Subtype,
-                                    capabilities::FixedId>;
+                                    capabilities::FixedId,
+                                    capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Integer.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Integer.hpp
@@ -37,12 +37,19 @@ nonstd::expected<capabilities::Numeric<xsd_integer>::div_result_cpp_type, Dynami
 template<>
 std::partial_ordering capabilities::Comparable<xsd_integer>::compare(cpp_type const &lhs, cpp_type const &rhs) noexcept;
 
+template<>
+std::optional<uint64_t> capabilities::Inlineable<xsd_integer>::try_into_inlined(cpp_type const &value) noexcept;
+
+template<>
+capabilities::Inlineable<xsd_integer>::cpp_type capabilities::Inlineable<xsd_integer>::from_inlined(uint64_t inlined) noexcept;
+
 extern template struct LiteralDatatypeImpl<xsd_integer,
                                            capabilities::Logical,
                                            capabilities::Numeric,
                                            capabilities::Comparable,
                                            capabilities::Subtype,
-                                           capabilities::FixedId>;
+                                           capabilities::FixedId,
+                                           capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry
 
@@ -54,7 +61,8 @@ struct Integer : registry::LiteralDatatypeImpl<registry::xsd_integer,
                                                registry::capabilities::Numeric,
                                                registry::capabilities::Comparable,
                                                registry::capabilities::Subtype,
-                                               registry::capabilities::FixedId> {};
+                                               registry::capabilities::FixedId,
+                                               registry::capabilities::Inlineable> {};
 
 }  // namespace rdf4cpp::rdf::datatypes::xsd
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Long.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Long.cpp
@@ -32,6 +32,7 @@ template struct LiteralDatatypeImpl<xsd_long,
                                     capabilities::NumericStub,
                                     capabilities::Subtype,
                                     capabilities::Comparable,
-                                    capabilities::FixedId>;
+                                    capabilities::FixedId,
+                                    capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Long.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Long.hpp
@@ -42,7 +42,8 @@ extern template struct LiteralDatatypeImpl<xsd_long,
                                            capabilities::NumericStub,
                                            capabilities::Subtype,
                                            capabilities::Comparable,
-                                           capabilities::FixedId>;
+                                           capabilities::FixedId,
+                                           capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry
 
@@ -54,7 +55,8 @@ struct Long : registry::LiteralDatatypeImpl<registry::xsd_long,
                                             registry::capabilities::NumericStub,
                                             registry::capabilities::Subtype,
                                             registry::capabilities::Comparable,
-                                            registry::capabilities::FixedId> {};
+                                            registry::capabilities::FixedId,
+                                            registry::capabilities::Inlineable> {};
 
 }  // namespace rdf4cpp::rdf::datatypes::xsd
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Short.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Short.cpp
@@ -24,6 +24,7 @@ template struct LiteralDatatypeImpl<xsd_short,
                                     capabilities::NumericStub,
                                     capabilities::Subtype,
                                     capabilities::Comparable,
-                                    capabilities::FixedId>;
+                                    capabilities::FixedId,
+                                    capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Short.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Short.hpp
@@ -41,7 +41,8 @@ extern template struct LiteralDatatypeImpl<xsd_short,
                                            capabilities::NumericStub,
                                            capabilities::Subtype,
                                            capabilities::Comparable,
-                                           capabilities::FixedId>;
+                                           capabilities::FixedId,
+                                           capabilities::Inlineable>;
 
 }  // namespace rdf4cpp::rdf::datatypes::registry
 
@@ -53,7 +54,8 @@ struct Short : registry::LiteralDatatypeImpl<registry::xsd_short,
                                              registry::capabilities::NumericStub,
                                              registry::capabilities::Subtype,
                                              registry::capabilities::Comparable,
-                                             registry::capabilities::FixedId> {};
+                                             registry::capabilities::FixedId,
+                                             registry::capabilities::Inlineable> {};
 
 }  // namespace rdf4cpp::rdf::datatypes::xsd
 

--- a/src/rdf4cpp/rdf/storage/node/identifier/NodeBackendHandle.cpp
+++ b/src/rdf4cpp/rdf/storage/node/identifier/NodeBackendHandle.cpp
@@ -31,7 +31,6 @@ struct __attribute__((__packed__)) NodeBackendHandleImpl {
             NodeStorageID::underlying_type storage_id_ : NodeStorageID::width;
             uint8_t inlined : 1;
             uint8_t free_tagging_bits : 3;
-
         } fields_;
     };
 
@@ -100,8 +99,17 @@ NodeStorageID NodeBackendHandle::node_storage_id() const noexcept {
 NodeBackendHandle::NodeBackendHandle(NodeID node_id, RDFNodeType node_type, NodeStorageID node_storage_id, bool inlined, uint8_t tagging_bits) noexcept
     : raw_(unsafe_copy_cast<uint64_t>(NodeBackendHandleImpl{node_id, node_type, node_storage_id, inlined, tagging_bits})) {}
 
+NodeBackendHandle NodeBackendHandle::datatype_iri_handle_for_fixed_lit_handle(NodeBackendHandle lit_handle) noexcept {
+    assert(lit_handle.is_literal());
+    assert(lit_handle.node_id().literal_type().is_fixed());
+    return NodeBackendHandle{NodeID{static_cast<uint64_t>(lit_handle.node_id().literal_type().to_underlying())},
+                             storage::node::identifier::RDFNodeType::IRI,
+                             lit_handle.node_storage_id()};
+}
+
 uint64_t NodeBackendHandle::raw() const noexcept {
     return raw_;
 }
+
 
 }  // namespace rdf4cpp::rdf::storage::node::identifier

--- a/src/rdf4cpp/rdf/storage/node/identifier/NodeBackendHandle.hpp
+++ b/src/rdf4cpp/rdf/storage/node/identifier/NodeBackendHandle.hpp
@@ -32,7 +32,7 @@ public:
      * @param node_storage_id  the NodeStorageID
      * @param tagging_bits tagging bits (must be all zero for usage with the backend)
      */
-    explicit NodeBackendHandle(NodeID node_id, RDFNodeType node_type, NodeStorageID node_storage_id, uint8_t tagging_bits = {}) noexcept;
+    explicit NodeBackendHandle(NodeID node_id, RDFNodeType node_type, NodeStorageID node_storage_id, bool inlined = false, uint8_t tagging_bits = {}) noexcept;
 
     /**
      * Get the RDFNodeType
@@ -78,6 +78,11 @@ public:
      * @return
      */
     [[nodiscard]] NodeID node_id() const noexcept;
+
+    /**
+     * @return Whether the LiteralID is an inlined value or a normal node storage ID
+     */
+    [[nodiscard]] bool is_inlined() const noexcept;
 
     /**
      * Get the free tagging bits

--- a/src/rdf4cpp/rdf/storage/node/identifier/NodeBackendHandle.hpp
+++ b/src/rdf4cpp/rdf/storage/node/identifier/NodeBackendHandle.hpp
@@ -35,6 +35,13 @@ public:
     explicit NodeBackendHandle(NodeID node_id, RDFNodeType node_type, NodeStorageID node_storage_id, bool inlined = false, uint8_t tagging_bits = {}) noexcept;
 
     /**
+     * Constructor to create an IRI handle for the datatype of a Literal with fixed id datatype
+     * @param lit_handle handle of the literal
+     * @return handle to the datatype of the literal
+     */
+    [[nodiscard]] static NodeBackendHandle datatype_iri_handle_for_fixed_lit_handle(NodeBackendHandle lit_handle) noexcept;
+
+    /**
      * Get the RDFNodeType
      * @returnRDFNodeType
      */

--- a/src/rdf4cpp/rdf/storage/node/identifier/README.md
+++ b/src/rdf4cpp/rdf/storage/node/identifier/README.md
@@ -5,12 +5,14 @@ rdf4cpp uses `NodeBackendHandle` – a 64 bit wide type – to identify `Node`s 
 The following figure gives an overview of its memory layout.
 ```
 LSB                                                          MSB
-┣━━━━━━━━━━━━━━━━ NodeBackendHandle (64 bit) ━━━━━━━━━━━━━━━━━━┫
-├────────────── NodeID (48 bit) ───────────────┤├┤├────────┤├──┤
-├───────── LiteralID (42 bit) ───────────┤├────┤^     ^      ^
-                                            ^   |     |      |
-                                            |   |     |      free tagging bits (4 bit)
-                          LiteralType (6 bit)   |     |
+┣━━━━━━━━━━━━━━━━ NodeBackendHandle (64 bit) ━━━━━━━━━━━━━━━━━━━┫
+├────────────── NodeID (48 bit) ───────────────┤├┤├────────┤├┤├─┤
+├───────── LiteralID (42 bit) ───────────┤├────┤^     ^     ^  ^
+                                            ^   |     |     |   |
+                                            |   |     |     |   free tagging bits (3 bit)
+                          LiteralType (6 bit)   |     |     |
+                                                |     |     inlining tagging bit (1 bit)
+                                                |     |
                                                 |     NodeStorageID (10 bit)
                                                 |
                                                 NodeType (2 bit)                                                                                               
@@ -19,9 +21,12 @@ LSB                                                          MSB
 `NodeID` is the most frequently used identifier and is thus aligned with the LSB. 
 In the following, the parts of `NodeBackendHandle` will be explained starting from the most significant bits because the parts in the less significant depend on the parts in the more significant bits.  
 
-## Free Tagging Bits (4 bit)
-
+## Free Tagging Bits (3 bit)
 The _free tagging bits_ can be used by the internal storage to store 4 bit of information. Before calling any functions on a `NodeBackendHandle` the _free tagging bits_ must be reset to 0 again.  
+
+## Inlinining tagging bit (1 bit)
+The _inlinining tagging bit_ indicates whether the value of the node is stored directly (in-place) inside the NodeID
+instead of the node storage.
 
 ## `NodeStorageID` (10 bit) 
 The `NodeStorageID` identifies the `NodeStorage` in which the identified `Node` is stored.

--- a/src/rdf4cpp/rdf/util/CowString.hpp
+++ b/src/rdf4cpp/rdf/util/CowString.hpp
@@ -66,6 +66,28 @@ public:
     }
 
     /**
+     * Converts this CowString into std::string by copy
+     */
+    [[nodiscard]] constexpr std::string into_owned() const & noexcept {
+        if (this->is_borrowed()) {
+            return std::string{this->get_borrowed()};
+        }
+
+        return this->get_owned();
+    }
+
+    /**
+     * Converts this CowString into std::string (by move if the owned form is active)
+     */
+    [[nodiscard]] constexpr std::string into_owned() && noexcept {
+        if (this->is_borrowed()) {
+            return std::string{this->get_borrowed()};
+        }
+
+        return std::move(this->get_owned());
+    }
+
+    /**
      * Returns a non-const reference to the owned form of the data (std::string)
      * Converts the data to the owned for if it is currently the borrowed form
      */

--- a/src/rdf4cpp/rdf/util/CowString.hpp
+++ b/src/rdf4cpp/rdf/util/CowString.hpp
@@ -1,0 +1,63 @@
+#ifndef RDF4CPP_UTIL_COWSTRING_HPP
+#define RDF4CPP_UTIL_COWSTRING_HPP
+
+#include <string>
+#include <string_view>
+#include <variant>
+
+namespace rdf4cpp::rdf::util {
+
+struct CowString {
+private:
+    using repr_t = std::variant<std::string, std::string_view>;
+    repr_t data;
+
+public:
+    CowString(std::string const &value) : data{value} {}
+    CowString(std::string &&value) : data{std::move(value)} {}
+    CowString(std::string_view const value) : data{value} {}
+
+    inline operator std::string_view() const noexcept {
+        return std::visit([](auto const &value) noexcept -> std::string_view {
+            return value;
+        }, this->data);
+    }
+
+    inline operator std::string() const noexcept {
+        return std::string{*this};
+    }
+
+    inline std::strong_ordering operator<=>(CowString const &other) const noexcept {
+        return static_cast<std::string_view>(*this) <=> static_cast<std::string_view>(other);
+    }
+
+    inline friend std::strong_ordering operator<=>(CowString const &lhs, char const *rhs) noexcept {
+        return static_cast<std::string_view>(lhs) <=> rhs;
+    }
+
+    inline friend std::strong_ordering operator<=>(char const *lhs, CowString const &rhs) noexcept {
+        return lhs <=> static_cast<std::string_view>(rhs);
+    }
+
+    inline friend std::strong_ordering operator<=>(CowString const &lhs, std::string_view const rhs) noexcept {
+        return static_cast<std::string_view>(lhs) <=> rhs;
+    }
+
+    inline friend std::strong_ordering operator<=>(std::string_view const lhs, CowString const &rhs) noexcept {
+        return lhs <=> static_cast<std::string_view>(rhs);
+    }
+
+    template<size_t N>
+    friend std::strong_ordering operator<=>(CowString const &lhs, char const (&rhs)[N]) noexcept {
+        return static_cast<std::string_view>(lhs) <=> rhs;
+    }
+
+    template<size_t N>
+    friend std::strong_ordering operator<=>(char const (&lhs)[N], CowString const &rhs) noexcept {
+        return lhs <=> static_cast<std::string_view>(rhs);
+    }
+};
+
+} // namespace rdf4cpp::rdf::util
+
+#endif  //RDF4CPP_UTIL_COWSTRING_HPP

--- a/src/rdf4cpp/rdf/util/CowString.hpp
+++ b/src/rdf4cpp/rdf/util/CowString.hpp
@@ -32,10 +32,10 @@ private:
 public:
     constexpr CowString(ownership_tag::Borrowed, std::string_view const value) noexcept : data{std::in_place_type<std::string_view>, value} {}
 
-    constexpr CowString(ownership_tag::Owned, std::string const &value) : data{std::in_place_type<std::string>, value} {}
-    constexpr CowString(ownership_tag::Owned, std::string &&value) noexcept : data{std::in_place_type<std::string>, std::move(value)} {}
+    inline CowString(ownership_tag::Owned, std::string const &value) : data{std::in_place_type<std::string>, value} {}
+    inline CowString(ownership_tag::Owned, std::string &&value) noexcept : data{std::in_place_type<std::string>, std::move(value)} {}
 
-    inline operator std::string_view() const noexcept {
+    constexpr operator std::string_view() const noexcept {
         return this->view();
     }
 
@@ -68,7 +68,7 @@ public:
     /**
      * Converts this CowString into std::string by copy
      */
-    [[nodiscard]] constexpr std::string into_owned() const & noexcept {
+    [[nodiscard]] inline std::string into_owned() const & noexcept {
         if (this->is_borrowed()) {
             return std::string{this->get_borrowed()};
         }
@@ -79,7 +79,7 @@ public:
     /**
      * Converts this CowString into std::string (by move if the owned form is active)
      */
-    [[nodiscard]] constexpr std::string into_owned() && noexcept {
+    [[nodiscard]] inline std::string into_owned() && noexcept {
         if (this->is_borrowed()) {
             return std::string{this->get_borrowed()};
         }
@@ -91,7 +91,7 @@ public:
      * Returns a non-const reference to the owned form of the data (std::string)
      * Converts the data to the owned for if it is currently the borrowed form
      */
-    [[nodiscard]] constexpr std::string &to_mutable() noexcept {
+    [[nodiscard]] inline std::string &to_mutable() noexcept {
         if (this->is_borrowed()) {
             this->data = std::string{this->get_borrowed()};
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -215,6 +215,14 @@ target_link_libraries(tests_NonNegativeInteger
 set_property(TARGET tests_NonNegativeInteger PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_NonNegativeInteger COMMAND tests_NonNegativeInteger)
 
+add_executable(tests_CowString util/tests_CowString.cpp)
+target_link_libraries(tests_CowString
+        doctest
+        rdf4cpp
+        )
+set_property(TARGET tests_CowString PROPERTY CXX_STANDARD 20)
+add_test(NAME tests_CowString COMMAND tests_CowString)
+
 add_executable(tests_TriBool util/tests_TriBool.cpp)
 target_link_libraries(tests_TriBool
         doctest

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -223,6 +223,14 @@ target_link_libraries(tests_TriBool
 set_property(TARGET tests_TriBool PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_TriBool COMMAND tests_TriBool)
 
+add_executable(tests_Inlining util/tests_Inlining.cpp)
+target_link_libraries(tests_Inlining
+        doctest
+        rdf4cpp
+        )
+set_property(TARGET tests_Inlining PROPERTY CXX_STANDARD 20)
+add_test(NAME tests_Inlining COMMAND tests_Inlining)
+
 add_executable(tests_LangString datatype/tests_LangString.cpp)
 target_link_libraries(tests_LangString
         doctest

--- a/tests/datatype/tests_Double.cpp
+++ b/tests/datatype/tests_Double.cpp
@@ -88,3 +88,10 @@ TEST_CASE("Datatype Double") {
 
     CHECK_THROWS(no_discard_dummy = Literal("454sdsd", type_iri));
 }
+
+TEST_CASE("double inlining") {
+    double value = 9999;
+    auto lit = Literal::make<datatypes::xsd::Double>(value);
+    CHECK(lit.backend_handle().is_inlined());
+    CHECK(lit.value<datatypes::xsd::Double>() == value);
+}

--- a/tests/datatype/tests_Float.cpp
+++ b/tests/datatype/tests_Float.cpp
@@ -110,3 +110,13 @@ TEST_CASE("round-trip") {
     std::cout << lit.lexical_form() << std::endl;
     CHECK(lit.value<datatypes::xsd::Float>() == value);
 }
+
+TEST_CASE("inlining") {
+    using datatypes::xsd::Float;
+
+    Float::cpp_type f = 123.89f;
+    auto const inlined = Float::try_into_inlined(f);
+    auto const deinlined = Float::from_inlined(*inlined);
+
+    CHECK(f == deinlined);
+}

--- a/tests/datatype/tests_Int.cpp
+++ b/tests/datatype/tests_Int.cpp
@@ -4,6 +4,7 @@
 #include <rdf4cpp/rdf.hpp>
 
 using namespace rdf4cpp::rdf;
+using namespace datatypes;
 
 TEST_CASE("Datatype Int") {
 
@@ -76,4 +77,32 @@ TEST_CASE("Datatype Int") {
     CHECK_THROWS(no_discard_dummy = Literal("-2147483648.0001", type_iri));
 
     CHECK_THROWS(no_discard_dummy = Literal("a23dg.59566", type_iri));
+}
+
+TEST_CASE("32bit positive int inlining") {
+    auto const i = std::numeric_limits<xsd::Int::cpp_type>::max();
+    auto const lit1 = Literal::make<xsd::Int>(i);
+    auto const lit2 = Literal::make(std::to_string(i), IRI{xsd::Int::identifier});
+    CHECK(lit1.backend_handle().is_inlined());
+    CHECK(lit2.backend_handle().is_inlined());
+    CHECK(lit1 == lit2);
+
+    auto const extracted1 = lit1.template value<xsd::Int>();
+    auto const extracted2 = lit2.value();
+    CHECK(extracted1 == i);
+    CHECK(std::any_cast<xsd::Int::cpp_type>(extracted2) == i);
+}
+
+TEST_CASE("32bit negative int inlining") {
+    auto const i = std::numeric_limits<xsd::Int::cpp_type>::min();
+    auto const lit1 = Literal::make<xsd::Int>(i);
+    auto const lit2 = Literal::make(std::to_string(i), IRI{xsd::Int::identifier});
+    CHECK(lit1.backend_handle().is_inlined());
+    CHECK(lit2.backend_handle().is_inlined());
+    CHECK(lit1 == lit2);
+
+    auto const extracted1 = lit1.template value<xsd::Int>();
+    auto const extracted2 = lit2.value();
+    CHECK(extracted1 == i);
+    CHECK(std::any_cast<xsd::Int::cpp_type>(extracted2) == i);
 }

--- a/tests/datatype/tests_Integer.cpp
+++ b/tests/datatype/tests_Integer.cpp
@@ -4,6 +4,7 @@
 #include <rdf4cpp/rdf.hpp>
 
 using namespace rdf4cpp::rdf;
+using namespace datatypes;
 
 TEST_CASE("integer capabilities") {
     static_assert(datatypes::LiteralDatatype<datatypes::xsd::Integer>);
@@ -89,4 +90,16 @@ TEST_CASE("other int types serializing") {
 
     auto lit1 = Literal::make<Int>(std::numeric_limits<Int::cpp_type>::min());
     CHECK(lit1.lexical_form() == std::to_string(std::numeric_limits<Int::cpp_type>::min()));
+}
+
+TEST_CASE("integer inlining") {
+    SUBCASE("small") {
+        auto lit = Literal::make<xsd::Integer>((1l << 41) - 1);
+        CHECK(lit.backend_handle().is_inlined());
+    }
+
+    SUBCASE("too large") {
+        auto lit = Literal::make<xsd::Integer>(xsd::Integer::cpp_type{"9999999999999999999999"});
+        CHECK(!lit.backend_handle().is_inlined());
+    }
 }

--- a/tests/datatype/tests_LangString.cpp
+++ b/tests/datatype/tests_LangString.cpp
@@ -6,6 +6,8 @@
 using namespace rdf4cpp::rdf;
 
 TEST_CASE("rdf:langString") {
+    static_assert(!datatypes::InlineableLiteralDatatype<datatypes::rdf::LangString>, "beware: making rdf:langString inlineable requires additional code in Literal");
+
     CHECK_THROWS(Literal{"hello", IRI{datatypes::rdf::LangString::identifier}});
     CHECK_THROWS(Literal::make("hello", IRI{datatypes::rdf::LangString::identifier}));
 

--- a/tests/datatype/tests_Long.cpp
+++ b/tests/datatype/tests_Long.cpp
@@ -4,6 +4,7 @@
 #include <rdf4cpp/rdf.hpp>
 
 using namespace rdf4cpp::rdf;
+using namespace datatypes;
 
 TEST_CASE("Datatype Long") {
 
@@ -56,4 +57,27 @@ TEST_CASE("Datatype Long") {
     CHECK_THROWS(no_discard_dummy = Literal("qwerty", type_iri));
 
     CHECK_THROWS(no_discard_dummy = Literal("1.00001", type_iri));
+}
+
+TEST_CASE("small 64bit positive int inlining") {
+    auto const i = (1l << 41) - 1;
+    auto const lit1 = Literal::make<xsd::Long>(i);
+    auto const lit2 = Literal::make(std::to_string(i), IRI{xsd::Long::identifier});
+    CHECK(lit1.backend_handle().is_inlined());
+    CHECK(lit2.backend_handle().is_inlined());
+    CHECK(lit1 == lit2);
+
+    auto const extracted1 = lit1.template value<xsd::Long>();
+    auto const extracted2 = lit2.value();
+    CHECK(extracted1 == i);
+    CHECK(std::any_cast<xsd::Long::cpp_type>(extracted2) == i);
+}
+
+TEST_CASE("negative 64bit int inlining") {
+    auto const i = -256;
+    auto const lit1 = Literal::make<xsd::Long>(i);
+    auto const lit2 = Literal::make(std::to_string(i), IRI{xsd::Long::identifier});
+    CHECK(lit1.backend_handle().is_inlined());
+    CHECK(lit2.backend_handle().is_inlined());
+    CHECK(lit1 == lit2);
 }

--- a/tests/datatype/tests_NegativeInteger.cpp
+++ b/tests/datatype/tests_NegativeInteger.cpp
@@ -53,3 +53,15 @@ TEST_CASE("Datatype NegativeInteger") {
 
     CHECK_THROWS(no_discard_dummy = Literal("a23dg.59566", type_iri));
 }
+
+TEST_CASE("xsd:negativeInteger inlining") {
+    using datatypes::xsd::NegativeInteger;
+
+    auto one_lit = Literal::make<NegativeInteger>(-1);
+    CHECK(one_lit.backend_handle().is_inlined());
+    CHECK(one_lit.value<NegativeInteger>() == -1);
+
+    auto large_lit = Literal::make<NegativeInteger>(-(1l << 42));
+    CHECK(large_lit.backend_handle().is_inlined());
+    CHECK(large_lit.value<NegativeInteger>() == (-(1l << 42)));
+}

--- a/tests/datatype/tests_NonNegativeInteger.cpp
+++ b/tests/datatype/tests_NonNegativeInteger.cpp
@@ -53,3 +53,19 @@ TEST_CASE("Datatype NonNegativeInteger") {
 
     CHECK_THROWS(no_discard_dummy = Literal("-0.01", type_iri));
 }
+
+TEST_CASE("xsd:nonNegativeInteger inlining") {
+    using datatypes::xsd::NonNegativeInteger;
+
+    auto zero_lit = Literal::make<NonNegativeInteger>(0);
+    CHECK(zero_lit.backend_handle().is_inlined());
+    CHECK(zero_lit.value<NonNegativeInteger>() == 0);
+
+    auto one_lit = Literal::make<NonNegativeInteger>(1);
+    CHECK(one_lit.backend_handle().is_inlined());
+    CHECK(one_lit.value<NonNegativeInteger>() == 1);
+
+    auto large_lit = Literal::make<NonNegativeInteger>((1ul << 42) - 1);
+    CHECK(large_lit.backend_handle().is_inlined());
+    CHECK(large_lit.value<NonNegativeInteger>() == ((1ul << 42) - 1));
+}

--- a/tests/datatype/tests_NonPositiveInteger.cpp
+++ b/tests/datatype/tests_NonPositiveInteger.cpp
@@ -53,3 +53,19 @@ TEST_CASE("Datatype NonPositiveInteger") {
 
     CHECK_THROWS(no_discard_dummy = Literal("0.01", type_iri));
 }
+
+TEST_CASE("xsd:nonPositiveInteger inlining") {
+    using datatypes::xsd::NonPositiveInteger;
+
+    auto zero_lit = Literal::make<NonPositiveInteger>(0);
+    CHECK(zero_lit.backend_handle().is_inlined());
+    CHECK(zero_lit.value<NonPositiveInteger>() == 0);
+
+    auto one_lit = Literal::make<NonPositiveInteger>(-1);
+    CHECK(one_lit.backend_handle().is_inlined());
+    CHECK(one_lit.value<NonPositiveInteger>() == -1);
+
+    auto large_lit = Literal::make<NonPositiveInteger>(-(1l << 42) + 1);
+    CHECK(large_lit.backend_handle().is_inlined());
+    CHECK(large_lit.value<NonPositiveInteger>() == (-(1l << 42) + 1));
+}

--- a/tests/datatype/tests_PositiveInteger.cpp
+++ b/tests/datatype/tests_PositiveInteger.cpp
@@ -53,3 +53,15 @@ TEST_CASE("Datatype PositiveInteger") {
 
     CHECK_THROWS(no_discard_dummy = Literal("-0.01", type_iri));
 }
+
+TEST_CASE("xsd:positiveInteger inlining") {
+    using datatypes::xsd::PositiveInteger;
+
+    auto one_lit = Literal::make<PositiveInteger>(1);
+    CHECK(one_lit.backend_handle().is_inlined());
+    CHECK(one_lit.value<PositiveInteger>() == 1);
+
+    auto large_lit = Literal::make<PositiveInteger>(1l << 42);
+    CHECK(large_lit.backend_handle().is_inlined());
+    CHECK(large_lit.value<PositiveInteger>() == (1l << 42));
+}

--- a/tests/nodes/tests_Literal.cpp
+++ b/tests/nodes/tests_Literal.cpp
@@ -14,8 +14,7 @@ TEST_CASE("Literal - Check for only lexical form") {
     CHECK(lit1.is_literal());
     CHECK(not lit1.is_variable());
     CHECK(not lit1.is_iri());
-    lit1.lexical_form() == "Bugs Bunny";
-    //CHECK(lit1.lexical_form() == "Bugs Bunny");
+    CHECK(lit1.lexical_form() == "Bugs Bunny");
     CHECK(lit1.datatype() == iri);
     CHECK(lit1.language_tag() == "");
     CHECK(std::string(lit1) == "\"Bugs Bunny\"^^<http://www.w3.org/2001/XMLSchema#string>");

--- a/tests/nodes/tests_Literal.cpp
+++ b/tests/nodes/tests_Literal.cpp
@@ -8,32 +8,32 @@ using namespace rdf4cpp::rdf;
 TEST_CASE("Literal - Check for only lexical form") {
 
     auto iri = IRI{"http://www.w3.org/2001/XMLSchema#string"};
-    auto lit1 = Literal{"Bugs Bunny"};
+    auto lit1 = Literal{"Bunny"};
 
     CHECK(not lit1.is_blank_node());
     CHECK(lit1.is_literal());
     CHECK(not lit1.is_variable());
     CHECK(not lit1.is_iri());
-    CHECK(lit1.lexical_form() == "Bugs Bunny");
+    CHECK(lit1.lexical_form() == "Bunny");
     CHECK(lit1.datatype() == iri);
     CHECK(lit1.language_tag() == "");
-    CHECK(std::string(lit1) == "\"Bugs Bunny\"^^<http://www.w3.org/2001/XMLSchema#string>");
+    CHECK(std::string(lit1) == "\"Bunny\"^^<http://www.w3.org/2001/XMLSchema#string>");
 }
 
 TEST_CASE("Literal - Check for lexical form with IRI") {
 
     SUBCASE("string datatype") {
         auto iri = IRI{"http://www.w3.org/2001/XMLSchema#string"};
-        auto lit1 = Literal{"Bugs Bunny", iri};
+        auto lit1 = Literal{"Bunny", iri};
 
         CHECK(not lit1.is_blank_node());
         CHECK(lit1.is_literal());
         CHECK(not lit1.is_variable());
         CHECK(not lit1.is_iri());
-        CHECK(lit1.lexical_form() == "Bugs Bunny");
+        CHECK(lit1.lexical_form() == "Bunny");
         CHECK(lit1.datatype() == iri);
         CHECK(lit1.language_tag() == "");
-        CHECK(std::string(lit1) == "\"Bugs Bunny\"^^<http://www.w3.org/2001/XMLSchema#string>");
+        CHECK(std::string(lit1) == "\"Bunny\"^^<http://www.w3.org/2001/XMLSchema#string>");
     }
     SUBCASE("int datatype") {
         auto iri = IRI{"http://www.w3.org/2001/XMLSchema#int"};
@@ -131,16 +131,16 @@ TEST_CASE("Literal - Check for lexical form with IRI") {
 TEST_CASE("Literal - Check for lexical form with language tag") {
 
     auto iri = IRI{"http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"};
-    auto lit1 = Literal{"Bugs Bunny", "en"};
+    auto lit1 = Literal{"Bunny", "en"};
 
     CHECK(not lit1.is_blank_node());
     CHECK(lit1.is_literal());
     CHECK(not lit1.is_variable());
     CHECK(not lit1.is_iri());
-    CHECK(lit1.lexical_form() == "Bugs Bunny");
+    CHECK(lit1.lexical_form() == "Bunny");
     CHECK(lit1.datatype() == iri);
     CHECK(lit1.language_tag() == "en");
-    CHECK(std::string(lit1) == "\"Bugs Bunny\"@en");
+    CHECK(std::string(lit1) == "\"Bunny\"@en");
 }
 
 TEST_CASE("Literal - ctor edge-case") {

--- a/tests/nodes/tests_Literal.cpp
+++ b/tests/nodes/tests_Literal.cpp
@@ -14,7 +14,8 @@ TEST_CASE("Literal - Check for only lexical form") {
     CHECK(lit1.is_literal());
     CHECK(not lit1.is_variable());
     CHECK(not lit1.is_iri());
-    CHECK(lit1.lexical_form() == "Bugs Bunny");
+    lit1.lexical_form() == "Bugs Bunny";
+    //CHECK(lit1.lexical_form() == "Bugs Bunny");
     CHECK(lit1.datatype() == iri);
     CHECK(lit1.language_tag() == "");
     CHECK(std::string(lit1) == "\"Bugs Bunny\"^^<http://www.w3.org/2001/XMLSchema#string>");

--- a/tests/util/tests_CowString.cpp
+++ b/tests/util/tests_CowString.cpp
@@ -1,0 +1,52 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+
+#include <doctest/doctest.h>
+#include <rdf4cpp/rdf.hpp>
+
+using namespace rdf4cpp::rdf::util;
+
+TEST_SUITE("CowString") {
+    TEST_CASE("borrowed") {
+        CowString s{ownership_tag::borrowed, "Hello World"};
+        CHECK(s == "Hello World");
+        CHECK(s.view() == "Hello World");
+
+        std::string _ignore;
+        CHECK_THROWS(_ignore = s.get_owned());
+
+        CHECK(s.get_borrowed() == "Hello World");
+    }
+
+    TEST_CASE("owned") {
+        CowString bull{ownership_tag::owned, "Moo!"};
+        CHECK(bull == "Moo!");
+        CHECK(bull.view() == "Moo!");
+
+        std::string_view _ignore;
+        CHECK_THROWS(_ignore = bull.get_borrowed());
+
+        CHECK(bull.get_owned() == "Moo!");
+        CHECK(std::move(bull).get_owned() == "Moo!");
+    }
+
+    TEST_CASE("CowString equality") {
+        CowString calf1{ownership_tag::borrowed, "Moo?"};
+        CowString calf2{ownership_tag::owned, "Moo?"};
+
+        CHECK(calf1 == calf2);
+    }
+
+    TEST_CASE("to_mutable") {
+        CowString buffalo{ownership_tag::borrowed, "spherical cow"};
+
+        std::string _ignore;
+        CHECK_THROWS(_ignore = buffalo.get_owned());
+
+        buffalo.to_mutable() += "!";
+        CHECK_NOTHROW(_ignore = buffalo.get_owned());
+        CHECK(buffalo == "spherical cow!");
+
+        buffalo.to_mutable() += "!";
+        CHECK(buffalo == "spherical cow!!");
+    }
+}

--- a/tests/util/tests_Inlining.cpp
+++ b/tests/util/tests_Inlining.cpp
@@ -21,34 +21,90 @@ TEST_SUITE("inlining util") {
         CHECK(unpacked == smaller);
     }
 
-    TEST_CASE("signed smaller into bigger") {
-        auto const smaller = std::numeric_limits<int32_t>::min();
+    TEST_CASE("unsigned equal size") {
+        uint64_t const smaller = (1ul << 42) - 1;
         auto const packed = try_pack_integral<uint64_t, 42>(smaller);
         CHECK(packed.has_value());
 
-        CHECK(*packed < (1ul << 32));
-
-        auto const unpacked = unpack_integral<int32_t, 42>(*packed);
+        auto const unpacked = unpack_integral<uint64_t, 42>(*packed);
         CHECK(unpacked == smaller);
     }
 
-    TEST_CASE("pack signed") {
-        for (int64_t i = 0; i < (1l << 19); ++i) {
-            auto packed = try_pack_integral<uint64_t, 20>(i);
+    TEST_CASE("signed smaller into bigger") {
+        SUBCASE("positive") {
+            auto const smaller = std::numeric_limits<int32_t>::max();
+            auto const packed = try_pack_integral<uint64_t, 42>(smaller);
             CHECK(packed.has_value());
 
-            auto unpacked = unpack_integral<int64_t, 20>(*packed);
+            CHECK(*packed < (1ul << 32));
 
-            REQUIRE(i == unpacked);
+            auto const unpacked = unpack_integral<int32_t, 42>(*packed);
+            CHECK(unpacked == smaller);
         }
 
-        for (int64_t i = -1; i >= -(1l << 19); --i) {
-            auto packed = try_pack_integral<uint64_t, 20>(i);
+        SUBCASE("negative") {
+            auto const smaller = std::numeric_limits<int32_t>::min();
+            auto const packed = try_pack_integral<uint64_t, 42>(smaller);
             CHECK(packed.has_value());
 
-            auto unpacked = unpack_signed<int64_t, 20>(*packed);
+            CHECK(*packed < (1ul << 32));
 
-            REQUIRE(i == unpacked);
+            auto const unpacked = unpack_integral<int32_t, 42>(*packed);
+            CHECK(unpacked == smaller);
+        }
+    }
+
+    TEST_CASE("signed equal size") {
+        SUBCASE("positive") {
+            int64_t const smaller = 812741;
+            auto const packed = try_pack_integral<uint64_t, 42>(smaller);
+            CHECK(packed.has_value());
+
+            auto const unpacked = unpack_integral<int64_t, 42>(*packed);
+            CHECK(unpacked == smaller);
+        }
+
+        SUBCASE("negative") {
+            int64_t const smaller = -9999;
+            auto const packed = try_pack_integral<uint64_t, 42>(smaller);
+            CHECK(packed.has_value());
+
+            auto const unpacked = unpack_integral<int64_t, 42>(*packed);
+            CHECK(unpacked == smaller);
+        }
+    }
+
+    TEST_CASE("pack signed") {
+        SUBCASE("positive packable") {
+            for (int64_t i = 0; i < (1l << 19); ++i) {
+                auto packed = try_pack_integral<uint64_t, 20>(i);
+                CHECK(packed.has_value());
+
+                auto unpacked = unpack_integral<int64_t, 20>(*packed);
+
+                REQUIRE(i == unpacked);
+            }
+        }
+
+        SUBCASE("positive too large") {
+            auto not_packed_pos = try_pack_integral<uint64_t, 20>(1l << 22);
+            CHECK(!not_packed_pos.has_value());
+        }
+
+        SUBCASE("packable negative") {
+            for (int64_t i = -1; i >= -(1l << 19); --i) {
+                auto packed = try_pack_integral<uint64_t, 20>(i);
+                CHECK(packed.has_value());
+
+                auto unpacked = unpack_signed<int64_t, 20>(*packed);
+
+                REQUIRE(i == unpacked);
+            }
+        }
+
+        SUBCASE("positive too large") {
+            auto not_packed_pos = try_pack_integral<uint64_t, 20>(-(1l << 22));
+            CHECK(!not_packed_pos.has_value());
         }
     }
 }

--- a/tests/util/tests_Inlining.cpp
+++ b/tests/util/tests_Inlining.cpp
@@ -12,93 +12,43 @@ TEST_SUITE("inlining util") {
 
     TEST_CASE("unsigned smaller into bigger") {
         auto const smaller = std::numeric_limits<uint32_t>::max();
-        auto const packed = pack<uint64_t>(smaller);
+        auto const packed = try_pack_integral<uint64_t, 42>(smaller);
+        CHECK(packed.has_value());
 
-        CHECK(packed < (1ul << 32));
+        CHECK(*packed < (1ul << 32));
 
-        auto const unpacked = unpack<uint32_t>(packed);
+        auto const unpacked = unpack_integral<uint32_t, 42>(*packed);
         CHECK(unpacked == smaller);
     }
 
     TEST_CASE("signed smaller into bigger") {
         auto const smaller = std::numeric_limits<int32_t>::min();
-        auto const packed = pack<uint64_t>(smaller);
+        auto const packed = try_pack_integral<uint64_t, 42>(smaller);
+        CHECK(packed.has_value());
 
-        CHECK(packed < (1ul << 32));
+        CHECK(*packed < (1ul << 32));
 
-        auto const unpacked = unpack<int32_t>(packed);
+        auto const unpacked = unpack_integral<int32_t, 42>(*packed);
         CHECK(unpacked == smaller);
     }
 
-    TEST_CASE("unsigned bigger into smaller") {
-        auto const bigger = static_cast<uint64_t>(std::numeric_limits<uint32_t>::max());
-        auto const packed = pack<uint32_t>(bigger);
+    TEST_CASE("pack signed") {
+        for (int64_t i = 0; i < (1l << 19); ++i) {
+            auto packed = try_pack_integral<uint64_t, 20>(i);
+            CHECK(packed.has_value());
 
-        auto const unpacked = unpack<uint64_t>(packed);
-        CHECK(bigger == unpacked);
-    }
+            auto unpacked = unpack_integral<int64_t, 20>(*packed);
 
-    // TODO?: this does not work, do we want it work? (usecase: negative 64bit number into 42bit LiteralID)
-    //TEST_CASE("signed bigger into smaller") {
-    //    int64_t const bigger = -256l;
-    //    auto const packed = pack<uint32_t>(bigger);
-    //
-    //    auto const unpacked = unpack<int64_t>(packed);
-    //    CHECK(bigger == unpacked);
-    //}
-}
+            REQUIRE(i == unpacked);
+        }
 
-TEST_SUITE("literal inlining") {
-    using namespace datatypes;
+        for (int64_t i = -1; i >= -(1l << 19); --i) {
+            auto packed = try_pack_integral<uint64_t, 20>(i);
+            CHECK(packed.has_value());
 
-    TEST_CASE("32bit positive int inlining") {
-        auto const i = std::numeric_limits<xsd::Int::cpp_type>::max();
-        auto const lit1 = Literal::make<xsd::Int>(i);
-        auto const lit2 = Literal::make(std::to_string(i), IRI{xsd::Int::identifier});
-        CHECK(lit1.backend_handle().is_inlined());
-        CHECK(lit2.backend_handle().is_inlined());
-        CHECK(lit1 == lit2);
+            auto unpacked = unpack_signed<int64_t, 20>(*packed);
 
-        auto const extracted1 = lit1.template value<xsd::Int>();
-        auto const extracted2 = lit2.value();
-        CHECK(extracted1 == i);
-        CHECK(std::any_cast<xsd::Int::cpp_type>(extracted2) == i);
-    }
-
-    TEST_CASE("32bit negative int inlining") {
-        auto const i = std::numeric_limits<xsd::Int::cpp_type>::min();
-        auto const lit1 = Literal::make<xsd::Int>(i);
-        auto const lit2 = Literal::make(std::to_string(i), IRI{xsd::Int::identifier});
-        CHECK(lit1.backend_handle().is_inlined());
-        CHECK(lit2.backend_handle().is_inlined());
-        CHECK(lit1 == lit2);
-
-        auto const extracted1 = lit1.template value<xsd::Int>();
-        auto const extracted2 = lit2.value();
-        CHECK(extracted1 == i);
-        CHECK(std::any_cast<xsd::Int::cpp_type>(extracted2) == i);
-    }
-
-    TEST_CASE("small 64bit positive int inlining") {
-        auto const i = 1l << (storage::node::identifier::LiteralID::width - 1);
-        auto const lit1 = Literal::make<xsd::Long>(i);
-        auto const lit2 = Literal::make(std::to_string(i), IRI{xsd::Long::identifier});
-        CHECK(lit1.backend_handle().is_inlined());
-        CHECK(lit2.backend_handle().is_inlined());
-        CHECK(lit1 == lit2);
-
-        auto const extracted1 = lit1.template value<xsd::Long>();
-        auto const extracted2 = lit2.value();
-        CHECK(extracted1 == i);
-        CHECK(std::any_cast<xsd::Long::cpp_type>(extracted2) == i);
-    }
-
-    TEST_CASE("negative 64bit int not-inlining") {
-        auto const i = -256;
-        auto const lit1 = Literal::make<xsd::Long>(i);
-        auto const lit2 = Literal::make(std::to_string(i), IRI{xsd::Long::identifier});
-        CHECK(!lit1.backend_handle().is_inlined()); // cannot be inlined bits left of 42bit boundary would need to be set
-        CHECK(!lit2.backend_handle().is_inlined());
-        CHECK(lit1 == lit2);
+            REQUIRE(i == unpacked);
+        }
     }
 }

--- a/tests/util/tests_Inlining.cpp
+++ b/tests/util/tests_Inlining.cpp
@@ -1,0 +1,84 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+
+#include <doctest/doctest.h>
+#include <rdf4cpp/rdf.hpp>
+
+#include <limits>
+
+using namespace rdf4cpp::rdf;
+
+TEST_SUITE("inlining util") {
+    using namespace datatypes::registry::util;
+
+    TEST_CASE("unsigned smaller into bigger") {
+        auto const smaller = std::numeric_limits<uint32_t>::max();
+        auto const packed = pack<uint64_t>(smaller);
+
+        CHECK(packed < (1ul << 32));
+
+        auto const unpacked = unpack<uint32_t>(packed);
+        CHECK(unpacked == smaller);
+    }
+
+    TEST_CASE("signed smaller into bigger") {
+        auto const smaller = std::numeric_limits<int32_t>::min();
+        auto const packed = pack<uint64_t>(smaller);
+
+        CHECK(packed < (1ul << 32));
+
+        auto const unpacked = unpack<int32_t>(packed);
+        CHECK(unpacked == smaller);
+    }
+
+    TEST_CASE("unsigned bigger into smaller") {
+        auto const bigger = static_cast<uint64_t>(std::numeric_limits<uint32_t>::max());
+        auto const packed = pack<uint32_t>(bigger);
+
+        auto const unpacked = unpack<uint64_t>(packed);
+        CHECK(bigger == unpacked);
+    }
+
+    // TODO?: this does not work, do we want it work? (usecase: negative 64bit number into 42bit LiteralID)
+    //TEST_CASE("signed bigger into smaller") {
+    //    int64_t const bigger = -256l;
+    //    auto const packed = pack<uint32_t>(bigger);
+    //
+    //    auto const unpacked = unpack<int64_t>(packed);
+    //    CHECK(bigger == unpacked);
+    //}
+}
+
+TEST_SUITE("literal inlining") {
+    using namespace datatypes;
+
+    TEST_CASE("32bit positive int inlining") {
+        auto const lit = Literal::make<xsd::Int>(std::numeric_limits<xsd::Int::cpp_type>::max());
+        CHECK(lit.backend_handle().is_inlined());
+
+        auto const extracted = lit.template value<xsd::Int>();
+        CHECK(extracted == std::numeric_limits<xsd::Int::cpp_type>::max());
+    }
+
+    TEST_CASE("32bit negative int inlining") {
+        auto const lit = Literal::make<xsd::Int>(std::numeric_limits<xsd::Int::cpp_type>::min());
+        CHECK(lit.backend_handle().is_inlined());
+
+        auto const extracted = lit.template value<xsd::Int>();
+        CHECK(extracted == std::numeric_limits<xsd::Int::cpp_type>::min());
+    }
+
+    TEST_CASE("small 64bit positive int inlining") {
+        auto const i = 1l << (storage::node::identifier::LiteralID::width - 1);
+        auto const lit = Literal::make<xsd::Long>(i);
+        CHECK(lit.backend_handle().is_inlined());
+
+        auto const extracted = lit.template value<xsd::Long>();
+        CHECK(extracted == i);
+    }
+
+    TEST_CASE("negative 64bit int not-inlining") {
+        auto const i = -256;
+        auto const lit = Literal::make<xsd::Long>(i);
+        CHECK(!lit.backend_handle().is_inlined()); // cannot be inlined bits left of 42bit boundary would need to be set
+    }
+}

--- a/tests/util/tests_Inlining.cpp
+++ b/tests/util/tests_Inlining.cpp
@@ -52,33 +52,53 @@ TEST_SUITE("literal inlining") {
     using namespace datatypes;
 
     TEST_CASE("32bit positive int inlining") {
-        auto const lit = Literal::make<xsd::Int>(std::numeric_limits<xsd::Int::cpp_type>::max());
-        CHECK(lit.backend_handle().is_inlined());
+        auto const i = std::numeric_limits<xsd::Int::cpp_type>::max();
+        auto const lit1 = Literal::make<xsd::Int>(i);
+        auto const lit2 = Literal::make(std::to_string(i), IRI{xsd::Int::identifier});
+        CHECK(lit1.backend_handle().is_inlined());
+        CHECK(lit2.backend_handle().is_inlined());
+        CHECK(lit1 == lit2);
 
-        auto const extracted = lit.template value<xsd::Int>();
-        CHECK(extracted == std::numeric_limits<xsd::Int::cpp_type>::max());
+        auto const extracted1 = lit1.template value<xsd::Int>();
+        auto const extracted2 = lit2.value();
+        CHECK(extracted1 == i);
+        CHECK(std::any_cast<xsd::Int::cpp_type>(extracted2) == i);
     }
 
     TEST_CASE("32bit negative int inlining") {
-        auto const lit = Literal::make<xsd::Int>(std::numeric_limits<xsd::Int::cpp_type>::min());
-        CHECK(lit.backend_handle().is_inlined());
+        auto const i = std::numeric_limits<xsd::Int::cpp_type>::min();
+        auto const lit1 = Literal::make<xsd::Int>(i);
+        auto const lit2 = Literal::make(std::to_string(i), IRI{xsd::Int::identifier});
+        CHECK(lit1.backend_handle().is_inlined());
+        CHECK(lit2.backend_handle().is_inlined());
+        CHECK(lit1 == lit2);
 
-        auto const extracted = lit.template value<xsd::Int>();
-        CHECK(extracted == std::numeric_limits<xsd::Int::cpp_type>::min());
+        auto const extracted1 = lit1.template value<xsd::Int>();
+        auto const extracted2 = lit2.value();
+        CHECK(extracted1 == i);
+        CHECK(std::any_cast<xsd::Int::cpp_type>(extracted2) == i);
     }
 
     TEST_CASE("small 64bit positive int inlining") {
         auto const i = 1l << (storage::node::identifier::LiteralID::width - 1);
-        auto const lit = Literal::make<xsd::Long>(i);
-        CHECK(lit.backend_handle().is_inlined());
+        auto const lit1 = Literal::make<xsd::Long>(i);
+        auto const lit2 = Literal::make(std::to_string(i), IRI{xsd::Long::identifier});
+        CHECK(lit1.backend_handle().is_inlined());
+        CHECK(lit2.backend_handle().is_inlined());
+        CHECK(lit1 == lit2);
 
-        auto const extracted = lit.template value<xsd::Long>();
-        CHECK(extracted == i);
+        auto const extracted1 = lit1.template value<xsd::Long>();
+        auto const extracted2 = lit2.value();
+        CHECK(extracted1 == i);
+        CHECK(std::any_cast<xsd::Long::cpp_type>(extracted2) == i);
     }
 
     TEST_CASE("negative 64bit int not-inlining") {
         auto const i = -256;
-        auto const lit = Literal::make<xsd::Long>(i);
-        CHECK(!lit.backend_handle().is_inlined()); // cannot be inlined bits left of 42bit boundary would need to be set
+        auto const lit1 = Literal::make<xsd::Long>(i);
+        auto const lit2 = Literal::make(std::to_string(i), IRI{xsd::Long::identifier});
+        CHECK(!lit1.backend_handle().is_inlined()); // cannot be inlined bits left of 42bit boundary would need to be set
+        CHECK(!lit2.backend_handle().is_inlined());
+        CHECK(lit1 == lit2);
     }
 }


### PR DESCRIPTION
TODOs:

- [x] make other types (other than xsd:int) inlineable where applicable
- [x] think about inlining IRIs, BNodes => IRIs: no, not enough space, BNodes: no
- [x] rdf:langString inlining? => no, not enough space to be useful
- [x] some comments
- [x] resolve todos in code