### PR TITLE
Fix: Precision errors when casting decimal -> double

### DIFF
--- a/src/rdf4cpp/rdf/datatypes/LiteralDatatype.hpp
+++ b/src/rdf4cpp/rdf/datatypes/LiteralDatatype.hpp
@@ -101,21 +101,23 @@ concept ComparableLiteralDatatype = LiteralDatatype<LiteralDatatypeImpl> && requ
                                                                             };
 
 template<typename LiteralDatatypeImpl>
-concept PromotableLiteralDatatype = LiteralDatatype<LiteralDatatypeImpl> && requires(typename LiteralDatatypeImpl::cpp_type const &value, typename LiteralDatatypeImpl::promoted_cpp_type const &promoted_value) {
-                                                                                requires LiteralDatatype<typename LiteralDatatypeImpl::promoted>;
-                                                                                typename LiteralDatatypeImpl::promoted_cpp_type;
-                                                                                { LiteralDatatypeImpl::promotion_rank } -> std::convertible_to<unsigned>;
-                                                                                { LiteralDatatypeImpl::promote(value) } -> std::convertible_to<typename LiteralDatatypeImpl::promoted_cpp_type>;
-                                                                                { LiteralDatatypeImpl::demote(promoted_value) } -> std::convertible_to<nonstd::expected<typename LiteralDatatypeImpl::cpp_type, DynamicError>>;
+concept PromotableLiteralDatatype = LiteralDatatype<LiteralDatatypeImpl> && requires(typename LiteralDatatypeImpl::cpp_type const &value, typename LiteralDatatypeImpl::template promoted_cpp_type<0> const &promoted_value) {
+                                                                                requires LiteralDatatype<typename LiteralDatatypeImpl::template promoted<0>>;
+                                                                                typename LiteralDatatypeImpl::template promoted_cpp_type<0>;
+                                                                                { LiteralDatatypeImpl::promotion_rank } -> std::convertible_to<size_t>;
+                                                                                { LiteralDatatypeImpl::max_promotion_specialization_ix } -> std::convertible_to<size_t>;
+                                                                                { LiteralDatatypeImpl::template promote<0>(value) } -> std::convertible_to<typename LiteralDatatypeImpl::template promoted_cpp_type<0>>;
+                                                                                { LiteralDatatypeImpl::template demote<0>(promoted_value) } -> std::convertible_to<nonstd::expected<typename LiteralDatatypeImpl::cpp_type, DynamicError>>;
                                                                             };
 
 template<typename LiteralDatatypeImpl>
-concept SubtypedLiteralDatatype = LiteralDatatype<LiteralDatatypeImpl> && requires(typename LiteralDatatypeImpl::cpp_type const &value, typename LiteralDatatypeImpl::super_cpp_type const &super_value) {
-                                                                              requires LiteralDatatype<typename LiteralDatatypeImpl::supertype>;
-                                                                              typename LiteralDatatypeImpl::super_cpp_type;
-                                                                              { LiteralDatatypeImpl::subtype_rank } -> std::convertible_to<unsigned>;
-                                                                              { LiteralDatatypeImpl::into_supertype(value) } -> std::convertible_to<typename LiteralDatatypeImpl::super_cpp_type>;
-                                                                              { LiteralDatatypeImpl::from_supertype(super_value) } -> std::convertible_to<nonstd::expected<typename LiteralDatatypeImpl::cpp_type, DynamicError>>;
+concept SubtypedLiteralDatatype = LiteralDatatype<LiteralDatatypeImpl> && requires(typename LiteralDatatypeImpl::cpp_type const &value, typename LiteralDatatypeImpl::template super_cpp_type<0> const &super_value) {
+                                                                              requires LiteralDatatype<typename LiteralDatatypeImpl::template supertype<0>>;
+                                                                              typename LiteralDatatypeImpl::template super_cpp_type<0>;
+                                                                              { LiteralDatatypeImpl::subtype_rank } -> std::convertible_to<size_t>;
+                                                                              { LiteralDatatypeImpl::max_supertype_specialization_ix } -> std::convertible_to<size_t>;
+                                                                              { LiteralDatatypeImpl::template into_supertype<0>(value) } -> std::convertible_to<typename LiteralDatatypeImpl::template super_cpp_type<0>>;
+                                                                              { LiteralDatatypeImpl::template from_supertype<0>(super_value) } -> std::convertible_to<nonstd::expected<typename LiteralDatatypeImpl::cpp_type, DynamicError>>;
                                                                           };
 
 /**

--- a/src/rdf4cpp/rdf/datatypes/registry/DatatypeMapping.hpp
+++ b/src/rdf4cpp/rdf/datatypes/registry/DatatypeMapping.hpp
@@ -24,6 +24,11 @@ struct DatatypePromotionMapping {
     using promoted = std::false_type;
 };
 
+template<util::ConstexprString type_iri>
+struct DatatypePromotionSpecializationOverride {
+    static constexpr size_t max_specialization_ix = 0;
+};
+
 /**
  * Mapping type_iri -> supertype of itself
  * @note supertype must be LiteralDatatype
@@ -31,6 +36,11 @@ struct DatatypePromotionMapping {
 template<util::ConstexprString type_iri>
 struct DatatypeSupertypeMapping {
     using supertype = std::false_type;
+};
+
+template<util::ConstexprString type_iri>
+struct DatatypeSupertypeSpecializationOverride {
+    static constexpr size_t max_specialization_ix = 0;
 };
 
 /**
@@ -98,17 +108,39 @@ struct DatatypeNegResultMapping {
 
 namespace detail_rank {
 
+template<util::ConstexprString type_iri, size_t N>
+struct NthPromotion {
+    using prev = typename NthPromotion<type_iri, N - 1>::promoted;
+    using promoted = typename DatatypePromotionMapping<prev::identifier>::promoted;
+};
+
+template<util::ConstexprString type_iri>
+struct NthPromotion<type_iri, 0> {
+    using promoted = typename DatatypePromotionMapping<type_iri>::promoted;
+};
+
+template<util::ConstexprString type_iri, size_t N>
+struct NthSupertype {
+    using prev = typename NthSupertype<type_iri, N - 1>::supertype;
+    using supertype = typename DatatypeSupertypeMapping<prev::identifier>::promoted;
+};
+
+template<util::ConstexprString type_iri>
+struct NthSupertype<type_iri, 0> {
+    using supertype = typename DatatypeSupertypeMapping<type_iri>::supertype;
+};
+
 /**
  * The promotion rank of a type (the number of times a type can be promoted)
  */
 template<util::ConstexprString type_iri, typename enable = void>
 struct DatatypePromotionRank {
-    static constexpr unsigned value = 0;
+    static constexpr size_t value = 0;
 };
 
 template<util::ConstexprString type_iri>
 struct DatatypePromotionRank<type_iri, std::enable_if_t<!std::is_same_v<typename DatatypePromotionMapping<type_iri>::promoted, std::false_type>>> {
-    static constexpr unsigned value = 1 + DatatypePromotionRank<DatatypePromotionMapping<type_iri>::promoted::identifier>::value;
+    static constexpr size_t value = 1 + DatatypePromotionRank<DatatypePromotionMapping<type_iri>::promoted::identifier>::value;
 };
 
 /**
@@ -116,12 +148,12 @@ struct DatatypePromotionRank<type_iri, std::enable_if_t<!std::is_same_v<typename
  */
 template<util::ConstexprString type_iri, typename enable = void>
 struct DatatypeSubtypeRank {
-    static constexpr unsigned value = 0;
+    static constexpr size_t value = 0;
 };
 
 template<util::ConstexprString type_iri>
 struct DatatypeSubtypeRank<type_iri, std::enable_if_t<!std::is_same_v<typename DatatypeSupertypeMapping<type_iri>::supertype, std::false_type>>> {
-    static constexpr unsigned value = 1 + DatatypeSubtypeRank<DatatypeSupertypeMapping<type_iri>::supertype::identifier>::value;
+    static constexpr size_t value = 1 + DatatypeSubtypeRank<DatatypeSupertypeMapping<type_iri>::supertype::identifier>::value;
 };
 
 }  // namespace detail_rank

--- a/src/rdf4cpp/rdf/datatypes/registry/LiteralDatatypeImpl.hpp
+++ b/src/rdf4cpp/rdf/datatypes/registry/LiteralDatatypeImpl.hpp
@@ -77,24 +77,31 @@ struct Default {
     }
 };
 
