### PR TITLE
Fix: datatype behaviour fixes

### DIFF
--- a/.github/workflows/reusable_run_test_and_examples_by_linking_type.yml
+++ b/.github/workflows/reusable_run_test_and_examples_by_linking_type.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Run tests
         working-directory: build_dir
         run: |
-          ctest --parallel 2
+          ctest --parallel 2 --verbose
 
       - name: Report coverage
         env:

--- a/src/rdf4cpp/rdf/Literal.cpp
+++ b/src/rdf4cpp/rdf/Literal.cpp
@@ -46,6 +46,10 @@ util::CowString Literal::lexical_form() const noexcept {
 }
 
 Literal Literal::as_lexical_form(NodeStorage &node_storage) const noexcept {
+    if (this->null()) {
+        return Literal{};
+    }
+
     return Literal::make_simple_unchecked(this->lexical_form(), node_storage);
 }
 
@@ -67,6 +71,10 @@ util::CowString Literal::display() const noexcept {
 }
 
 Literal Literal::as_display(Node::NodeStorage &node_storage) const noexcept {
+    if (this->null()) {
+        return Literal{};
+    }
+
     return Literal::make_simple_unchecked(this->display(), node_storage);
 }
 

--- a/src/rdf4cpp/rdf/Literal.hpp
+++ b/src/rdf4cpp/rdf/Literal.hpp
@@ -206,6 +206,18 @@ public:
     [[nodiscard]] Literal as_lexical_form(NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
 
     /**
+     * Returns the user friendly string version of this. This is for example used when casting numerics to string.
+     * @return user friendly string representation
+     */
+    [[nodiscard]] util::CowString display() const noexcept;
+
+    /**
+     * Converts this into it's user friendly string representation as xsd:string. See Literal::display for more details.
+     * @return user friendly string representation of this as xsd:string
+     */
+    [[nodiscard]] Literal as_display(NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
+
+    /**
      * Returns the datatype IRI of this.
      * @return datatype IRI
      */
@@ -340,8 +352,8 @@ public:
             auto const &lit = this->handle_.literal_backend();
 
             return datatypes::registry::LangStringRepr{
-                    .lexical_form = std::string{lit.lexical_form},
-                    .language_tag = std::string{lit.language_tag}};
+                    .lexical_form = lit.lexical_form,
+                    .language_tag = lit.language_tag};
         }
 
         return LiteralDatatype_t::from_string(this->lexical_form());

--- a/src/rdf4cpp/rdf/Literal.hpp
+++ b/src/rdf4cpp/rdf/Literal.hpp
@@ -157,7 +157,7 @@ public:
             }
         }
 
-        return Literal::make_noninlined_typed_unchecked(LiteralDatatype_t::to_string(compatible_value),
+        return Literal::make_noninlined_typed_unchecked(LiteralDatatype_t::to_canonical_string(compatible_value),
                                                         IRI{LiteralDatatype_t::datatype_id, node_storage},
                                                         node_storage);
     }
@@ -201,21 +201,21 @@ public:
      * Converts this into it's lexical form as xsd:string. See Literal::lexical_form for more details.
      *
      * @param node_storage where to put the resulting literal