+
 /**
  * The capability to be promoted to another LiteralDatatype, e.g. Decimal -> Float.
  */
 template<util::ConstexprString type_iri>
 struct Promotable {
-    using promoted = typename DatatypePromotionMapping<type_iri>::promoted;
-
     using cpp_type = typename DatatypeMapping<type_iri>::cpp_datatype;
-    using promoted_cpp_type = typename DatatypeMapping<promoted::identifier>::cpp_datatype;
 
-    static constexpr unsigned promotion_rank = detail_rank::DatatypePromotionRank<type_iri>::value;
+    static constexpr size_t promotion_rank = detail_rank::DatatypePromotionRank<type_iri>::value;
+    static constexpr size_t max_promotion_specialization_ix = DatatypePromotionSpecializationOverride<type_iri>::max_specialization_ix;
 
-    inline static promoted_cpp_type promote(cpp_type const &value) noexcept {
-        return static_cast<promoted_cpp_type>(value);
+    template<size_t ix = 0>
+    using promoted = typename detail_rank::NthPromotion<type_iri, ix>::promoted;
+
+    template<size_t ix = 0>
+    using promoted_cpp_type = typename DatatypeMapping<promoted<ix>::identifier>::cpp_datatype;
+
+    template<size_t ix = 0>
+    inline static promoted_cpp_type<ix> promote(cpp_type const &value) noexcept {
+        return static_cast<promoted_cpp_type<ix>>(value);
     }
 
-    inline static nonstd::expected<cpp_type, DynamicError> demote(promoted_cpp_type const &value) noexcept {
-        if constexpr (std::is_integral_v<cpp_type> && std::is_integral_v<promoted_cpp_type>) {
+    template<size_t ix = 0>
+    inline static nonstd::expected<cpp_type, DynamicError> demote(promoted_cpp_type<ix> const &value) noexcept {
+        if constexpr (std::is_integral_v<cpp_type> && std::is_integral_v<promoted_cpp_type<ix>>) {
             if (!std::in_range<cpp_type>(value)) {
                 return nonstd::make_unexpected(DynamicError::InvalidValueForCast);
             }
@@ -109,19 +116,25 @@ struct Promotable {
  */
 template<util::ConstexprString type_iri>
 struct Subtype {
-    using supertype = typename DatatypeSupertypeMapping<type_iri>::supertype;
-
     using cpp_type = typename DatatypeMapping<type_iri>::cpp_datatype;
-    using super_cpp_type = typename DatatypeMapping<supertype::identifier>::cpp_datatype;
 
-    static constexpr unsigned subtype_rank = detail_rank::DatatypeSubtypeRank<type_iri>::value;
+    static constexpr size_t subtype_rank = detail_rank::DatatypeSubtypeRank<type_iri>::value;
+    static constexpr size_t max_supertype_specialization_ix = DatatypeSupertypeSpecializationOverride<type_iri>::max_specialization_ix;
 
-    inline static super_cpp_type into_supertype(cpp_type const &value) noexcept {
-        return static_cast<super_cpp_type>(value);
+    template<size_t ix = 0>
+    using supertype = typename detail_rank::NthSupertype<type_iri, ix>::supertype;
+
+    template<size_t ix = 0>
+    using super_cpp_type = typename DatatypeMapping<supertype<ix>::identifier>::cpp_datatype;
+
+    template<size_t ix = 0>
+    inline static super_cpp_type<ix> into_supertype(cpp_type const &value) noexcept {
+        return static_cast<super_cpp_type<ix>>(value);
     }
 
-    inline static nonstd::expected<cpp_type, DynamicError> from_supertype(super_cpp_type const &value) noexcept {
-        if constexpr (std::is_integral_v<cpp_type> && std::is_integral_v<super_cpp_type>) {
+    template<size_t ix = 0>
+    inline static nonstd::expected<cpp_type, DynamicError> from_supertype(super_cpp_type<ix> const &value) noexcept {
+        if constexpr (std::is_integral_v<cpp_type> && std::is_integral_v<super_cpp_type<ix>>) {
             if (!std::in_range<cpp_type>(value)) {
                 return nonstd::make_unexpected(DynamicError::InvalidValueForCast);
             }

--- a/src/rdf4cpp/rdf/datatypes/registry/util/TypeList.hpp
+++ b/src/rdf4cpp/rdf/datatypes/registry/util/TypeList.hpp
@@ -103,7 +103,7 @@ constexpr auto type_list_generate_impl(std::index_sequence<ixs...>, F f) noexcep
  * @endcode
  */
 template<typename ListA, typename ListB>
-using type_list_cat = decltype(type_list_detail::type_list_cat_impl(std::declval<ListA>(), std::declval<ListB>()));
+using type_list_cat = decltype(type_list_detail::type_list_cat_impl(ListA{}, ListB{}));
 
 
 /**

--- a/src/rdf4cpp/rdf/datatypes/registry/util/TypeList.hpp
+++ b/src/rdf4cpp/rdf/datatypes/registry/util/TypeList.hpp
@@ -48,9 +48,7 @@ concept nothrow_mixed_invocable = requires (F f, RParam rparam) {
 
 
 template<typename ...Ts, typename ...Us>
-consteval mz::type_list<Ts..., Us...> type_list_cat_impl(mz::type_list<Ts...>, mz::type_list<Us...>) {
-    return {};
-}
+mz::type_list<Ts..., Us...> type_list_cat_impl(mz::type_list<Ts...>, mz::type_list<Us...>);
 
 template<typename MapF, typename ...Ts> requires (template_invocable<MapF, Ts> && ...)
 constexpr auto type_list_map_impl(mz::type_list<Ts...>, MapF f) noexcept((nothrow_template_invocable<MapF, Ts> && ...)) {

--- a/src/rdf4cpp/rdf/datatypes/xsd/Decimal.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/Decimal.hpp
@@ -23,6 +23,11 @@ struct DatatypePromotionMapping<xsd_decimal> {
 };
 
 template<>
+struct DatatypePromotionSpecializationOverride<xsd_decimal> {
+    static constexpr size_t max_specialization_ix = 1;
+};
+
+template<>
 capabilities::Default<xsd_decimal>::cpp_type capabilities::Default<xsd_decimal>::from_string(std::string_view s);
 
 template<>

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/NonNegativeInteger.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/NonNegativeInteger.cpp
@@ -38,7 +38,8 @@ std::partial_ordering capabilities::Comparable<xsd_non_negative_integer>::compar
 }
 
 template<>
-nonstd::expected<capabilities::Default<xsd_non_negative_integer>::cpp_type, DynamicError> capabilities::Subtype<xsd_non_negative_integer>::from_supertype(super_cpp_type const &value) noexcept {
+template<>
+nonstd::expected<capabilities::Default<xsd_non_negative_integer>::cpp_type, DynamicError> capabilities::Subtype<xsd_non_negative_integer>::from_supertype<0>(super_cpp_type<0> const &value) noexcept {
     if (value < 0) {
         return nonstd::make_unexpected(DynamicError::InvalidValueForCast);
     }

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/NonNegativeInteger.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/NonNegativeInteger.hpp
@@ -34,7 +34,8 @@ template<>
 std::partial_ordering capabilities::Comparable<xsd_non_negative_integer>::compare(cpp_type const &lhs, cpp_type const &rhs) noexcept;
 
 template<>
-nonstd::expected<capabilities::Default<xsd_non_negative_integer>::cpp_type, DynamicError> capabilities::Subtype<xsd_non_negative_integer>::from_supertype(super_cpp_type const &value) noexcept;
+template<>
+nonstd::expected<capabilities::Default<xsd_non_negative_integer>::cpp_type, DynamicError> capabilities::Subtype<xsd_non_negative_integer>::from_supertype<0>(super_cpp_type<0> const &value) noexcept;
 
 template<>
 std::optional<uint64_t> capabilities::Inlineable<xsd_non_negative_integer>::try_into_inlined(cpp_type const &value) noexcept;

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/PositiveInteger.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/PositiveInteger.cpp
@@ -38,7 +38,8 @@ std::partial_ordering capabilities::Comparable<xsd_positive_integer>::compare(cp
 }
 
 template<>
-nonstd::expected<capabilities::Default<xsd_positive_integer>::cpp_type, DynamicError> capabilities::Subtype<xsd_positive_integer>::from_supertype(super_cpp_type const &value) noexcept {
+template<>
+nonstd::expected<capabilities::Default<xsd_positive_integer>::cpp_type, DynamicError> capabilities::Subtype<xsd_positive_integer>::from_supertype<0>(super_cpp_type<0> const &value) noexcept {
     if (value < 1) {
         return nonstd::make_unexpected(DynamicError::InvalidValueForCast);
     }

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/PositiveInteger.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/PositiveInteger.hpp
@@ -35,7 +35,8 @@ template<>
 std::partial_ordering capabilities::Comparable<xsd_positive_integer>::compare(cpp_type const &lhs, cpp_type const &rhs) noexcept;
 
 template<>
-nonstd::expected<capabilities::Default<xsd_positive_integer>::cpp_type, DynamicError> capabilities::Subtype<xsd_positive_integer>::from_supertype(super_cpp_type const &value) noexcept;
+template<>
+nonstd::expected<capabilities::Default<xsd_positive_integer>::cpp_type, DynamicError> capabilities::Subtype<xsd_positive_integer>::from_supertype<0>(super_cpp_type<0> const &value) noexcept;
 
 template<>
 std::optional<uint64_t> capabilities::Inlineable<xsd_positive_integer>::try_into_inlined(cpp_type const &value) noexcept;

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedLong.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedLong.cpp
@@ -19,7 +19,8 @@ bool capabilities::Logical<xsd_unsigned_long>::effective_boolean_value(cpp_type 
 }
 
 template<>
-nonstd::expected<capabilities::Default<xsd_unsigned_long>::cpp_type, DynamicError> capabilities::Subtype<xsd_unsigned_long>::from_supertype(super_cpp_type const &value) noexcept {
+template<>
+nonstd::expected<capabilities::Default<xsd_unsigned_long>::cpp_type, DynamicError> capabilities::Subtype<xsd_unsigned_long>::from_supertype<0>(super_cpp_type<0> const &value) noexcept {
     if (value > std::numeric_limits<cpp_type>::max() || value < std::numeric_limits<cpp_type>::min()) {
         return nonstd::make_unexpected(DynamicError::InvalidValueForCast);
     }

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedLong.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_negative/UnsignedLong.hpp
@@ -36,7 +36,8 @@ template<>
 bool capabilities::Logical<xsd_unsigned_long>::effective_boolean_value(cpp_type const &value) noexcept;
 
 template<>
-nonstd::expected<capabilities::Default<xsd_unsigned_long>::cpp_type, DynamicError> capabilities::Subtype<xsd_unsigned_long>::from_supertype(super_cpp_type const &value) noexcept;
+template<>
+nonstd::expected<capabilities::Default<xsd_unsigned_long>::cpp_type, DynamicError> capabilities::Subtype<xsd_unsigned_long>::from_supertype<0>(super_cpp_type<0> const &value) noexcept;
 
 extern template struct LiteralDatatypeImpl<xsd_unsigned_long,
                                            capabilities::Logical,

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_positive/NegativeInteger.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_positive/NegativeInteger.cpp
@@ -38,7 +38,8 @@ std::partial_ordering capabilities::Comparable<xsd_negative_integer>::compare(cp
 }
 
 template<>
-nonstd::expected<capabilities::Default<xsd_negative_integer>::cpp_type, DynamicError> capabilities::Subtype<xsd_negative_integer>::from_supertype(super_cpp_type const &value) noexcept {
+template<>
+nonstd::expected<capabilities::Default<xsd_negative_integer>::cpp_type, DynamicError> capabilities::Subtype<xsd_negative_integer>::from_supertype<0>(super_cpp_type<0> const &value) noexcept {
     if (value > -1) {
         return nonstd::make_unexpected(DynamicError::InvalidValueForCast);
     }

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_positive/NegativeInteger.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_positive/NegativeInteger.hpp
@@ -38,7 +38,8 @@ template<>
 std::partial_ordering capabilities::Comparable<xsd_negative_integer>::compare(cpp_type const &lhs, cpp_type const &rhs) noexcept;
 
 template<>
-nonstd::expected<capabilities::Default<xsd_negative_integer>::cpp_type, DynamicError> capabilities::Subtype<xsd_negative_integer>::from_supertype(super_cpp_type const &value) noexcept;
+template<>
+nonstd::expected<capabilities::Default<xsd_negative_integer>::cpp_type, DynamicError> capabilities::Subtype<xsd_negative_integer>::from_supertype<0>(super_cpp_type<0> const &value) noexcept;
 
 template<>
 std::optional<uint64_t> capabilities::Inlineable<xsd_negative_integer>::try_into_inlined(cpp_type const &value) noexcept;

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_positive/NonPositiveInteger.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_positive/NonPositiveInteger.cpp
@@ -38,7 +38,8 @@ std::partial_ordering capabilities::Comparable<xsd_non_positive_integer>::compar
 }
 
 template<>
-nonstd::expected<capabilities::Default<xsd_non_positive_integer>::cpp_type, DynamicError> capabilities::Subtype<xsd_non_positive_integer>::from_supertype(super_cpp_type const &value) noexcept {
+template<>
+nonstd::expected<capabilities::Default<xsd_non_positive_integer>::cpp_type, DynamicError> capabilities::Subtype<xsd_non_positive_integer>::from_supertype<0>(super_cpp_type<0> const &value) noexcept {
     if (value > 0) {
         return nonstd::make_unexpected(DynamicError::InvalidValueForCast);
     }

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/non_positive/NonPositiveInteger.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/non_positive/NonPositiveInteger.hpp
@@ -35,7 +35,8 @@ template<>
 std::partial_ordering capabilities::Comparable<xsd_non_positive_integer>::compare(cpp_type const &lhs, cpp_type const &rhs) noexcept;
 
 template<>
-nonstd::expected<capabilities::Default<xsd_non_positive_integer>::cpp_type, DynamicError> capabilities::Subtype<xsd_non_positive_integer>::from_supertype(super_cpp_type const &value) noexcept;
+template<>
+nonstd::expected<capabilities::Default<xsd_non_positive_integer>::cpp_type, DynamicError> capabilities::Subtype<xsd_non_positive_integer>::from_supertype<0>(super_cpp_type<0> const &value) noexcept;
 
 template<>
 std::optional<uint64_t> capabilities::Inlineable<xsd_non_positive_integer>::try_into_inlined(cpp_type const &value) noexcept;

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Long.cpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Long.cpp
@@ -19,7 +19,8 @@ bool capabilities::Logical<xsd_long>::effective_boolean_value(cpp_type const &va
 }
 
 template<>
-nonstd::expected<capabilities::Default<xsd_long>::cpp_type, DynamicError> capabilities::Subtype<xsd_long>::from_supertype(super_cpp_type const &value) noexcept {
+template<>
+nonstd::expected<capabilities::Default<xsd_long>::cpp_type, DynamicError> capabilities::Subtype<xsd_long>::from_supertype<0>(super_cpp_type<0> const &value) noexcept {
     if (value > std::numeric_limits<cpp_type>::max() || value < std::numeric_limits<cpp_type>::min()) {
         return nonstd::make_unexpected(DynamicError::InvalidValueForCast);
     }

--- a/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Long.hpp
+++ b/src/rdf4cpp/rdf/datatypes/xsd/integers/signed/Long.hpp
@@ -35,7 +35,8 @@ template<>
 bool capabilities::Logical<xsd_long>::effective_boolean_value(cpp_type const &value) noexcept;
 
 template<>
-nonstd::expected<capabilities::Default<xsd_long>::cpp_type, DynamicError> capabilities::Subtype<xsd_long>::from_supertype(super_cpp_type const &value) noexcept;
+template<>
+nonstd::expected<capabilities::Default<xsd_long>::cpp_type, DynamicError> capabilities::Subtype<xsd_long>::from_supertype<0>(super_cpp_type<0> const &value) noexcept;
 
 extern template struct LiteralDatatypeImpl<xsd_long,
                                            capabilities::Logical,

--- a/tests/nodes/tests_Literal.cpp
+++ b/tests/nodes/tests_Literal.cpp
@@ -340,3 +340,7 @@ TEST_CASE("Literal - casting") {
         CHECK(lit2.null());
     }
 }
+
+TEST_CASE("indirect casting precision") {
+    CHECK(Literal::make<datatypes::xsd::Double>(2e-1) + Literal::make<datatypes::xsd::Decimal>(datatypes::xsd::Decimal::cpp_type{"0.2"}) == Literal::make<datatypes::xsd::Double>(4e-1));
+}


### PR DESCRIPTION
As mentioned in #119 previously adding decimals and doubles resulted in a precision loss.

This way due to the cast of `xsd:double("0.2"^^xsd:decimal)` being roughly equivalent to `xsd:double(xsd:float("0.2"^^xsd:decimal))` which resulted from a limitation in the type hierarchy.

Previously only direct (neighbour) conversion functions could be specialized, i.e.  `xsd:decimal -> xsd:float`
or `xsd:float -> xsd:double` but not `xsd:decimal -> xsd:double`. As this is the order they appear in their promotion hierarchy. The (latter) indirect conversion function was instead automatically generated by composing the former two direct conversion functions, which then lead to the precision error.

This PR solves this problem by allowing types to explicitly specialize non-direct conversion functions further downstream, i.e. `xsd:decimal` can now specialize the promotion to `xsd:double` directly.

The mechanism to achieve this consists of:
- index templated promotion and supertype functions (`capabilities::Promotable::promote`, `capabilities::Subtyped::into_supertype`)
- a value that specifies the maximum index of specialization for the templated conversion functions (`DatatypePromotionSpecializationOverride::max_specialization_ix`, `DatatypeSupertypeSpecializationOverride::max_specialization_ix`)
- and some small changes in the hierarchy calculation

I am not sure why the diff is so horrible btw :(