-     * @return lexical form of this as xsd:string
+     * @return lexical form of this as xsd:string if this is not the null literal, otherwise returns the null literal
      */
     [[nodiscard]] Literal as_lexical_form(NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
 
     /**
-     * Returns the user friendly string version of this. This is for example used when casting numerics to string.
+     * Returns the simplified/more user friendly string version of this. This is for example used when casting numerics to string.
      * @return user friendly string representation
      */
-    [[nodiscard]] util::CowString display() const noexcept;
+    [[nodiscard]] util::CowString simplified_lexical_form() const noexcept;
 
     /**
-     * Converts this into it's user friendly string representation as xsd:string. See Literal::display for more details.
-     * @return user friendly string representation of this as xsd:string
+     * Converts this into it's simplified/more user friendly string representation as xsd:string. See Literal::to_simplified_string for more details.
+     * @return user friendly string representation of this as xsd:string if this is not the null literal, otherwise returns the null literal
      */
-    [[nodiscard]] Literal as_display(NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
+    [[nodiscard]] Literal as_simplified_lexical_form(NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
 
     /**
      * Returns the datatype IRI of this.

--- a/src/rdf4cpp/rdf/datatypes/LiteralDatatype.hpp
+++ b/src/rdf4cpp/rdf/datatypes/LiteralDatatype.hpp
@@ -17,7 +17,8 @@ concept LiteralDatatype = requires(LiteralDatatypeImpl, std::string_view sv, typ
                               { LiteralDatatypeImpl::identifier } -> std::convertible_to<std::string_view>;
                               { LiteralDatatypeImpl::datatype_id } -> std::convertible_to<registry::DatatypeIDView>;
                               { LiteralDatatypeImpl::from_string(sv) } -> std::convertible_to<typename LiteralDatatypeImpl::cpp_type>;
-                              { LiteralDatatypeImpl::to_string(cpp_value) } -> std::convertible_to<std::string>;
+                              { LiteralDatatypeImpl::to_canonical_string(cpp_value) } -> std::convertible_to<std::string>;
+                              { LiteralDatatypeImpl::to_simplified_string(cpp_value) } -> std::convertible_to<std::string>;
                           };
 
 template<typename LiteralDatatypeImpl>

--- a/src/rdf4cpp/rdf/datatypes/owl/Rational.cpp
+++ b/src/rdf4cpp/rdf/datatypes/owl/Rational.cpp
@@ -22,7 +22,7 @@ capabilities::Default<owl_rational>::cpp_type capabilities::Default<owl_rational
 }
 
 template<>
-std::string capabilities::Default<owl_rational>::to_string(cpp_type const &value) noexcept {
+std::string capabilities::Default<owl_rational>::to_canonical_string(cpp_type const &value) noexcept {
     if (auto den = denominator(value); den < 0) {
         // canonicalize x/-y to -x/y and -x/-y to x/y
         cpp_type const canonical{-numerator(value), -std::move(den)};

--- a/src/rdf4cpp/rdf/datatypes/owl/Rational.hpp
+++ b/src/rdf4cpp/rdf/datatypes/owl/Rational.hpp
@@ -19,7 +19,7 @@ template<>
 capabilities::Default<owl_rational>::cpp_type capabilities::Default<owl_rational>::from_string(std::string_view s);
 
 template<>
-std::string capabilities::Default<owl_rational>::to_string(cpp_type const &value) noexcept;
+std::string capabilities::Default<owl_rational>::to_canonical_string(cpp_type const &value) noexcept;
 
 template<>
 bool capabilities::Logical<owl_rational>::effective_boolean_value(cpp_type const &value) noexcept;

--- a/src/rdf4cpp/rdf/datatypes/rdf/LangString.cpp
+++ b/src/rdf4cpp/rdf/datatypes/rdf/LangString.cpp
@@ -1,6 +1,16 @@
 #include <rdf4cpp/rdf/datatypes/rdf/LangString.hpp>
 
+#include <rdf4cpp/rdf/datatypes/registry/util/LangTag.hpp>
+
 namespace rdf4cpp::rdf::datatypes::registry {
+
+std::weak_ordering registry::LangStringRepr::operator<=>(LangStringRepr const &other) const noexcept {
+    if (auto const lfc = this->lexical_form <=> other.lexical_form; lfc != std::strong_ordering::equal) {
+        return lfc;
+    }
+
+    return util::LangTagView{this->language_tag.data(), this->language_tag.size()} <=> util::LangTagView{other.language_tag.data(), other.language_tag.size()};
+}
 
 template struct LiteralDatatypeImpl<rdf_lang_string,
                                     capabilities::Comparable,

--- a/src/rdf4cpp/rdf/datatypes/rdf/LangString.hpp
+++ b/src/rdf4cpp/rdf/datatypes/rdf/LangString.hpp
@@ -7,10 +7,17 @@
 namespace rdf4cpp::rdf::datatypes::registry {
 
 struct LangStringRepr {
-    std::string lexical_form;
-    std::string language_tag;
+    std::string_view lexical_form;
+    std::string_view language_tag;
 
-    auto operator<=>(LangStringRepr const &) const = default;
+    std::weak_ordering operator<=>(LangStringRepr const &other) const noexcept;
+
+    bool operator==(LangStringRepr const &) const noexcept = default;
+    bool operator!=(LangStringRepr const &) const noexcept = default;
+    bool operator<(LangStringRepr const &) const noexcept = default;
+    bool operator<=(LangStringRepr const &) const noexcept = default;
+    bool operator>(LangStringRepr const &) const noexcept = default;
+    bool operator>=(LangStringRepr const &) const noexcept = default;
 };
 
 template<>

--- a/src/rdf4cpp/rdf/datatypes/rdf/LangString.hpp
+++ b/src/rdf4cpp/rdf/datatypes/rdf/LangString.hpp
@@ -33,7 +33,7 @@ inline capabilities::Default<rdf_lang_string>::cpp_type capabilities::Default<rd
 }
 
 template<>
-inline std::string capabilities::Default<rdf_lang_string>::to_string(cpp_type const &) noexcept {
+inline std::string capabilities::Default<rdf_lang_string>::to_canonical_string(cpp_type const &) noexcept {
     // dummy implementation, actual implementation in Literal
     assert(false);
     __builtin_unreachable();

--- a/src/rdf4cpp/rdf/datatypes/registry/DatatypeRegistry.cpp
+++ b/src/rdf4cpp/rdf/datatypes/registry/DatatypeRegistry.cpp
@@ -62,17 +62,17 @@ DatatypeRegistry::factory_fptr_t DatatypeRegistry::get_factory(DatatypeIDView co
     return res.has_value() ? *res : nullptr;
 }
 
-DatatypeRegistry::to_string_fptr_t DatatypeRegistry::get_to_string(DatatypeIDView const datatype_id) noexcept {
+DatatypeRegistry::to_string_fptr_t DatatypeRegistry::get_to_canonical_string(DatatypeIDView const datatype_id) noexcept {
     auto const res = find_map_entry(datatype_id, [](auto const &entry) noexcept {
-        return entry.to_string_fptr;
+        return entry.to_canonical_string_fptr;
     });
 
     return res.has_value() ? *res : nullptr;
 }
 
-DatatypeRegistry::to_string_fptr_t DatatypeRegistry::get_display(DatatypeIDView const datatype_id) noexcept {
+DatatypeRegistry::to_string_fptr_t DatatypeRegistry::get_to_simplified_string(DatatypeIDView const datatype_id) noexcept {
     auto const res = find_map_entry(datatype_id, [](auto const &entry) noexcept {
-        return entry.display_fptr;
+        return entry.to_simplified_string_fptr;
     });
 
     return res.has_value() ? *res : nullptr;

--- a/src/rdf4cpp/rdf/datatypes/registry/DatatypeRegistry.cpp
+++ b/src/rdf4cpp/rdf/datatypes/registry/DatatypeRegistry.cpp
@@ -70,6 +70,15 @@ DatatypeRegistry::to_string_fptr_t DatatypeRegistry::get_to_string(DatatypeIDVie
     return res.has_value() ? *res : nullptr;
 }
 
+DatatypeRegistry::to_string_fptr_t DatatypeRegistry::get_display(DatatypeIDView const datatype_id) noexcept {
+    auto const res = find_map_entry(datatype_id, [](auto const &entry) noexcept {
+        return entry.display_fptr;
+    });
+
+    return res.has_value() ? *res : nullptr;
+}
+
+
 DatatypeRegistry::NumericOps const *DatatypeRegistry::get_numerical_ops(DatatypeIDView const datatype_id) noexcept {
     auto const res = find_map_entry(datatype_id, [](auto const &entry) noexcept {
         return &entry.numeric_ops;

--- a/src/rdf4cpp/rdf/datatypes/registry/DatatypeRegistry.hpp
+++ b/src/rdf4cpp/rdf/datatypes/registry/DatatypeRegistry.hpp
@@ -96,6 +96,7 @@ public:
         std::string datatype_iri;         // datatype IRI string
         factory_fptr_t factory_fptr;      // construct from string
         to_string_fptr_t to_string_fptr;  // convert to string
+        to_string_fptr_t display_fptr;    // convert to user-friendly string
 
         ebv_fptr_t ebv_fptr; // convert to effective boolean value
 
@@ -111,6 +112,7 @@ public:
                     .datatype_iri = "",
                     .factory_fptr = nullptr,
                     .to_string_fptr = nullptr,
+                    .display_fptr = nullptr,
                     .ebv_fptr = nullptr,
                     .numeric_ops = std::nullopt,
                     .inlining_ops = std::nullopt,
@@ -123,6 +125,7 @@ public:
                     .datatype_iri = std::string{datatype_iri},
                     .factory_fptr = nullptr,
                     .to_string_fptr = nullptr,
+                    .display_fptr = nullptr,
                     .ebv_fptr = nullptr,
                     .numeric_ops = std::nullopt,
                     .inlining_ops = std::nullopt,
@@ -227,6 +230,13 @@ public:
      * @return function pointer or nullptr
      */
     [[nodiscard]] static to_string_fptr_t get_to_string(DatatypeIDView datatype_id) noexcept;
+
+    /**
+     * Get the display function for a datatype. This function can be used for user friendly output.
+     * @param datatype_id datatype id for the corresponding datatype
+     * @return function pointer if datatype was found else nullptr
+     */
+    [[nodiscard]] static to_string_fptr_t get_display(DatatypeIDView datatype_id) noexcept;
 
     /**
      * Try to get the numerical ops function table for a datatype.
@@ -383,8 +393,11 @@ inline void DatatypeRegistry::add() noexcept {
             .factory_fptr = [](std::string_view string_repr) -> std::any {
                 return std::any{LiteralDatatype_t::from_string(string_repr)};
             },
-            .to_string_fptr = [](const std::any &value) noexcept -> std::string {
+            .to_string_fptr = [](std::any const &value) noexcept -> std::string {
                 return LiteralDatatype_t::to_string(std::any_cast<typename LiteralDatatype_t::cpp_type>(value));
+            },
+            .display_fptr = [](std::any const &value) noexcept -> std::string {
+                return LiteralDatatype_t::display(std::any_cast<typename LiteralDatatype_t::cpp_type>(value));
             },
             .ebv_fptr = ebv_fptr,
             .numeric_ops = num_ops,

--- a/src/rdf4cpp/rdf/datatypes/registry/DatatypeRegistry.hpp
+++ b/src/rdf4cpp/rdf/datatypes/registry/DatatypeRegistry.hpp
@@ -93,10 +93,10 @@ public:
     };
 
     struct DatatypeEntry {
-        std::string datatype_iri;         // datatype IRI string
-        factory_fptr_t factory_fptr;      // construct from string
-        to_string_fptr_t to_string_fptr;  // convert to string
-        to_string_fptr_t display_fptr;    // convert to user-friendly string
+        std::string datatype_iri;                   // datatype IRI string
+        factory_fptr_t factory_fptr;                // construct from string
+        to_string_fptr_t to_canonical_string_fptr;  // convert to canonical string
+        to_string_fptr_t to_simplified_string_fptr; // convert to simplified string (e.g. for casting to xsd:string)
 
         ebv_fptr_t ebv_fptr; // convert to effective boolean value
 
@@ -111,8 +111,8 @@ public:
             return DatatypeEntry{
                     .datatype_iri = "",
                     .factory_fptr = nullptr,
-                    .to_string_fptr = nullptr,
-                    .display_fptr = nullptr,
+                    .to_canonical_string_fptr = nullptr,
+                    .to_simplified_string_fptr = nullptr,
                     .ebv_fptr = nullptr,
                     .numeric_ops = std::nullopt,
                     .inlining_ops = std::nullopt,
@@ -124,8 +124,8 @@ public:
             return DatatypeEntry{
                     .datatype_iri = std::string{datatype_iri},
                     .factory_fptr = nullptr,
-                    .to_string_fptr = nullptr,
-                    .display_fptr = nullptr,
+                    .to_canonical_string_fptr = nullptr,
+                    .to_simplified_string_fptr = nullptr,
                     .ebv_fptr = nullptr,
                     .numeric_ops = std::nullopt,
                     .inlining_ops = std::nullopt,
@@ -225,18 +225,18 @@ public:
     [[nodiscard]] static factory_fptr_t get_factory(DatatypeIDView datatype_id) noexcept;
 
     /**
-     * Get a to_string function for a datatype. The factory_fptr_t can be used like `std::string str_repr = to_string_fptr(any_typed_arg)`.
+     * Get a to_canonical_string function for a datatype. The factory_fptr_t can be used like `std::string str_repr = to_canonical_string_fptr(any_typed_arg)`.
      * @param datatype_id datatype id for the corresponding datatype
      * @return function pointer or nullptr
      */
-    [[nodiscard]] static to_string_fptr_t get_to_string(DatatypeIDView datatype_id) noexcept;
+    [[nodiscard]] static to_string_fptr_t get_to_canonical_string(DatatypeIDView datatype_id) noexcept;
 
     /**
-     * Get the display function for a datatype. This function can be used for user friendly output.
+     * Get the to_simplified_string function for a datatype. This function can be used for user friendly output.
      * @param datatype_id datatype id for the corresponding datatype
      * @return function pointer if datatype was found else nullptr
      */
-    [[nodiscard]] static to_string_fptr_t get_display(DatatypeIDView datatype_id) noexcept;
+    [[nodiscard]] static to_string_fptr_t get_to_simplified_string(DatatypeIDView datatype_id) noexcept;
 
     /**
      * Try to get the numerical ops function table for a datatype.
@@ -393,11 +393,11 @@ inline void DatatypeRegistry::add() noexcept {
             .factory_fptr = [](std::string_view string_repr) -> std::any {
                 return std::any{LiteralDatatype_t::from_string(string_repr)};
             },
-            .to_string_fptr = [](std::any const &value) noexcept -> std::string {
-                return LiteralDatatype_t::to_string(std::any_cast<typename LiteralDatatype_t::cpp_type>(value));
+            .to_canonical_string_fptr = [](std::any const &value) noexcept -> std::string {
+                return LiteralDatatype_t::to_canonical_string(std::any_cast<typename LiteralDatatype_t::cpp_type>(value));
             },
-            .display_fptr = [](std::any const &value) noexcept -> std::string {
-                return LiteralDatatype_t::display(std::any_cast<typename LiteralDatatype_t::cpp_type>(value));
+            .to_simplified_string_fptr = [](std::any const &value) noexcept -> std::string {
+                return LiteralDatatype_t::to_simplified_string(std::any_cast<typename LiteralDatatype_t::cpp_type>(value));
             },
             .ebv_fptr = ebv_fptr,
             .numeric_ops = num_ops,

--- a/src/rdf4cpp/rdf/datatypes/registry/LiteralDatatypeImpl.hpp
+++ b/src/rdf4cpp/rdf/datatypes/registry/LiteralDatatypeImpl.hpp
@@ -69,8 +69,8 @@ struct Default {
      * @param value the value
      * @return <div>value</div>'s canonical string representation
      */
-    inline static std::string to_string(cpp_type const &value) noexcept {
-        // If not further specified, to_string is instantiated via operator<<. If operator<< is not defined for cpp_type instantiation will fail.
+    inline static std::string to_canonical_string(cpp_type const &value) noexcept {
+        // If not further specified, to_canonical_string is instantiated via operator<<. If operator<< is not defined for cpp_type instantiation will fail.
         std::stringstream str_s;
         str_s << value;
         return str_s.str();
@@ -80,8 +80,8 @@ struct Default {
      * Returns a string representation of a datatype that is intended to be shown in user friendly output.
      * E.g. when casting to xsd:string
      */
-    inline static std::string display(cpp_type const &value) noexcept {
-        return to_string(value);
+    inline static std::string to_simplified_string(cpp_type const &value) noexcept {
+        return to_canonical_string(value);
     }
 };
 

--- a/src/rdf4cpp/rdf/datatypes/registry/LiteralDatatypeImpl.hpp
+++ b/src/rdf4cpp/rdf/datatypes/registry/LiteralDatatypeImpl.hpp
@@ -75,6 +75,14 @@ struct Default {
         str_s << value;
         return str_s.str();
     }
+
+    /**
+     * Returns a string representation of a datatype that is intended to be shown in user friendly output.
+     * E.g. when casting to xsd:string
+     */
+    inline static std::string display(cpp_type const &value) noexcept {
+        return to_string(value);
+    }
 };
 
 /**

--- a/src/rdf4cpp/rdf/datatypes/registry/util/LangTag.hpp
+++ b/src/rdf4cpp/rdf/datatypes/registry/util/LangTag.hpp
@@ -1,0 +1,55 @@
+#ifndef RDF4CPP_REGISTRY_UTIL_LANGTAG_HPP
+#define RDF4CPP_REGISTRY_UTIL_LANGTAG_HPP
+
+#include <string_view>
+
+namespace rdf4cpp::rdf::datatypes::registry::util {
+
+struct LangTagCharTraits : std::char_traits<char> {
+    static constexpr bool eq(char_type const c1, char_type const c2) noexcept {
+        return std::tolower(c1) == std::tolower(c2);
+    }
+
+    static constexpr bool ne(char_type const c1, char_type const c2) noexcept {
+        return std::tolower(c1) != std::tolower(c2);
+    }
+
+    static constexpr bool lt(char_type const c1, char_type const c2) noexcept {
+        return std::tolower(c1) < std::tolower(c2);
+    }
+
+    static constexpr int compare(char_type const *s1, char_type const *s2, size_t const len) noexcept {
+        for (size_t ix = 0; ix < len; ++ix) {
+            auto const c1 = std::tolower(s1[ix]);
+            auto const c2 = std::tolower(s2[ix]);
+
+            if (c1 < c2) {
+                return -1;
+            }
+
+            if (c1 > c2) {
+                return 1;
+            }
+        }
+
+        return 0;
+    }
+
+    static constexpr char_type const *find(char_type const *s, size_t const len, char const needle) noexcept {
+        auto const ineedle = std::tolower(needle);
+
+        for (size_t ix = 0; ix < len; ++ix) {
+            if (std::tolower(s[ix]) == ineedle) {
+                return &s[ix];
+            }
+        }
+
+        return nullptr;
+    }
+};
+
+using LangTagView = std::basic_string_view<char, LangTagCharTraits>;
+
+}  //namespace rdf4cpp::rdf::datatypes::registry::util
+
+#endif  //RDF4CPP_REGISTRY_UTIL_LANGTAG_HPP

--- a/src/rdf4cpp/rdf/datatypes/registry/util/LangTag.hpp
+++ b/src/rdf4cpp/rdf/datatypes/registry/util/LangTag.hpp
@@ -6,6 +6,13 @@
 namespace rdf4cpp::rdf::datatypes::registry::util {
 
 struct LangTagCharTraits : std::char_traits<char> {
+    using char_type = std::char_traits<char>::char_type;
+    using pos_type = std::char_traits<char>::pos_type;
+    using int_type = std::char_traits<char>::int_type;
+    using off_type = std::char_traits<char>::off_type;
+    using state_type = std::char_traits<char>::state_type;
+    using comparison_category = std::char_traits<char>::comparison_category;
+
     static constexpr bool eq(char_type const c1, char_type const c2) noexcept {
         return std::tolower(c1) == std::tolower(c2);
     }

--- a/src/rdf4cpp/rdf/datatypes/xsd/Base64Binary.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Base64Binary.cpp
@@ -220,7 +220,7 @@ capabilities::Default<xsd_base64_binary>::cpp_type capabilities::Default<xsd_bas
 }
 
 template<>
-std::string capabilities::Default<xsd_base64_binary>::to_string(cpp_type const &value) noexcept {
+std::string capabilities::Default<xsd_base64_binary>::to_canonical_string(cpp_type const &value) noexcept {
     return value.to_encoded();
 }
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/Base64Binary.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Base64Binary.hpp
@@ -69,7 +69,7 @@ template<>
 capabilities::Default<xsd_base64_binary>::cpp_type capabilities::Default<xsd_base64_binary>::from_string(std::string_view s);
 
 template<>
-std::string capabilities::Default<xsd_base64_binary>::to_string(cpp_type const &value) noexcept;
+std::string capabilities::Default<xsd_base64_binary>::to_canonical_string(cpp_type const &value) noexcept;
 
 extern template struct LiteralDatatypeImpl<xsd_base64_binary>;
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/Boolean.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Boolean.cpp
@@ -16,7 +16,7 @@ capabilities::Default<xsd_boolean>::cpp_type capabilities::Default<xsd_boolean>:
 }
 
 template<>
-std::string capabilities::Default<xsd_boolean>::to_string(const cpp_type &value) noexcept {
+std::string capabilities::Default<xsd_boolean>::to_canonical_string(cpp_type const &value) noexcept {
     if (value)  {
         return "true";
     } else {

--- a/src/rdf4cpp/rdf/datatypes/xsd/Boolean.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Boolean.hpp
@@ -21,7 +21,7 @@ template<>
 capabilities::Default<xsd_boolean>::cpp_type capabilities::Default<xsd_boolean>::from_string(std::string_view s);
 
 template<>
-std::string capabilities::Default<xsd_boolean>::to_string(const cpp_type &value) noexcept;
+std::string capabilities::Default<xsd_boolean>::to_canonical_string(cpp_type const &value) noexcept;
 
 template<>
 bool capabilities::Logical<xsd_boolean>::effective_boolean_value(cpp_type const &value) noexcept;

--- a/src/rdf4cpp/rdf/datatypes/xsd/Decimal.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Decimal.cpp
@@ -9,7 +9,8 @@ namespace rdf4cpp::rdf::datatypes::registry {
 
 template<>
 capabilities::Default<xsd_decimal>::cpp_type capabilities::Default<xsd_decimal>::from_string(std::string_view s) {
-    static std::regex const decimal_regex{R"#((\+|-)?[0-9]+\.[0-9]*)#", std::regex_constants::optimize};
+    // https://www.w3.org/TR/xmlschema11-2/#decimal
+    static std::regex const decimal_regex{R"#((\+|-)?([0-9]+(\.[0-9]*)?|\.[0-9]+))#", std::regex_constants::optimize};
 
     if (!std::regex_match(s.begin(), s.end(), decimal_regex)) {
         throw std::runtime_error{"XSD Parsing Error"};
@@ -19,15 +20,11 @@ capabilities::Default<xsd_decimal>::cpp_type capabilities::Default<xsd_decimal>:
         s.remove_prefix(1);
     }
 
-    try {
-        return cpp_type{s};
-    } catch (std::runtime_error const &e) {
-        throw std::runtime_error{std::string{"xsd:decimal parsing error: "} + e.what()};
-    }
+    return cpp_type{s};
 }
 
 template<>
-std::string capabilities::Default<xsd_decimal>::to_string(const cpp_type &value) noexcept {
+std::string capabilities::Default<xsd_decimal>::to_string(cpp_type const &value) noexcept {
     auto s = value.str(std::numeric_limits<cpp_type>::digits10, std::ios_base::fixed | std::ios_base::showpoint);
     auto const non_zero_pos = s.find_last_not_of('0');
 
@@ -42,6 +39,11 @@ std::string capabilities::Default<xsd_decimal>::to_string(const cpp_type &value)
     s.resize(non_zero_pos + 1 + static_cast<std::string::size_type>(s[non_zero_pos] == '.'));
 
     return s;
+}
+
+template<>
+std::string capabilities::Default<xsd_decimal>::display(cpp_type const &value) noexcept {
+    return value.str();
 }
 
 template<>

--- a/src/rdf4cpp/rdf/datatypes/xsd/Decimal.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Decimal.cpp
@@ -24,7 +24,7 @@ capabilities::Default<xsd_decimal>::cpp_type capabilities::Default<xsd_decimal>:
 }
 
 template<>
-std::string capabilities::Default<xsd_decimal>::to_string(cpp_type const &value) noexcept {
+std::string capabilities::Default<xsd_decimal>::to_canonical_string(cpp_type const &value) noexcept {
     auto s = value.str(std::numeric_limits<cpp_type>::digits10, std::ios_base::fixed | std::ios_base::showpoint);
     auto const non_zero_pos = s.find_last_not_of('0');
 
@@ -42,7 +42,7 @@ std::string capabilities::Default<xsd_decimal>::to_string(cpp_type const &value)
 }
 
 template<>
-std::string capabilities::Default<xsd_decimal>::display(cpp_type const &value) noexcept {
+std::string capabilities::Default<xsd_decimal>::to_simplified_string(cpp_type const &value) noexcept {
     return value.str();
 }
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/Decimal.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Decimal.hpp
@@ -26,10 +26,10 @@ template<>
 capabilities::Default<xsd_decimal>::cpp_type capabilities::Default<xsd_decimal>::from_string(std::string_view s);
 
 template<>
-std::string capabilities::Default<xsd_decimal>::to_string(const cpp_type &value) noexcept;
+std::string capabilities::Default<xsd_decimal>::to_canonical_string(const cpp_type &value) noexcept;
 
 template<>
-std::string capabilities::Default<xsd_decimal>::display(cpp_type const &value) noexcept;
+std::string capabilities::Default<xsd_decimal>::to_simplified_string(cpp_type const &value) noexcept;
 
 template<>
 nonstd::expected<capabilities::Numeric<xsd_decimal>::add_result_cpp_type, DynamicError> capabilities::Numeric<xsd_decimal>::add(cpp_type const &lhs, cpp_type const &rhs) noexcept;

--- a/src/rdf4cpp/rdf/datatypes/xsd/Decimal.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Decimal.hpp
@@ -29,6 +29,9 @@ template<>
 std::string capabilities::Default<xsd_decimal>::to_string(const cpp_type &value) noexcept;
 
 template<>
+std::string capabilities::Default<xsd_decimal>::display(cpp_type const &value) noexcept;
+
+template<>
 nonstd::expected<capabilities::Numeric<xsd_decimal>::add_result_cpp_type, DynamicError> capabilities::Numeric<xsd_decimal>::add(cpp_type const &lhs, cpp_type const &rhs) noexcept;
 
 template<>

--- a/src/rdf4cpp/rdf/datatypes/xsd/Double.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Double.cpp
@@ -16,6 +16,25 @@ std::string capabilities::Default<xsd_double>::to_string(cpp_type const &value) 
 }
 
 template<>
+std::string capabilities::Default<xsd_double>::display(cpp_type const &value) noexcept {
+    if (value == 0) {
+        return std::signbit(value) ? "-0" : "0";
+    }
+
+    if (auto const abs = std::abs(value); abs >= 0.000001 && abs < 1000000) {
+        static constexpr size_t buf_sz = 2 + std::numeric_limits<cpp_type>::max_exponent10 + std::numeric_limits<cpp_type>::max_digits10;
+        std::array<char, buf_sz> buf;
+
+        auto const res = std::to_chars(buf.data(), buf.data() + buf.size(), value, std::chars_format::fixed);
+        assert(res.ec == std::errc{});
+
+        return std::string{buf.data(), static_cast<std::string::size_type>(res.ptr - buf.data())};
+    }
+
+    return to_string(value);
+}
+
+template<>
 bool capabilities::Logical<xsd_double>::effective_boolean_value(cpp_type const &value) noexcept {
     return !std::isnan(value) && value != 0.0;
 }

--- a/src/rdf4cpp/rdf/datatypes/xsd/Double.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Double.cpp
@@ -11,12 +11,12 @@ capabilities::Default<xsd_double>::cpp_type capabilities::Default<xsd_double>::f
 }
 
 template<>
-std::string capabilities::Default<xsd_double>::to_string(cpp_type const &value) noexcept {
+std::string capabilities::Default<xsd_double>::to_canonical_string(cpp_type const &value) noexcept {
     return util::to_chars_canonical(value);
 }
 
 template<>
-std::string capabilities::Default<xsd_double>::display(cpp_type const &value) noexcept {
+std::string capabilities::Default<xsd_double>::to_simplified_string(cpp_type const &value) noexcept {
     return util::to_chars_simplified(value);
 }
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/Double.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Double.cpp
@@ -12,26 +12,12 @@ capabilities::Default<xsd_double>::cpp_type capabilities::Default<xsd_double>::f
 
 template<>
 std::string capabilities::Default<xsd_double>::to_string(cpp_type const &value) noexcept {
-    return util::to_chars(value);
+    return util::to_chars_canonical(value);
 }
 
 template<>
 std::string capabilities::Default<xsd_double>::display(cpp_type const &value) noexcept {
-    if (value == 0) {
-        return std::signbit(value) ? "-0" : "0";
-    }
-
-    if (auto const abs = std::abs(value); abs >= 0.000001 && abs < 1000000) {
-        static constexpr size_t buf_sz = 2 + std::numeric_limits<cpp_type>::max_exponent10 + std::numeric_limits<cpp_type>::max_digits10;
-        std::array<char, buf_sz> buf;
-
-        auto const res = std::to_chars(buf.data(), buf.data() + buf.size(), value, std::chars_format::fixed);
-        assert(res.ec == std::errc{});
-
-        return std::string{buf.data(), static_cast<std::string::size_type>(res.ptr - buf.data())};
-    }
-
-    return to_string(value);
+    return util::to_chars_simplified(value);
 }
 
 template<>

--- a/src/rdf4cpp/rdf/datatypes/xsd/Double.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Double.hpp
@@ -16,10 +16,10 @@ template<>
 capabilities::Default<xsd_double>::cpp_type capabilities::Default<xsd_double>::from_string(std::string_view s);
 
 template<>
-std::string capabilities::Default<xsd_double>::to_string(cpp_type const &value) noexcept;
+std::string capabilities::Default<xsd_double>::to_canonical_string(cpp_type const &value) noexcept;
 
 template<>
-std::string capabilities::Default<xsd_double>::display(cpp_type const &value) noexcept;
+std::string capabilities::Default<xsd_double>::to_simplified_string(cpp_type const &value) noexcept;
 
 template<>
 bool capabilities::Logical<xsd_double>::effective_boolean_value(cpp_type const &value) noexcept;

--- a/src/rdf4cpp/rdf/datatypes/xsd/Double.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Double.hpp
@@ -19,6 +19,9 @@ template<>
 std::string capabilities::Default<xsd_double>::to_string(cpp_type const &value) noexcept;
 
 template<>
+std::string capabilities::Default<xsd_double>::display(cpp_type const &value) noexcept;
+
+template<>
 bool capabilities::Logical<xsd_double>::effective_boolean_value(cpp_type const &value) noexcept;
 
 template<>

--- a/src/rdf4cpp/rdf/datatypes/xsd/Float.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Float.cpp
@@ -12,7 +12,6 @@ capabilities::Default<xsd_float>::cpp_type capabilities::Default<xsd_float>::fro
 
 template<>
 std::string capabilities::Default<xsd_float>::to_string(cpp_type const &value) noexcept {
-    std::abort();
     return util::to_chars(value);
 }
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/Float.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Float.cpp
@@ -11,12 +11,12 @@ capabilities::Default<xsd_float>::cpp_type capabilities::Default<xsd_float>::fro
 }
 
 template<>
-std::string capabilities::Default<xsd_float>::to_string(cpp_type const &value) noexcept {
+std::string capabilities::Default<xsd_float>::to_canonical_string(cpp_type const &value) noexcept {
     return util::to_chars_canonical(value);
 }
 
 template<>
-std::string capabilities::Default<xsd_float>::display(cpp_type const &value) noexcept {
+std::string capabilities::Default<xsd_float>::to_simplified_string(cpp_type const &value) noexcept {
     return util::to_chars_simplified(value);
 }
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/Float.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Float.cpp
@@ -12,13 +12,12 @@ capabilities::Default<xsd_float>::cpp_type capabilities::Default<xsd_float>::fro
 
 template<>
 std::string capabilities::Default<xsd_float>::to_string(cpp_type const &value) noexcept {
+    std::abort();
     return util::to_chars(value);
 }
 
 template<>
 std::string capabilities::Default<xsd_float>::display(cpp_type const &value) noexcept {
-    std::abort();
-
     if (value == 0) {
         return std::signbit(value) ? "-0" : "0";
     }

--- a/src/rdf4cpp/rdf/datatypes/xsd/Float.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Float.cpp
@@ -12,26 +12,12 @@ capabilities::Default<xsd_float>::cpp_type capabilities::Default<xsd_float>::fro
 
 template<>
 std::string capabilities::Default<xsd_float>::to_string(cpp_type const &value) noexcept {
-    return util::to_chars(value);
+    return util::to_chars_canonical(value);
 }
 
 template<>
 std::string capabilities::Default<xsd_float>::display(cpp_type const &value) noexcept {
-    if (value == 0) {
-        return std::signbit(value) ? "-0" : "0";
-    }
-
-    if (auto const abs = std::abs(value); abs >= 0.000001 && abs < 1000000) {
-        static constexpr size_t buf_sz = 2 + std::numeric_limits<cpp_type>::max_exponent10 + std::numeric_limits<cpp_type>::max_digits10;
-        std::array<char, buf_sz> buf;
-
-        auto const res = std::to_chars(buf.data(), buf.data() + buf.size(), value, std::chars_format::fixed);
-        assert(res.ec == std::errc{});
-
-        return std::string{buf.data(), static_cast<std::string::size_type>(res.ptr - buf.data())};
-    }
-
-    return to_string(value);
+    return util::to_chars_simplified(value);
 }
 
 template<>

--- a/src/rdf4cpp/rdf/datatypes/xsd/Float.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Float.cpp
@@ -17,6 +17,8 @@ std::string capabilities::Default<xsd_float>::to_string(cpp_type const &value) n
 
 template<>
 std::string capabilities::Default<xsd_float>::display(cpp_type const &value) noexcept {
+    std::abort();
+
     if (value == 0) {
         return std::signbit(value) ? "-0" : "0";
     }

--- a/src/rdf4cpp/rdf/datatypes/xsd/Float.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Float.cpp
@@ -15,6 +15,24 @@ std::string capabilities::Default<xsd_float>::to_string(cpp_type const &value) n
     return util::to_chars(value);
 }
 
+template<>
+std::string capabilities::Default<xsd_float>::display(cpp_type const &value) noexcept {
+    if (value == 0) {
+        return std::signbit(value) ? "-0" : "0";
+    }
+
+    if (auto const abs = std::abs(value); abs >= 0.000001 && abs < 1000000) {
+        static constexpr size_t buf_sz = 2 + std::numeric_limits<cpp_type>::max_exponent10 + std::numeric_limits<cpp_type>::max_digits10;
+        std::array<char, buf_sz> buf;
+
+        auto const res = std::to_chars(buf.data(), buf.data() + buf.size(), value, std::chars_format::fixed);
+        assert(res.ec == std::errc{});
+
+        return std::string{buf.data(), static_cast<std::string::size_type>(res.ptr - buf.data())};
+    }
+
+    return to_string(value);
+}
 
 template<>
 bool capabilities::Logical<xsd_float>::effective_boolean_value(cpp_type const &value) noexcept {

--- a/src/rdf4cpp/rdf/datatypes/xsd/Float.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Float.hpp
@@ -25,6 +25,9 @@ template<>
 std::string capabilities::Default<xsd_float>::to_string(cpp_type const &value) noexcept;
 
 template<>
+std::string capabilities::Default<xsd_float>::display(cpp_type const &value) noexcept;
+
+template<>
 bool capabilities::Logical<xsd_float>::effective_boolean_value(cpp_type const &value) noexcept;
 
 template<>

--- a/src/rdf4cpp/rdf/datatypes/xsd/Float.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Float.hpp
@@ -22,10 +22,10 @@ template<>
 capabilities::Default<xsd_float>::cpp_type capabilities::Default<xsd_float>::from_string(std::string_view s);
 
 template<>
-std::string capabilities::Default<xsd_float>::to_string(cpp_type const &value) noexcept;
+std::string capabilities::Default<xsd_float>::to_canonical_string(cpp_type const &value) noexcept;
 
 template<>
-std::string capabilities::Default<xsd_float>::display(cpp_type const &value) noexcept;
+std::string capabilities::Default<xsd_float>::to_simplified_string(cpp_type const &value) noexcept;
 
 template<>
 bool capabilities::Logical<xsd_float>::effective_boolean_value(cpp_type const &value) noexcept;

--- a/src/rdf4cpp/rdf/datatypes/xsd/HexBinary.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/HexBinary.cpp
@@ -117,7 +117,7 @@ capabilities::Default<xsd_hex_binary>::cpp_type capabilities::Default<xsd_hex_bi
 }
 
 template<>
-std::string capabilities::Default<xsd_hex_binary>::to_string(cpp_type const &value) noexcept {
+std::string capabilities::Default<xsd_hex_binary>::to_canonical_string(cpp_type const &value) noexcept {
     return value.to_encoded();
 }
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/HexBinary.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/HexBinary.hpp
@@ -72,7 +72,7 @@ template<>
 capabilities::Default<xsd_hex_binary>::cpp_type capabilities::Default<xsd_hex_binary>::from_string(std::string_view s);
 
 template<>
-std::string capabilities::Default<xsd_hex_binary>::to_string(cpp_type const &value) noexcept;
+std::string capabilities::Default<xsd_hex_binary>::to_canonical_string(cpp_type const &value) noexcept;
 
 extern template struct LiteralDatatypeImpl<xsd_hex_binary>;
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/String.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/String.cpp
@@ -12,7 +12,7 @@ capabilities::Default<xsd_string>::cpp_type capabilities::Default<xsd_string>::f
 }
 
 template<>
-std::string capabilities::Default<xsd_string>::to_string(cpp_type const &value) noexcept {
+std::string capabilities::Default<xsd_string>::to_canonical_string(cpp_type const &value) noexcept {
     return value;
 }
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/String.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/String.hpp
@@ -16,7 +16,7 @@ template<>
 capabilities::Default<xsd_string>::cpp_type capabilities::Default<xsd_string>::from_string(std::string_view s);
 
 template<>
-std::string capabilities::Default<xsd_string>::to_string(cpp_type const &value) noexcept;
+std::string capabilities::Default<xsd_string>::to_canonical_string(cpp_type const &value) noexcept;
 
 template<>
 bool capabilities::Logical<xsd_string>::effective_boolean_value(cpp_type const &value) noexcept;

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedByte.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedByte.cpp
@@ -10,7 +10,7 @@ capabilities::Default<xsd_unsigned_byte>::cpp_type capabilities::Default<xsd_uns
 
 template<>
 std::string capabilities::Default<xsd_unsigned_byte>::to_string(cpp_type const &value) noexcept {
-    return util::to_chars(value);
+    return util::to_chars_canonical(value);
 }
 
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedByte.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedByte.cpp
@@ -9,7 +9,7 @@ capabilities::Default<xsd_unsigned_byte>::cpp_type capabilities::Default<xsd_uns
 }
 
 template<>
-std::string capabilities::Default<xsd_unsigned_byte>::to_string(cpp_type const &value) noexcept {
+std::string capabilities::Default<xsd_unsigned_byte>::to_canonical_string(cpp_type const &value) noexcept {
     return util::to_chars_canonical(value);
 }
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedByte.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedByte.hpp
@@ -30,7 +30,7 @@ template<>
 capabilities::Default<xsd_unsigned_byte>::cpp_type capabilities::Default<xsd_unsigned_byte>::from_string(std::string_view s);
 
 template<>
-std::string capabilities::Default<xsd_unsigned_byte>::to_string(cpp_type const &value) noexcept;
+std::string capabilities::Default<xsd_unsigned_byte>::to_canonical_string(cpp_type const &value) noexcept;
 
 template<>
 bool capabilities::Logical<xsd_unsigned_byte>::effective_boolean_value(cpp_type const &value) noexcept;

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedInt.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedInt.cpp
@@ -10,7 +10,7 @@ capabilities::Default<xsd_unsigned_int>::cpp_type capabilities::Default<xsd_unsi
 
 template<>
 std::string capabilities::Default<xsd_unsigned_int>::to_string(cpp_type const &value) noexcept {
-    return util::to_chars(value);
+    return util::to_chars_canonical(value);
 }
 
 template<>

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedInt.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedInt.cpp
@@ -9,7 +9,7 @@ capabilities::Default<xsd_unsigned_int>::cpp_type capabilities::Default<xsd_unsi
 }
 
 template<>
-std::string capabilities::Default<xsd_unsigned_int>::to_string(cpp_type const &value) noexcept {
+std::string capabilities::Default<xsd_unsigned_int>::to_canonical_string(cpp_type const &value) noexcept {
     return util::to_chars_canonical(value);
 }
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedInt.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedInt.hpp
@@ -30,7 +30,7 @@ template<>
 capabilities::Default<xsd_unsigned_int>::cpp_type capabilities::Default<xsd_unsigned_int>::from_string(std::string_view s);
 
 template<>
-std::string capabilities::Default<xsd_unsigned_int>::to_string(cpp_type const &value) noexcept;
+std::string capabilities::Default<xsd_unsigned_int>::to_canonical_string(cpp_type const &value) noexcept;
 
 template<>
 bool capabilities::Logical<xsd_unsigned_int>::effective_boolean_value(cpp_type const &value) noexcept;

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedLong.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedLong.cpp
@@ -9,7 +9,7 @@ capabilities::Default<xsd_unsigned_long>::cpp_type capabilities::Default<xsd_uns
 }
 
 template<>
-std::string capabilities::Default<xsd_unsigned_long>::to_string(cpp_type const &value) noexcept {
+std::string capabilities::Default<xsd_unsigned_long>::to_canonical_string(cpp_type const &value) noexcept {
     return util::to_chars_canonical(value);
 }
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedLong.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedLong.cpp
@@ -10,7 +10,7 @@ capabilities::Default<xsd_unsigned_long>::cpp_type capabilities::Default<xsd_uns
 
 template<>
 std::string capabilities::Default<xsd_unsigned_long>::to_string(cpp_type const &value) noexcept {
-    return util::to_chars(value);
+    return util::to_chars_canonical(value);
 }
 
 template<>

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedLong.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedLong.hpp
@@ -30,7 +30,7 @@ template<>
 capabilities::Default<xsd_unsigned_long>::cpp_type capabilities::Default<xsd_unsigned_long>::from_string(std::string_view s);
 
 template<>
-std::string capabilities::Default<xsd_unsigned_long>::to_string(cpp_type const &value) noexcept;
+std::string capabilities::Default<xsd_unsigned_long>::to_canonical_string(cpp_type const &value) noexcept;
 
 template<>
 bool capabilities::Logical<xsd_unsigned_long>::effective_boolean_value(cpp_type const &value) noexcept;

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedShort.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedShort.cpp
@@ -9,7 +9,7 @@ capabilities::Default<xsd_unsigned_short>::cpp_type capabilities::Default<xsd_un
 }
 
 template<>
-std::string capabilities::Default<xsd_unsigned_short>::to_string(cpp_type const &value) noexcept {
+std::string capabilities::Default<xsd_unsigned_short>::to_canonical_string(cpp_type const &value) noexcept {
     return util::to_chars_canonical(value);
 }
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedShort.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedShort.cpp
@@ -10,7 +10,7 @@ capabilities::Default<xsd_unsigned_short>::cpp_type capabilities::Default<xsd_un
 
 template<>
 std::string capabilities::Default<xsd_unsigned_short>::to_string(cpp_type const &value) noexcept {
-    return util::to_chars(value);
+    return util::to_chars_canonical(value);
 }
 
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedShort.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedShort.hpp
@@ -30,7 +30,7 @@ template<>
 capabilities::Default<xsd_unsigned_short>::cpp_type capabilities::Default<xsd_unsigned_short>::from_string(std::string_view s);
 
 template<>
-std::string capabilities::Default<xsd_unsigned_short>::to_string(cpp_type const &value) noexcept;
+std::string capabilities::Default<xsd_unsigned_short>::to_canonical_string(cpp_type const &value) noexcept;
 
 template<>
 bool capabilities::Logical<xsd_unsigned_short>::effective_boolean_value(cpp_type const &value) noexcept;

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Byte.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Byte.cpp
@@ -10,7 +10,7 @@ capabilities::Default<xsd_byte>::cpp_type capabilities::Default<xsd_byte>::from_
 
 template<>
 std::string capabilities::Default<xsd_byte>::to_string(cpp_type const &value) noexcept {
-    return util::to_chars(value);
+    return util::to_chars_canonical(value);
 }
 
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Byte.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Byte.cpp
@@ -9,7 +9,7 @@ capabilities::Default<xsd_byte>::cpp_type capabilities::Default<xsd_byte>::from_
 }
 
 template<>
-std::string capabilities::Default<xsd_byte>::to_string(cpp_type const &value) noexcept {
+std::string capabilities::Default<xsd_byte>::to_canonical_string(cpp_type const &value) noexcept {
     return util::to_chars_canonical(value);
 }
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Byte.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Byte.hpp
@@ -30,7 +30,7 @@ template<>
 capabilities::Default<xsd_byte>::cpp_type capabilities::Default<xsd_byte>::from_string(std::string_view s);
 
 template<>
-std::string capabilities::Default<xsd_byte>::to_string(cpp_type const &value) noexcept;
+std::string capabilities::Default<xsd_byte>::to_canonical_string(cpp_type const &value) noexcept;
 
 
 template<>

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Int.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Int.cpp
@@ -11,7 +11,7 @@ capabilities::Default<xsd_int>::cpp_type capabilities::Default<xsd_int>::from_st
 
 template<>
 std::string capabilities::Default<xsd_int>::to_string(cpp_type const &value) noexcept {
-    return util::to_chars(value);
+    return util::to_chars_canonical(value);
 }
 
 template<>

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Int.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Int.cpp
@@ -10,7 +10,7 @@ capabilities::Default<xsd_int>::cpp_type capabilities::Default<xsd_int>::from_st
 }
 
 template<>
-std::string capabilities::Default<xsd_int>::to_string(cpp_type const &value) noexcept {
+std::string capabilities::Default<xsd_int>::to_canonical_string(cpp_type const &value) noexcept {
     return util::to_chars_canonical(value);
 }
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Int.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Int.hpp
@@ -30,7 +30,7 @@ template<>
 capabilities::Default<xsd_int>::cpp_type capabilities::Default<xsd_int>::from_string(std::string_view s);
 
 template<>
-std::string capabilities::Default<xsd_int>::to_string(cpp_type const &value) noexcept;
+std::string capabilities::Default<xsd_int>::to_canonical_string(cpp_type const &value) noexcept;
 
 template<>
 bool capabilities::Logical<xsd_int>::effective_boolean_value(cpp_type const &value) noexcept;

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Long.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Long.cpp
@@ -9,7 +9,7 @@ capabilities::Default<xsd_long>::cpp_type capabilities::Default<xsd_long>::from_
 }
 
 template<>
-std::string capabilities::Default<xsd_long>::to_string(cpp_type const &value) noexcept {
+std::string capabilities::Default<xsd_long>::to_canonical_string(cpp_type const &value) noexcept {
     return util::to_chars_canonical(value);
 }
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Long.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Long.cpp
@@ -10,7 +10,7 @@ capabilities::Default<xsd_long>::cpp_type capabilities::Default<xsd_long>::from_
 
 template<>
 std::string capabilities::Default<xsd_long>::to_string(cpp_type const &value) noexcept {
-    return util::to_chars(value);
+    return util::to_chars_canonical(value);
 }
 
 template<>

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Long.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Long.hpp
@@ -29,7 +29,7 @@ template<>
 capabilities::Default<xsd_long>::cpp_type capabilities::Default<xsd_long>::from_string(std::string_view s);
 
 template<>
-std::string capabilities::Default<xsd_long>::to_string(cpp_type const &value) noexcept;
+std::string capabilities::Default<xsd_long>::to_canonical_string(cpp_type const &value) noexcept;
 
 template<>
 bool capabilities::Logical<xsd_long>::effective_boolean_value(cpp_type const &value) noexcept;

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Short.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Short.cpp
@@ -9,7 +9,7 @@ capabilities::Default<xsd_short>::cpp_type capabilities::Default<xsd_short>::fro
 }
 
 template<>
-std::string capabilities::Default<xsd_short>::to_string(cpp_type const &value) noexcept {
+std::string capabilities::Default<xsd_short>::to_canonical_string(cpp_type const &value) noexcept {
     return util::to_chars_canonical(value);
 }
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Short.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Short.cpp
@@ -10,7 +10,7 @@ capabilities::Default<xsd_short>::cpp_type capabilities::Default<xsd_short>::fro
 
 template<>
 std::string capabilities::Default<xsd_short>::to_string(cpp_type const &value) noexcept {
-    return util::to_chars(value);
+    return util::to_chars_canonical(value);
 }
 
 

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Short.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Short.hpp
@@ -30,7 +30,7 @@ template<>
 capabilities::Default<xsd_short>::cpp_type capabilities::Default<xsd_short>::from_string(std::string_view s);
 
 template<>
-std::string capabilities::Default<xsd_short>::to_string(cpp_type const &value) noexcept;
+std::string capabilities::Default<xsd_short>::to_canonical_string(cpp_type const &value) noexcept;
 
 
 template<>

--- a/tests/datatype/tests_Double.cpp
+++ b/tests/datatype/tests_Double.cpp
@@ -89,6 +89,13 @@ TEST_CASE("Datatype Double") {
     CHECK_THROWS(no_discard_dummy = Literal("454sdsd", type_iri));
 }
 
+TEST_CASE("round-trip") {
+    datatypes::xsd::Double::cpp_type const value = -0.1234567890001;
+    auto const lit = Literal::make<datatypes::xsd::Double>(value);
+    std::cout << lit.lexical_form() << std::endl;
+    CHECK(lit.value<datatypes::xsd::Double>() == value);
+}
+
 TEST_CASE("double inlining") {
     double value = 9999;
     auto lit = Literal::make<datatypes::xsd::Double>(value);

--- a/tests/datatype/tests_LangString.cpp
+++ b/tests/datatype/tests_LangString.cpp
@@ -18,9 +18,12 @@ TEST_CASE("rdf:langString") {
 
     Literal const lit3{"hello", "de-DE"};
     Literal const lit4{"hallo", "de-DE"};
+    Literal const lit5{"hallo", "de-de"};
     CHECK(lit1 != lit3);
     CHECK(lit1 != lit4);
     CHECK(lit3 != lit4);
+    CHECK(lit3 != lit5);
+    CHECK(lit4 == lit5);
 
     SUBCASE("value extraction") {
         CHECK(static_cast<std::string>(lit1) == R"("hello"@en)");

--- a/tests/nodes/tests_Literal.cpp
+++ b/tests/nodes/tests_Literal.cpp
@@ -182,11 +182,128 @@ TEST_CASE("Literal - casting") {
         CHECK(lit2.value<Float>() == 1.2f);
     }
 
-    SUBCASE("any -> str") {
-        auto const lit1 = Literal::make<Decimal>(1.5);
-        auto const lit2 = lit1.template cast<String>();
+    SUBCASE("str -> boolean") {
+        SUBCASE("word-form") {
+            auto const lit1 = Literal::make<String>("true");
+            auto const lit2 = lit1.template cast<Boolean>();
 
-        CHECK(lit2.template value<String>() == "1.5");
+            CHECK(lit2.datatype() == IRI{Boolean::identifier});
+            CHECK(lit2.value<Boolean>());
+        }
+
+        SUBCASE("numeric form") {
+            auto const lit1 = Literal::make<String>("1");
+            auto const lit2 = lit1.template cast<Boolean>();
+
+            CHECK(lit2.datatype() == IRI{Boolean::identifier});
+            CHECK(lit2.value<Boolean>());
+        }
+    }
+
+    SUBCASE("any -> str") {
+        SUBCASE("decimal") {
+            SUBCASE("integral") {
+                auto const lit1 = Literal::make<Decimal>(Decimal::cpp_type{"1005.0"});
+                auto const lit2 = lit1.cast<String>();
+
+                CHECK(lit2.value<String>() == "1005");
+            }
+
+            SUBCASE("non-integral") {
+                auto const lit1 = Literal::make<Decimal>(1.5);
+                auto const lit2 = lit1.template cast<String>();
+
+                CHECK(lit2.template value<String>() == "1.5");
+            }
+        }
+
+        SUBCASE("float") {
+            SUBCASE("fixed notation - non-integral") {
+                auto const lit1 = Literal::make<Float>(10.5f);
+                auto const lit2 = lit1.template cast<String>();
+
+                CHECK(lit2.template value<String>() == "10.5");
+            }
+
+            SUBCASE("fixed notation - integral") {
+                auto const lit1 = Literal::make<Float>(100000.f);
+                auto const lit2 = lit1.template cast<String>();
+
+                CHECK(lit2.template value<String>() == "100000");
+            }
+
+            SUBCASE("large - scientific") {
+                auto const lit1 = Literal::make<Float>(1000001.f);
+                auto const lit2 = lit1.template cast<String>();
+
+                CHECK(lit2.template value<String>() == "1.000001E6");
+            }
+
+            SUBCASE("small - scientific") {
+                auto const lit1 = Literal::make<Float>(0.0000009f);
+                auto const lit2 = lit1.template cast<String>();
+
+                CHECK(lit2.template value<String>() == "9.0E-7");
+            }
+
+            SUBCASE("zero") {
+                auto const lit1 = Literal::make<Float>(0.0f);
+                auto const lit2 = lit1.template cast<String>();
+
+                CHECK(lit2.template value<String>() == "0");
+            }
+
+            SUBCASE("minus zero") {
+                auto const lit1 = Literal::make<Float>(-0.0f);
+                auto const lit2 = lit1.template cast<String>();
+
+                CHECK(lit2.template value<String>() == "-0");
+            }
+        }
+
+        SUBCASE("double") {
+            SUBCASE("fixed notation - non-integral") {
+                auto const lit1 = Literal::make<Double>(10.5);
+                auto const lit2 = lit1.template cast<String>();
+
+                CHECK(lit2.template value<String>() == "10.5");
+            }
+
+            SUBCASE("fixed notation - integral") {
+                auto const lit1 = Literal::make<Double>(100000.0);
+                auto const lit2 = lit1.template cast<String>();
+
+                CHECK(lit2.template value<String>() == "100000");
+            }
+
+            SUBCASE("large - scientific") {
+                auto const lit1 = Literal::make<Double>(1000001.0);
+                auto const lit2 = lit1.template cast<String>();
+
+                CHECK(lit2.template value<String>() == "1.000001E6");
+            }
+
+            SUBCASE("small - scientific") {
+                auto const lit1 = Literal::make<Double>(0.0000009);
+                auto const lit2 = lit1.template cast<String>();
+
+                CHECK(lit2.template value<String>() == "9.0E-7");
+            }
+
+            SUBCASE("zero") {
+                auto const lit1 = Literal::make<Double>(0.0);
+                auto const lit2 = lit1.template cast<String>();
+
+                CHECK(lit2.template value<String>() == "0");
+            }
+
+            SUBCASE("minus zero") {
+                auto const lit1 = Literal::make<Double>(-0.0);
+                auto const lit2 = lit1.template cast<String>();
+
+                CHECK(lit2.template value<String>() == "-0");
+            }
+        }
     }
 
     SUBCASE("any -> bool") {


### PR DESCRIPTION
This PR addresses a few things. The changes are all quite small so I didn't feel like opening a PR for each one was necessary. You can use the following as orientation to see which changes belong to what issue.

- #121
    - fixed regex
    - removed unecessary `try { } catch () { }` block (value already verified by regex so `boost` constructor cannot throw)
- #120
    - some reordering of special cases in `Literal::cast` to prioritize to/from `xsd:string` casts
    - a new function for datatypes called `capabilities::Default::display` (name as in Rust's `Display` trait)) mainly for numeric datatypes (but also others in the future)

- #117 
    - Added a `std::char_traits<>` like type for case insensitive comparisions on language tags (can be extended in the future if we discover additional requirements`

- a floating point canonicalization bug that would sometimes yield incorrect values
    - the original to_string for floating point values calculated `fraction = fmod(value, &exp)` to determine the
precision for the output (fraction == 0 => 1 to include an extra .0, else => max). 
While this is correct when formatting to fixed notation.
It is definitely wrong for scientific notation because the mantissa gets normalized to (e.g. to 1.001 for 1001.0).
This resulted in a significant loss of precision in large integer-like values.

- making `LangStringRepr` a view to the backend, which saves 2 allocations when working with `rdf:langString` values
    - Values of `rdf:langString`s currently will always be equivalent to what is stored in the backend, so instead of allocating 2 additional `std::string`s every time a `rdf:langString` value (= `LangStringRepr`) needs to be materialized the value will now instead just point to the backend. In the future when we inline the language tags the `std::string_view` can instead point to an entry of an `inline constexpr StaticFlatMap<enum LangTag, std::string_view>`.

- added null checks to `Literal::as_lexical_form()` and `Literal::as_display()` to unify behaviour between these functions and other `Literal -> Literal` transformation functions. (Having this property on those functions makes them chainable without manually checking for nullness everytime)