### PR TITLE
Fix: ambiguous Literal ctors

### DIFF
--- a/examples/graphs_and_datasets.cpp
+++ b/examples/graphs_and_datasets.cpp
@@ -12,10 +12,10 @@ int main(int argc, char *argv[]) {
     std::cout << "dataset node storage id: " << dataset.backend().node_storage().id().value << std::endl;
     std::cout << "dataset2 node storage id: " << dataset2.backend().node_storage().id().value << std::endl;
 
-    g.add({IRI{"http://example.com"}, IRI{"http://example.com"}, Literal("text", "en")});
-    g.add({IRI{"http://example.com"}, IRI{"http://example.com"}, Literal("text", "fr")});
-    g.add({IRI{"http://example.com"}, IRI{"http://example.com"}, Literal("txt")});
-    g.add({IRI{"http://example.com"}, IRI{"http://example.com"}, Literal("text")});
+    g.add({IRI{"http://example.com"}, IRI{"http://example.com"}, Literal::make_lang_tagged("text", "en")});
+    g.add({IRI{"http://example.com"}, IRI{"http://example.com"}, Literal::make_lang_tagged("text", "fr")});
+    g.add({IRI{"http://example.com"}, IRI{"http://example.com"}, Literal::make_simple("txt")});
+    g.add({IRI{"http://example.com"}, IRI{"http://example.com"}, Literal::make_simple("text")});
 
     dataset.add({IRI{"http://named_graph.com"}, IRI{"http://example.com"}, IRI{"http://example.com"}, Literal("text")});
 

--- a/examples/graphs_and_datasets.cpp
+++ b/examples/graphs_and_datasets.cpp
@@ -17,7 +17,7 @@ int main(int argc, char *argv[]) {
     g.add({IRI{"http://example.com"}, IRI{"http://example.com"}, Literal::make_simple("txt")});
     g.add({IRI{"http://example.com"}, IRI{"http://example.com"}, Literal::make_simple("text")});
 
-    dataset.add({IRI{"http://named_graph.com"}, IRI{"http://example.com"}, IRI{"http://example.com"}, Literal("text")});
+    dataset.add({IRI{"http://named_graph.com"}, IRI{"http://example.com"}, IRI{"http://example.com"}, Literal::make_simple("text")});
 
     std::cout << "dataset string: \n"
               << writer::NQuadsWriter(g.dataset()) << std::endl;

--- a/examples/literal_datatypes.cpp
+++ b/examples/literal_datatypes.cpp
@@ -6,7 +6,7 @@
 int main() {
     using namespace rdf4cpp::rdf;
 
-    Literal float_1_1("1.1", IRI{"http://www.w3.org/2001/XMLSchema#float"});
+    auto float_1_1 = Literal::make_typed("1.1", IRI{"http://www.w3.org/2001/XMLSchema#float"});
 
     std::cout << float_1_1 << std::endl;
     std::any any_float_ = float_1_1.value();
@@ -20,6 +20,6 @@ int main() {
     // datatypes::xsd::Float is an alias for the built-in type float
     std::cout << float_ << std::endl;
     // make a new literal with new value
-    Literal updated_float = Literal::make<datatypes::xsd::Float>(float_);
+    Literal updated_float = Literal::make_typed<datatypes::xsd::Float>(float_);
     std::cout << updated_float << std::endl;
 }

--- a/examples/rdf_nodes.cpp
+++ b/examples/rdf_nodes.cpp
@@ -37,11 +37,11 @@ int main() {
         std::cout << "---" << std::endl;
     };
 
-    Literal lit1("xxxx");
-    Literal lit2("xxxx", iri_pred);
-    Literal lit3("xxxx", IRI("http://example.com/pred2"));
-    Literal lit4("xxxx", "de");
-    Literal lit5{"xxxx", "de"};
+    auto lit1 = Literal::make_simple("xxxx");
+    auto lit2 = Literal::make_typed("xxxx", iri_pred);
+    auto lit3 = Literal::make_typed("xxxx", IRI("http://example.com/pred2"));
+    auto lit4 = Literal::make_lang_tagged("xxxx", "de");
+    auto lit5 = Literal::make_lang_tagged("xxxx", "de");
 
     print_literal_info(lit1);
     print_literal_info(lit2);

--- a/src/rdf4cpp/rdf/BlankNode.cpp
+++ b/src/rdf4cpp/rdf/BlankNode.cpp
@@ -1,12 +1,20 @@
 #include "BlankNode.hpp"
 
 namespace rdf4cpp::rdf {
-BlankNode::BlankNode() noexcept : Node{} {}
+BlankNode::BlankNode() noexcept : Node{NodeBackendHandle{{}, storage::node::identifier::RDFNodeType::BNode, {}}} {}
 BlankNode::BlankNode(std::string_view identifier, Node::NodeStorage &node_storage)
     : Node(NodeBackendHandle{node_storage.find_or_make_id(storage::node::view::BNodeBackendView{.identifier = identifier}),
                              storage::node::identifier::RDFNodeType::BNode,
                              node_storage.id()}) {}
 BlankNode::BlankNode(Node::NodeBackendHandle handle) noexcept : Node(handle) {}
+
+BlankNode BlankNode::make_null() noexcept {
+    return BlankNode{};
+}
+
+BlankNode BlankNode::make(std::string_view identifier, Node::NodeStorage &node_storage) {
+    return BlankNode{identifier, node_storage};
+}
 
 std::string_view BlankNode::identifier() const noexcept { return handle_.bnode_backend().identifier; }
 

--- a/src/rdf4cpp/rdf/BlankNode.hpp
+++ b/src/rdf4cpp/rdf/BlankNode.hpp
@@ -13,9 +13,25 @@ private:
     explicit BlankNode(NodeBackendHandle handle) noexcept;
 
 public:
+    /**
+     * Constructs the null-bnode
+     */
     BlankNode() noexcept;
-    explicit BlankNode(std::string_view identifier,
-                       NodeStorage &node_storage = NodeStorage::default_instance());
+
+    /**
+     * Constructs a bnode from an identifier
+     */
+    explicit BlankNode(std::string_view identifier, NodeStorage &node_storage = NodeStorage::default_instance());
+
+    /**
+     * Constructs the null-bnode
+     */
+    [[nodiscard]] static BlankNode make_null() noexcept;
+
+    /**
+     * Constructs a bnode from an identifier
+     */
+    [[nodiscard]] static BlankNode make(std::string_view identifier, NodeStorage &node_storage = NodeStorage::default_instance());
 
     /**
      * Get the string identifier of this. For BlankNode `_:abc` the identifier is `abc`.

--- a/src/rdf4cpp/rdf/IRI.cpp
+++ b/src/rdf4cpp/rdf/IRI.cpp
@@ -3,11 +3,11 @@
 namespace rdf4cpp::rdf {
 
 IRI::IRI(Node::NodeBackendHandle handle) noexcept : Node(handle) {}
-IRI::IRI() noexcept : Node(NodeBackendHandle{{}, storage::node::identifier::RDFNodeType::IRI, {}}) {}
+IRI::IRI() noexcept : Node{NodeBackendHandle{{}, storage::node::identifier::RDFNodeType::IRI, {}}} {}
 IRI::IRI(std::string_view iri, Node::NodeStorage &node_storage)
-    : Node(NodeBackendHandle{node_storage.find_or_make_id(storage::node::view::IRIBackendView{.identifier = iri}),
+    : Node{NodeBackendHandle{node_storage.find_or_make_id(storage::node::view::IRIBackendView{.identifier = iri}),
                              storage::node::identifier::RDFNodeType::IRI,
-                             node_storage.id()}) {}
+                             node_storage.id()}} {}
 
 IRI::IRI(datatypes::registry::DatatypeIDView id, Node::NodeStorage &node_storage) noexcept
     : IRI{visit(datatypes::registry::DatatypeIDVisitor{
@@ -20,6 +20,14 @@ IRI::IRI(datatypes::registry::DatatypeIDView id, Node::NodeStorage &node_storage
                             return IRI{dynamic, node_storage};
                         }},
                 id)} {
+}
+
+IRI IRI::make_null() noexcept {
+    return IRI{};
+}
+
+IRI IRI::make(std::string_view iri, Node::NodeStorage &node_storage) {
+    return IRI{iri, node_storage};
 }
 
 IRI::operator datatypes::registry::DatatypeIDView() const noexcept {
@@ -44,7 +52,7 @@ bool IRI::is_iri() const noexcept { return true; }
 
 
 IRI IRI::default_graph(NodeStorage &node_storage) {
-    return IRI("", node_storage);
+    return IRI{"", node_storage};
 }
 std::ostream &operator<<(std::ostream &os, const IRI &iri) {
     os << static_cast<std::string>(iri);
@@ -53,6 +61,5 @@ std::ostream &operator<<(std::ostream &os, const IRI &iri) {
 std::string_view IRI::identifier() const noexcept {
     return handle_.iri_backend().identifier;
 }
-
 
 }  // namespace rdf4cpp::rdf

--- a/src/rdf4cpp/rdf/IRI.hpp
+++ b/src/rdf4cpp/rdf/IRI.hpp
@@ -27,6 +27,9 @@ private:
 public:
     explicit IRI(Node::NodeBackendHandle handle) noexcept;
 
+    /**
+     * Constructs the null-iri
+     */
     IRI() noexcept;
 
     /**
@@ -34,8 +37,19 @@ public:
      * @param iri IRI string
      * @param node_storage optional custom node_storage used to store the IRI
      */
-    explicit IRI(std::string_view iri,
-                 NodeStorage &node_storage = NodeStorage::default_instance());
+    explicit IRI(std::string_view iri, NodeStorage &node_storage = NodeStorage::default_instance());
+
+    /**
+     * Constructs the null-iri
+     */
+    [[nodiscard]] static IRI make_null() noexcept;
+
+    /**
+     * Constructs an IRI object from a IRI string
+     * @param iri IRI string
+     * @param node_storage optional custom node_storage used to store the IRI
+     */
+    [[nodiscard]] static IRI make(std::string_view iri, NodeStorage &node_storage = NodeStorage::default_instance());
 
     /**
      * Get the IRI string of this.

--- a/src/rdf4cpp/rdf/Literal.cpp
+++ b/src/rdf4cpp/rdf/Literal.cpp
@@ -11,10 +11,7 @@ Literal::Literal(Node::NodeBackendHandle handle) noexcept
     : Node{handle} {}
 
 Literal::Literal() noexcept
-    : Node(NodeBackendHandle{{}, storage::node::identifier::RDFNodeType::Literal, {}}) {}
-
-Literal::Literal(std::string_view lexical_form, Node::NodeStorage &node_storage)
-    : Literal{make_simple_unchecked(lexical_form, node_storage)} {}
+    : Node{NodeBackendHandle{{}, storage::node::identifier::RDFNodeType::Literal, {}}} {}
 
 Literal Literal::make_null() noexcept {
     return Literal{};

--- a/src/rdf4cpp/rdf/Literal.cpp
+++ b/src/rdf4cpp/rdf/Literal.cpp
@@ -83,7 +83,7 @@ Literal Literal::make_typed(std::string_view lexical_form, IRI const &datatype, 
 
     if (datatype_identifier == datatypes::rdf::LangString::datatype_id) {
         // see: https://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal
-        throw std::invalid_argument{"cannot construct rdf:langString without a language tag, please call one of the other constructors"};
+        throw std::invalid_argument{"cannot construct rdf:langString without a language tag, please call one of the other factory functions"};
     }
 
     if (auto const *entry = DatatypeRegistry::get_entry(datatype_identifier); entry != nullptr) {

--- a/src/rdf4cpp/rdf/Literal.cpp
+++ b/src/rdf4cpp/rdf/Literal.cpp
@@ -7,20 +7,99 @@
 
 namespace rdf4cpp::rdf {
 
-Literal::Literal() noexcept
-    : Node(NodeBackendHandle{{}, storage::node::identifier::RDFNodeType::Literal, {}}) {}
-
 Literal::Literal(Node::NodeBackendHandle handle) noexcept
     : Node{handle} {}
+
+Literal::Literal() noexcept
+    : Node(NodeBackendHandle{{}, storage::node::identifier::RDFNodeType::Literal, {}}) {}
 
 Literal::Literal(std::string_view lexical_form, Node::NodeStorage &node_storage)
     : Literal{make_simple_unchecked(lexical_form, node_storage)} {}
 
-Literal::Literal(std::string_view lexical_form, const IRI &datatype, Node::NodeStorage &node_storage)
-    : Literal{make(lexical_form, datatype, node_storage)} {}
+Literal Literal::make_null() noexcept {
+    return Literal{};
+}
 
-Literal::Literal(std::string_view lexical_form, std::string_view lang, Node::NodeStorage &node_storage)
-    : Literal{make_lang_tagged_unchecked(lexical_form, lang, node_storage)} {}
+Literal Literal::make_simple_unchecked(std::string_view lexical_form, Node::NodeStorage &node_storage) noexcept {
+    return Literal{NodeBackendHandle{node_storage.find_or_make_id(storage::node::view::LiteralBackendView{
+                                             .datatype_id = storage::node::identifier::NodeID::xsd_string_iri.first,
+                                             .lexical_form = lexical_form,
+                                             .language_tag = ""}),
+                                     storage::node::identifier::RDFNodeType::Literal,
+                                     node_storage.id()}};
+}
+
+Literal Literal::make_noninlined_typed_unchecked(std::string_view lexical_form, IRI const &datatype, Node::NodeStorage &node_storage) noexcept {
+    return Literal{NodeBackendHandle{node_storage.find_or_make_id(storage::node::view::LiteralBackendView{
+                                             .datatype_id = datatype.to_node_storage(node_storage).backend_handle().node_id(),
+                                             .lexical_form = lexical_form,
+                                             .language_tag = ""}),
+                                     storage::node::identifier::RDFNodeType::Literal,
+                                     node_storage.id()}};
+}
+
+Literal Literal::make_lang_tagged_unchecked(std::string_view lexical_form, std::string_view lang, Node::NodeStorage &node_storage) noexcept {
+    return Literal{NodeBackendHandle{node_storage.find_or_make_id(storage::node::view::LiteralBackendView{
+                                             .datatype_id = storage::node::identifier::NodeID::rdf_langstring_iri.first,
+                                             .lexical_form = lexical_form,
+                                             .language_tag = lang}),
+                                     storage::node::identifier::RDFNodeType::Literal,
+                                     node_storage.id()}};
+}
+
+Literal Literal::make_inlined_typed_unchecked(uint64_t inlined_value, storage::node::identifier::LiteralType fixed_id, Node::NodeStorage &node_storage) noexcept {
+    using namespace storage::node::identifier;
+
+    assert(inlined_value >> LiteralID::width == 0);
+    assert(fixed_id != LiteralType::other());
+
+    return Literal{NodeBackendHandle{NodeID{LiteralID{inlined_value}, fixed_id},
+                                     RDFNodeType::Literal,
+                                     node_storage.id(),
+                                     true}};
+}
+
+Literal Literal::make_typed_unchecked(std::any const &value, datatypes::registry::DatatypeIDView datatype, datatypes::registry::DatatypeRegistry::DatatypeEntry const &entry, Node::NodeStorage &node_storage) noexcept {
+    if (entry.inlining_ops.has_value()) {
+        if (auto const maybe_inlined = entry.inlining_ops->try_into_inlined_fptr(value); maybe_inlined.has_value()) {
+            return Literal::make_inlined_typed_unchecked(*maybe_inlined, datatype.get_fixed(), node_storage);
+        }
+    }
+
+    return Literal::make_noninlined_typed_unchecked(entry.to_canonical_string_fptr(value),
+                                                    IRI{datatype, node_storage},
+                                                    node_storage);
+}
+
+Literal Literal::make_simple(std::string_view lexical_form, Node::NodeStorage &node_storage) {
+    return Literal::make_simple_unchecked(lexical_form, node_storage);
+}
+
+Literal Literal::make_lang_tagged(std::string_view lexical_form, std::string_view lang_tag, Node::NodeStorage &node_storage) {
+    return Literal::make_lang_tagged_unchecked(lexical_form, lang_tag, node_storage);
+}
+
+Literal Literal::make_typed(std::string_view lexical_form, IRI const &datatype, Node::NodeStorage &node_storage) {
+    using namespace datatypes::registry;
+
+    DatatypeIDView const datatype_identifier{datatype};
+
+    if (datatype_identifier == datatypes::rdf::LangString::datatype_id) {
+        // see: https://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal
+        throw std::invalid_argument{"cannot construct rdf:langString without a language tag, please call one of the other constructors"};
+    }
+
+    if (auto const *entry = DatatypeRegistry::get_entry(datatype_identifier); entry != nullptr) {
+        // exists => canonize
+
+        auto const cpp_value = entry->factory_fptr(lexical_form);
+        return Literal::make_typed_unchecked(cpp_value, datatype_identifier, *entry, node_storage);
+    } else {
+        // doesn't exist in the registry no way to canonicalize
+        return Literal::make_noninlined_typed_unchecked(lexical_form, datatype, node_storage);
+    }
+}
+
 
 IRI Literal::datatype() const noexcept {
     if (this->is_fixed()) {
@@ -189,78 +268,6 @@ std::any Literal::value() const noexcept {
     return {};
 }
 
-Literal Literal::make_simple_unchecked(std::string_view lexical_form, Node::NodeStorage &node_storage) noexcept {
-    return Literal{NodeBackendHandle{node_storage.find_or_make_id(storage::node::view::LiteralBackendView{
-                                             .datatype_id = storage::node::identifier::NodeID::xsd_string_iri.first,
-                                             .lexical_form = lexical_form,
-                                             .language_tag = ""}),
-                                     storage::node::identifier::RDFNodeType::Literal,
-                                     node_storage.id()}};
-}
-
-Literal Literal::make_noninlined_typed_unchecked(std::string_view lexical_form, IRI const &datatype, Node::NodeStorage &node_storage) noexcept {
-    return Literal{NodeBackendHandle{node_storage.find_or_make_id(storage::node::view::LiteralBackendView{
-                                             .datatype_id = datatype.to_node_storage(node_storage).backend_handle().node_id(),
-                                             .lexical_form = lexical_form,
-                                             .language_tag = ""}),
-                                     storage::node::identifier::RDFNodeType::Literal,
-                                     node_storage.id()}};
-}
-
-Literal Literal::make_lang_tagged_unchecked(std::string_view lexical_form, std::string_view lang, Node::NodeStorage &node_storage) noexcept {
-    return Literal{NodeBackendHandle{node_storage.find_or_make_id(storage::node::view::LiteralBackendView{
-                                             .datatype_id = storage::node::identifier::NodeID::rdf_langstring_iri.first,
-                                             .lexical_form = lexical_form,
-                                             .language_tag = lang}),
-                                     storage::node::identifier::RDFNodeType::Literal,
-                                     node_storage.id()}};
-}
-
-Literal Literal::make_inlined_typed_unchecked(uint64_t inlined_value, storage::node::identifier::LiteralType fixed_id, Node::NodeStorage &node_storage) noexcept {
-    using namespace storage::node::identifier;
-
-    assert(inlined_value >> LiteralID::width == 0);
-    assert(fixed_id != LiteralType::other());
-
-    return Literal{NodeBackendHandle{NodeID{LiteralID{inlined_value}, fixed_id},
-                                     RDFNodeType::Literal,
-                                     node_storage.id(),
-                                     true}};
-}
-
-Literal Literal::make_typed_unchecked(std::any const &value, datatypes::registry::DatatypeIDView datatype, datatypes::registry::DatatypeRegistry::DatatypeEntry const &entry, Node::NodeStorage &node_storage) noexcept {
-    if (entry.inlining_ops.has_value()) {
-        if (auto const maybe_inlined = entry.inlining_ops->try_into_inlined_fptr(value); maybe_inlined.has_value()) {
-            return Literal::make_inlined_typed_unchecked(*maybe_inlined, datatype.get_fixed(), node_storage);
-        }
-    }
-
-    return Literal::make_noninlined_typed_unchecked(entry.to_canonical_string_fptr(value),
-                                                    IRI{datatype, node_storage},
-                                                    node_storage);
-}
-
-Literal Literal::make(std::string_view lexical_form, IRI const &datatype, Node::NodeStorage &node_storage) {
-    using namespace datatypes::registry;
-
-    DatatypeIDView const datatype_identifier{datatype};
-
-    if (datatype_identifier == datatypes::rdf::LangString::datatype_id) {
-        // see: https://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal
-        throw std::invalid_argument{"cannot construct rdf:langString without a language tag, please call one of the other constructors"};
-    }
-
-    if (auto const *entry = DatatypeRegistry::get_entry(datatype_identifier); entry != nullptr) {
-        // exists => canonize
-
-        auto const cpp_value = entry->factory_fptr(lexical_form);
-        return Literal::make_typed_unchecked(cpp_value, datatype_identifier, *entry, node_storage);
-    } else {
-        // doesn't exist in the registry no way to canonicalize
-        return Literal::make_noninlined_typed_unchecked(lexical_form, datatype, node_storage);
-    }
-}
-
 Literal Literal::cast(IRI const &target, Node::NodeStorage &node_storage) const noexcept {
     using namespace datatypes::registry;
     using namespace datatypes::xsd;
@@ -279,7 +286,7 @@ Literal Literal::cast(IRI const &target, Node::NodeStorage &node_storage) const 
     if (this_dtid == String::datatype_id) {
         // string -> any
         try {
-            return Literal::make(this->lexical_form(), target, node_storage);
+            return Literal::make_typed(this->lexical_form(), target, node_storage);
         } catch (std::runtime_error const &) {
             return Literal{};
         }
@@ -758,7 +765,7 @@ Literal Literal::ebv_as_literal(NodeStorage &node_storage) const noexcept {
         return Literal{};
     }
 
-    return Literal::make<datatypes::xsd::Boolean>(ebv == util::TriBool::True, node_storage);
+    return Literal::make_typed<datatypes::xsd::Boolean>(ebv == util::TriBool::True, node_storage);
 }
 
 Literal Literal::logical_and(Literal const &other, Node::NodeStorage &node_storage) const noexcept {
@@ -768,7 +775,7 @@ Literal Literal::logical_and(Literal const &other, Node::NodeStorage &node_stora
         return Literal{};
     }
 
-    return Literal::make<datatypes::xsd::Boolean>(res, node_storage);
+    return Literal::make_typed<datatypes::xsd::Boolean>(res, node_storage);
 }
 
 Literal Literal::operator&&(Literal const &other) const noexcept {
@@ -782,7 +789,7 @@ Literal Literal::logical_or(Literal const &other, Node::NodeStorage &node_storag
         return Literal{};
     }
 
-    return Literal::make<datatypes::xsd::Boolean>(res, node_storage);
+    return Literal::make_typed<datatypes::xsd::Boolean>(res, node_storage);
 }
 
 Literal Literal::operator||(Literal const &other) const noexcept {
@@ -796,7 +803,7 @@ Literal Literal::logical_not(Node::NodeStorage &node_storage) const noexcept {
         return Literal{};
     }
 
-    return Literal::make<datatypes::xsd::Boolean>(ebv == util::TriBool::False, node_storage);
+    return Literal::make_typed<datatypes::xsd::Boolean>(ebv == util::TriBool::False, node_storage);
 }
 
 Literal Literal::operator!() const noexcept {

--- a/src/rdf4cpp/rdf/Literal.hpp
+++ b/src/rdf4cpp/rdf/Literal.hpp
@@ -106,30 +106,48 @@ protected:
     explicit Literal(Node::NodeBackendHandle handle) noexcept;
 
 public:
-    Literal() noexcept;
     /**
-     * Constructs a Literal from a lexical form. Datatype is `xsd:string`.
+     * Constructs the null-literal
+     */
+    Literal() noexcept;
+
+    /**
+     * Constructs a simple Literal from a lexical form. Datatype is `xsd:string`.
      * @param lexical_form the lexical form
      * @param node_storage optional custom node_storage used to store the literal
      */
     explicit Literal(std::string_view lexical_form,
                      NodeStorage &node_storage = NodeStorage::default_instance());
+
     /**
-     * Constructs a Literal from a lexical form and a datatype.
+     * Constructs the null-literal
+     */
+    [[nodiscard]] static Literal make_null() noexcept;
+
+    /**
+     * Constructs a simple Literal from a lexical form. Datatype is `xsd:string`.
      * @param lexical_form the lexical form
-     * @param datatype the datatype
      * @param node_storage optional custom node_storage used to store the literal
      */
-    Literal(std::string_view lexical_form, const IRI &datatype,
-            NodeStorage &node_storage = NodeStorage::default_instance());
+    [[nodiscard]] static Literal make_simple(std::string_view lexical_form, NodeStorage &node_storage = NodeStorage::default_instance());
+
     /**
      * Constructs a Literal from a lexical form and a language tag. The datatype is `rdf:langString`.
      * @param lexical_form the lexical form
      * @param lang the language tag
      * @param node_storage optional custom node_storage used to store the literal
      */
-    Literal(std::string_view lexical_form, std::string_view lang,
-            NodeStorage &node_storage = NodeStorage::default_instance());
+    [[nodiscard]] static Literal make_lang_tagged(std::string_view lexical_form, std::string_view lang_tag,
+                                                  NodeStorage &node_storage = NodeStorage::default_instance());
+
+    /**
+     * Constructs a Literal from a lexical form and a datatype.
+     * @param lexical_form the lexical form
+     * @param datatype the datatype
+     * @param node_storage optional custom node_storage used to store the literal
+     */
+    [[nodiscard]] static Literal make_typed(std::string_view lexical_form, IRI const &datatype,
+                                            NodeStorage &node_storage = NodeStorage::default_instance());
 
     /**
      * Constructs a literal from a compatible type. In this version of the function the datatype is specified at compile time.
@@ -142,8 +160,8 @@ public:
      * @return literal instance representing compatible_value
      */
     template<datatypes::LiteralDatatype LiteralDatatype_t>
-    static Literal make(typename LiteralDatatype_t::cpp_type compatible_value,
-                        NodeStorage &node_storage = NodeStorage::default_instance()) noexcept {
+    [[nodiscard]] static Literal make_typed(typename LiteralDatatype_t::cpp_type compatible_value,
+                                            NodeStorage &node_storage = NodeStorage::default_instance()) noexcept {
 
         if constexpr (std::is_same_v<LiteralDatatype_t, datatypes::rdf::LangString>) {
             return Literal::make_lang_tagged_unchecked(compatible_value.lexical_form,
@@ -161,17 +179,6 @@ public:
                                                         IRI{LiteralDatatype_t::datatype_id, node_storage},
                                                         node_storage);
     }
-
-    /**
-     * Constructs a literal from a compatible type. In this version of the function the datatype is specified at runtime.
-     * Due to the lookup of the converter functions, this function is slightly slower than its templated version.
-     * @param lexical_form
-     * @param datatype
-     * @param node_storage
-     * @return
-     */
-    static Literal make(std::string_view lexical_form, IRI const &datatype,
-                        NodeStorage &node_storage = NodeStorage::default_instance());
 
     /**
      * Tries to cast this literal to a literal of the given type IRI.

--- a/src/rdf4cpp/rdf/Literal.hpp
+++ b/src/rdf4cpp/rdf/Literal.hpp
@@ -112,14 +112,6 @@ public:
     Literal() noexcept;
 
     /**
-     * Constructs a simple Literal from a lexical form. Datatype is `xsd:string`.
-     * @param lexical_form the lexical form
-     * @param node_storage optional custom node_storage used to store the literal
-     */
-    explicit Literal(std::string_view lexical_form,
-                     NodeStorage &node_storage = NodeStorage::default_instance());
-
-    /**
      * Constructs the null-literal
      */
     [[nodiscard]] static Literal make_null() noexcept;

--- a/src/rdf4cpp/rdf/Node.cpp
+++ b/src/rdf4cpp/rdf/Node.cpp
@@ -10,6 +10,10 @@ namespace rdf4cpp::rdf {
 
 Node::Node(Node::NodeBackendHandle id) noexcept : handle_(id) {}
 
+Node Node::make_null() noexcept {
+    return Node{};
+}
+
 Node Node::to_node_storage(Node::NodeStorage &node_storage) const noexcept {
     if (this->backend_handle().node_storage_id() == node_storage.id())
         return *this;
@@ -39,7 +43,7 @@ Node Node::to_node_storage(Node::NodeStorage &node_storage) const noexcept {
                     return NodeID{};
             }
         }();
-        return Node(NodeBackendHandle{node_id, backend_handle().type(), node_storage.id()});
+        return Node{NodeBackendHandle{node_id, backend_handle().type(), node_storage.id()}};
     }
 }
 
@@ -50,8 +54,7 @@ Node::operator std::string() const noexcept {
         case RDFNodeType::BNode:
             return handle_.bnode_backend().n_string();
         case RDFNodeType::Literal: {
-            const auto &literal = static_cast<const Literal &>(*this);
-            return static_cast<std::string>(literal);
+            return static_cast<std::string>(static_cast<Literal>(*this));
         }
         case RDFNodeType::Variable:
             return handle_.variable_backend().n_string();
@@ -102,7 +105,7 @@ std::weak_ordering Node::operator<=>(const Node &other) const noexcept {
             case RDFNodeType::BNode:
                 return this->handle_.bnode_backend() <=> other.handle_.bnode_backend();
             case RDFNodeType::Literal:
-                return Literal{this->handle_}.compare_with_extensions(Literal{other.handle_});
+                return static_cast<Literal>(*this).compare_with_extensions(static_cast<Literal>(other));
             case RDFNodeType::Variable:
                 return this->handle_.variable_backend() <=> other.handle_.variable_backend();
             default:{
@@ -123,15 +126,15 @@ Node::operator BlankNode() const noexcept {
 }
 Node::operator IRI() const noexcept {
     assert(is_iri());
-    return IRI(handle_);
+    return IRI{handle_};
 }
 Node::operator Literal() const noexcept {
     assert(is_literal());
-    return Literal(handle_);
+    return Literal{handle_};
 }
 Node::operator query::Variable() const noexcept {
     assert(is_variable());
-    return query::Variable(handle_);
+    return query::Variable{handle_};
 }
 bool Node::null() const noexcept {
     return handle_.null();
@@ -161,6 +164,5 @@ Literal Node::ebv_as_literal([[maybe_unused]] NodeStorage &node_storage) const n
 
     return static_cast<Literal>(*this).ebv_as_literal(node_storage);
 }
-
 
 }  // namespace rdf4cpp::rdf

--- a/src/rdf4cpp/rdf/Node.hpp
+++ b/src/rdf4cpp/rdf/Node.hpp
@@ -25,6 +25,8 @@ class Variable;
  * <p><b>Please note:</b> The edges of an RDF Graph, dubbed <span>Predicate</span>s, are <span>IRI</span>s. As such the same resource can also be used as a node.
  * For the sake of simplicity, we decided to have no separate class for edges in an RDF graph.
  * You can determine if a Node is an edge by the the fact that it is used as predicate in a Dataset, Graph, Quad, Statement, QuadPattern or TriplePattern.</p>
+ *
+ * @warning This type is a POD.
  */
 class Node {
 protected:
@@ -44,8 +46,15 @@ public:
     /**
      * Default construction produces null() const Node. This node models an unset or invalid Node.
      * null() const <span>Node</span>s should only be used as temporary placeholders. They cannot be inserted into a Graph or Dataset.
+     *
+     * @warning This type is POD. The constructor needs to be invoked explicitly. Alternatively: call Node::make_null()
      */
     Node() noexcept = default;
+
+    /**
+     * Construct the null-node
+     */
+    [[nodiscard]] static Node make_null() noexcept;
 
     /**
      * Returns a string representation of the given node in N-format as defined by <a href="https://www.w3.org/TR/n-triples/">N-Triples</a> and <a href="https://www.w3.org/TR/n-quads/">N-Quads</a>.

--- a/src/rdf4cpp/rdf/parser/private/IStreamQuadIteratorSerdImpl.cpp
+++ b/src/rdf4cpp/rdf/parser/private/IStreamQuadIteratorSerdImpl.cpp
@@ -146,11 +146,11 @@ nonstd::expected<Literal, SerdStatus> IStreamQuadIterator::Impl::get_literal(Ser
                 return nonstd::make_unexpected(datatype_iri->error());
             }
 
-            return Literal{literal_value, datatype_iri->value(), this->node_storage};
+            return Literal::make_typed(literal_value, datatype_iri->value(), this->node_storage);
         } else if (lang != nullptr) {
-            return Literal{literal_value, node_into_string_view(lang), this->node_storage};
+            return Literal::make_lang_tagged(literal_value, node_into_string_view(lang), this->node_storage);
         } else {
-            return Literal{literal_value, this->node_storage};
+            return Literal::make_simple(literal_value, this->node_storage);
         }
     } catch (std::runtime_error const &e) {
         // NOTE: line, col not entirely accurate as this function is called after a triple was parsed

--- a/src/rdf4cpp/rdf/query/Variable.cpp
+++ b/src/rdf4cpp/rdf/query/Variable.cpp
@@ -2,11 +2,19 @@
 
 namespace rdf4cpp::rdf::query {
 Variable::Variable() noexcept : Node(NodeBackendHandle{{}, storage::node::identifier::RDFNodeType::Variable, {}}) {}
-Variable::Variable(std::string_view identifier, bool anonymous, NodeStorage &node_storage)
-    : Node(NodeBackendHandle{node_storage.find_or_make_id(storage::node::view::VariableBackendView{.name = identifier, .is_anonymous = anonymous}),
+Variable::Variable(std::string_view name, bool anonymous, NodeStorage &node_storage)
+    : Node{NodeBackendHandle{node_storage.find_or_make_id(storage::node::view::VariableBackendView{.name = name, .is_anonymous = anonymous}),
                              storage::node::identifier::RDFNodeType::Variable,
-                             node_storage.id()}) {}
-Variable::Variable(Node::NodeBackendHandle handle) noexcept : Node(handle) {}
+                             node_storage.id()}} {}
+Variable::Variable(Node::NodeBackendHandle handle) noexcept : Node{handle} {}
+
+Variable Variable::make_named(std::string_view name, Node::NodeStorage &node_storage) {
+    return Variable{name, false, node_storage};
+}
+
+Variable Variable::make_anonymous(std::string_view name, Node::NodeStorage &node_storage) {
+    return Variable{name, true, node_storage};
+}
 
 bool Variable::is_anonymous() const {
     // TODO: encode is_anonymous into variable ID
@@ -27,5 +35,7 @@ std::ostream &operator<<(std::ostream &os, const Variable &variable) {
     os << static_cast<std::string>(variable);
     return os;
 }
+
+
 
 }  // namespace rdf4cpp::rdf::query

--- a/src/rdf4cpp/rdf/query/Variable.hpp
+++ b/src/rdf4cpp/rdf/query/Variable.hpp
@@ -15,6 +15,9 @@ public:
     explicit Variable(std::string_view name, bool anonymous = false,
                       NodeStorage &node_storage = NodeStorage::default_instance());
 
+    [[nodiscard]] static Variable make_named(std::string_view name, NodeStorage &node_storage = NodeStorage::default_instance());
+    [[nodiscard]] static Variable make_anonymous(std::string_view name, NodeStorage &node_storage = NodeStorage::default_instance());
+
     [[nodiscard]] bool is_anonymous() const;
 
     [[nodiscard]] std::string_view name() const;

--- a/test_FetchContent/src/test_FetchContent.cpp
+++ b/test_FetchContent/src/test_FetchContent.cpp
@@ -5,7 +5,7 @@
 int main() {
     using namespace rdf4cpp::rdf;
 
-    Literal datatype_test_lit{"123.0", IRI{"http://www.w3.org/2001/XMLSchema#double"}}; // segfault if registering of datatypes does not work
+    auto const datatype_test_lit = Literal::make_typed("123.0", IRI{"http://www.w3.org/2001/XMLSchema#double"}); // segfault if registering of datatypes does not work
     std::cout << datatype_test_lit << std::endl;
-    std::cout << Literal{"Using FetchContent works."} << std::endl;
+    std::cout << Literal::make_simple("Using FetchContent works.") << std::endl;
 }

--- a/test_package/example.cpp
+++ b/test_package/example.cpp
@@ -5,7 +5,7 @@
 int main() {
     using namespace rdf4cpp::rdf;
 
-    Literal datatype_test_lit{"123.0", IRI{"http://www.w3.org/2001/XMLSchema#double"}}; // segfault if registering of datatypes does not work
+    auto const datatype_test_lit = Literal::make_typed("123.0", IRI{"http://www.w3.org/2001/XMLSchema#double"}); // segfault if registering of datatypes does not work
     std::cout << datatype_test_lit << std::endl;
-    std::cout << Literal{"Using the conan package works."} << std::endl;
+    std::cout << Literal::make_simple("Using the conan package works.") << std::endl;
 }

--- a/tests/datatype/tests_Boolean.cpp
+++ b/tests/datatype/tests_Boolean.cpp
@@ -32,42 +32,42 @@ TEST_CASE("Datatype Boolean") {
     std::string false_val{"false"};
 
     bool value = true;
-    auto lit1 = Literal::make<datatypes::xsd::Boolean>(value);
+    auto lit1 = Literal::make_typed<datatypes::xsd::Boolean>(value);
     CHECK(lit1.value<datatypes::xsd::Boolean>() == value);
     CHECK(lit1.lexical_form() == true_val);
 
     value = false;
-    auto lit2 = Literal::make<datatypes::xsd::Boolean>(value);
+    auto lit2 = Literal::make_typed<datatypes::xsd::Boolean>(value);
     CHECK(lit2.value<datatypes::xsd::Boolean>() == value);
     CHECK(lit2.lexical_form() == false_val);
 
     value = 1;
-    auto lit3 = Literal::make<datatypes::xsd::Boolean>(value);
+    auto lit3 = Literal::make_typed<datatypes::xsd::Boolean>(value);
     CHECK(lit3.value<datatypes::xsd::Boolean>() == value);
     CHECK(lit3.lexical_form() == true_val);
 
     value = 0;
-    auto lit4 = Literal::make<datatypes::xsd::Boolean>(value);
+    auto lit4 = Literal::make_typed<datatypes::xsd::Boolean>(value);
     CHECK(lit4.value<datatypes::xsd::Boolean>() == value);
     CHECK(lit4.lexical_form() == false_val);
 
     value = true;
-    auto lit5 = Literal{true_val, type_iri};
+    auto lit5 = Literal::make_typed(true_val, type_iri);
     CHECK(lit5.value<datatypes::xsd::Boolean>() == value);
     CHECK(std::any_cast<bool>(lit5.value()) == value);
 
     value = false;
-    auto lit6 = Literal{false_val, type_iri};
+    auto lit6 = Literal::make_typed(false_val, type_iri);
     CHECK(lit6.value<datatypes::xsd::Boolean>() == value);
     CHECK(std::any_cast<bool>(lit6.value()) == value);
 
     value = 1;
-    auto lit7 = Literal{"1", type_iri};
+    auto lit7 = Literal::make_typed("1", type_iri);
     CHECK(lit7.value<datatypes::xsd::Boolean>() == value);
     CHECK(lit7.lexical_form() == true_val);
 
     value = 0;
-    auto lit8 = Literal{"0", type_iri};
+    auto lit8 = Literal::make_typed("0", type_iri);
     CHECK(lit8.value<datatypes::xsd::Boolean>() == value);
     CHECK(lit8.lexical_form() == false_val);
 
@@ -83,11 +83,11 @@ TEST_CASE("Datatype Boolean") {
     // suppress warnings regarding attribute ‘nodiscard’
     Literal no_discard_dummy;
 
-    CHECK_THROWS_WITH_AS(no_discard_dummy = Literal("5", type_iri), "XSD Parsing Error", std::runtime_error);
+    CHECK_THROWS_WITH_AS(no_discard_dummy = Literal::make_typed("5", type_iri), "XSD Parsing Error", std::runtime_error);
 
-    CHECK_THROWS_WITH_AS(no_discard_dummy =  Literal("adsfg", type_iri), "XSD Parsing Error", std::runtime_error);
+    CHECK_THROWS_WITH_AS(no_discard_dummy =  Literal::make_typed("adsfg", type_iri), "XSD Parsing Error", std::runtime_error);
 
-    CHECK_THROWS_WITH_AS(no_discard_dummy =  Literal("5.64566", type_iri), "XSD Parsing Error", std::runtime_error);
+    CHECK_THROWS_WITH_AS(no_discard_dummy =  Literal::make_typed("5.64566", type_iri), "XSD Parsing Error", std::runtime_error);
 
-    CHECK_THROWS_WITH_AS(no_discard_dummy =  Literal("1.7e", type_iri), "XSD Parsing Error", std::runtime_error);
+    CHECK_THROWS_WITH_AS(no_discard_dummy =  Literal::make_typed("1.7e", type_iri), "XSD Parsing Error", std::runtime_error);
 }

--- a/tests/datatype/tests_Byte.cpp
+++ b/tests/datatype/tests_Byte.cpp
@@ -19,27 +19,27 @@ TEST_CASE("Datatype Byte") {
     CHECK(std::is_same_v<type, int8_t>);
 
     auto value = 1;
-    auto lit1 = Literal::make<datatypes::xsd::Byte>(value);
+    auto lit1 = Literal::make_typed<datatypes::xsd::Byte>(value);
     CHECK(lit1.value<datatypes::xsd::Byte>() == value);
     CHECK(lit1.lexical_form() == std::to_string(value));
 
     value = -128;
-    auto lit2 = Literal::make<datatypes::xsd::Byte>(value);
+    auto lit2 = Literal::make_typed<datatypes::xsd::Byte>(value);
     CHECK(lit2.value<datatypes::xsd::Byte>() == value);
     CHECK(lit2.lexical_form() == std::to_string(value));
 
     value = 127;
-    auto lit3 = Literal::make<datatypes::xsd::Byte>(value);
+    auto lit3 = Literal::make_typed<datatypes::xsd::Byte>(value);
     CHECK(lit3.value<datatypes::xsd::Byte>() == value);
     CHECK(lit3.lexical_form() == std::to_string(value));
 
     value = 1;
-    auto lit4 = Literal{std::to_string(value), type_iri};
+    auto lit4 = Literal::make_typed(std::to_string(value), type_iri);
     CHECK(lit4.value<datatypes::xsd::Byte>() == value);
     CHECK(lit4.lexical_form() == std::to_string(value));
 
     value = 127;
-    auto lit5 = Literal{std::to_string(value), type_iri};
+    auto lit5 = Literal::make_typed(std::to_string(value), type_iri);
     CHECK(lit5.value<datatypes::xsd::Byte>() == value);
     CHECK(lit5.lexical_form() == std::to_string(value));
 
@@ -51,13 +51,13 @@ TEST_CASE("Datatype Byte") {
     // suppress warnings regarding attribute ‘nodiscard’
     Literal no_discard_dummy;
 
-    CHECK_THROWS(no_discard_dummy = Literal("139", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("139", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("-130", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("-130", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("0.00001", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("0.00001", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("qwerty", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("qwerty", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("a23dg.59566", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("a23dg.59566", type_iri));
 }

--- a/tests/datatype/tests_Decimal.cpp
+++ b/tests/datatype/tests_Decimal.cpp
@@ -31,65 +31,65 @@ TEST_CASE("Datatype Decimal") {
     std::string rdf_dbl_0_0{"0.0"};
 
     type value = 1.00;
-    auto lit1 = Literal::make<datatypes::xsd::Decimal>(value);
+    auto lit1 = Literal::make_typed<datatypes::xsd::Decimal>(value);
     CHECK(lit1.value<datatypes::xsd::Decimal>() == value);
     CHECK(lit1.lexical_form() == rdf_dbl_1_0);
 
     value = 64582165456988.6235896;
-    auto lit2 = Literal::make<datatypes::xsd::Decimal>(value);
+    auto lit2 = Literal::make_typed<datatypes::xsd::Decimal>(value);
     CHECK(lit2.value<datatypes::xsd::Decimal>() == value);
 
     value = -64524654389.12345678;
-    auto lit3 = Literal::make<datatypes::xsd::Decimal>(value);
+    auto lit3 = Literal::make_typed<datatypes::xsd::Decimal>(value);
     CHECK(lit3.value<datatypes::xsd::Decimal>() == value);
 
     value = 1.0;
-    auto lit4 = Literal{to_string(value), type_iri};
+    auto lit4 = Literal::make_typed(to_string(value), type_iri);
     CHECK(lit4.value<datatypes::xsd::Decimal>() == value);
     CHECK(lit4.lexical_form() == rdf_dbl_1_0);
 
     value = type{"64582165456988.235046"};
-    auto lit5 = Literal{"64582165456988.235046", type_iri};
+    auto lit5 = Literal::make_typed("64582165456988.235046", type_iri);
     CHECK(lit5.value<datatypes::xsd::Decimal>() == value);
 
     value = 1;
-    auto lit6 = Literal{"1.", type_iri};
+    auto lit6 = Literal::make_typed("1.", type_iri);
     CHECK(lit6.value<datatypes::xsd::Decimal>() == value);
     CHECK(lit6.lexical_form() == rdf_dbl_1_0);
 
-    auto lit7 = Literal{rdf_dbl_1_0, type_iri};
+    auto lit7 = Literal::make_typed(rdf_dbl_1_0, type_iri);
     CHECK(lit7.value<datatypes::xsd::Decimal>() == value);
     CHECK(lit7.lexical_form() == rdf_dbl_1_0);
 
-    auto lit8 = Literal{"1.00", type_iri};
+    auto lit8 = Literal::make_typed("1.00", type_iri);
     CHECK(lit8.value<datatypes::xsd::Decimal>() == value);
     CHECK(lit8.lexical_form() == rdf_dbl_1_0);
 
     value = std::numeric_limits<double>::max();
-    auto lit9 = Literal{to_string(value), type_iri};
+    auto lit9 = Literal::make_typed(to_string(value), type_iri);
     CHECK(lit9.value<datatypes::xsd::Decimal>() == value);
 
     value = type{"3.111"};
-    auto lit10 = Literal::make<datatypes::xsd::Decimal>(value);
+    auto lit10 = Literal::make_typed<datatypes::xsd::Decimal>(value);
     CHECK(lit10.value<datatypes::xsd::Decimal>() == value);
 
     value = 0;
-    auto lit11 = Literal::make<datatypes::xsd::Decimal>(value);
+    auto lit11 = Literal::make_typed<datatypes::xsd::Decimal>(value);
     CHECK(lit11.value<datatypes::xsd::Decimal>() == value);
     CHECK(lit11.lexical_form() == rdf_dbl_0_0);
 
     value = 1.0;
-    auto lit12 = Literal{"+1.0000", type_iri};
+    auto lit12 = Literal::make_typed("+1.0000", type_iri);
     CHECK(lit12.value<datatypes::xsd::Decimal>() == value);
     CHECK(lit12.lexical_form() == rdf_dbl_1_0);
 
     value = type{"0.000000005"};
-    auto lit13 = Literal::make<datatypes::xsd::Decimal>(value);
+    auto lit13 = Literal::make_typed<datatypes::xsd::Decimal>(value);
     CHECK(lit13.value<datatypes::xsd::Decimal>() == value);
     CHECK(lit13.lexical_form() == "0.000000005");
 
     value = 6000000000.0;
-    auto lit14 = Literal::make<datatypes::xsd::Decimal>(value);
+    auto lit14 = Literal::make_typed<datatypes::xsd::Decimal>(value);
     CHECK(lit14.value<datatypes::xsd::Decimal>() == value);
     CHECK(lit14.lexical_form() == "6000000000.0");
 
@@ -111,19 +111,19 @@ TEST_CASE("Datatype Decimal") {
     // suppress warnings regarding attribute ‘nodiscard’
     Literal no_discard_dummy;
 
-    CHECK_THROWS_WITH_AS(no_discard_dummy = Literal("NAN", type_iri), "XSD Parsing Error", std::runtime_error);
+    CHECK_THROWS_WITH_AS(no_discard_dummy = Literal::make_typed("NAN", type_iri), "XSD Parsing Error", std::runtime_error);
 
-    CHECK_THROWS_WITH_AS(no_discard_dummy = Literal("INF", type_iri), "XSD Parsing Error", std::runtime_error);
+    CHECK_THROWS_WITH_AS(no_discard_dummy = Literal::make_typed("INF", type_iri), "XSD Parsing Error", std::runtime_error);
 
     value = INFINITY;
-    CHECK_THROWS_WITH_AS(no_discard_dummy = Literal(to_string(value), type_iri), "XSD Parsing Error", std::runtime_error);
+    CHECK_THROWS_WITH_AS(no_discard_dummy = Literal::make_typed(to_string(value), type_iri), "XSD Parsing Error", std::runtime_error);
 
     value = NAN;
-    CHECK_THROWS_WITH_AS(no_discard_dummy = Literal(to_string(value), type_iri), "XSD Parsing Error", std::runtime_error);
+    CHECK_THROWS_WITH_AS(no_discard_dummy = Literal::make_typed(to_string(value), type_iri), "XSD Parsing Error", std::runtime_error);
 
-    CHECK_THROWS_WITH_AS(no_discard_dummy = Literal("454sdsd", type_iri), "XSD Parsing Error", std::runtime_error);
+    CHECK_THROWS_WITH_AS(no_discard_dummy = Literal::make_typed("454sdsd", type_iri), "XSD Parsing Error", std::runtime_error);
 
-    CHECK_THROWS_WITH_AS(no_discard_dummy = Literal("2.225E-307", type_iri), "XSD Parsing Error", std::runtime_error);
+    CHECK_THROWS_WITH_AS(no_discard_dummy = Literal::make_typed("2.225E-307", type_iri), "XSD Parsing Error", std::runtime_error);
 }
 
 TEST_CASE("precision") {
@@ -139,14 +139,14 @@ TEST_CASE("precision") {
     cpp_type const n = 18;
     cpp_type const x = i * pow(cpp_type{10}, -n);
 
-    Literal const lit = Literal::make<datatypes::xsd::Decimal>(x);
+    Literal const lit = Literal::make_typed<datatypes::xsd::Decimal>(x);
     CHECK(lit.lexical_form() == "0.999999999999999999");
 }
 
 TEST_CASE("Datatype Decimal buffer overread UB") {
     std::string const s = "123.456";
-    std::string_view const sv{ s.data(), 5 };
+    std::string_view const sv{s.data(), 5};
 
-    Literal const lit{ sv, datatypes::xsd::Decimal::identifier };
+    auto const lit = Literal::make_typed(sv, IRI{datatypes::xsd::Decimal::identifier});
     CHECK(lit.value<datatypes::xsd::Decimal>() == datatypes::xsd::Decimal::cpp_type{"123.4"});
 }

--- a/tests/datatype/tests_Double.cpp
+++ b/tests/datatype/tests_Double.cpp
@@ -17,59 +17,59 @@ TEST_CASE("Datatype Double") {
     std::string rdf_dbl_1_0{"1.0E0"};
 
     double value = 1.00;
-    auto lit1 = Literal::make<datatypes::xsd::Double>(value);
+    auto lit1 = Literal::make_typed<datatypes::xsd::Double>(value);
     CHECK(lit1.value<datatypes::xsd::Double>() == value);
     CHECK(lit1.lexical_form() == rdf_dbl_1_0);
 
     value = 987456321123456.123586987;
-    auto lit2 = Literal::make<datatypes::xsd::Double>(value);
+    auto lit2 = Literal::make_typed<datatypes::xsd::Double>(value);
     CHECK(lit2.value<datatypes::xsd::Double>() == value);
 
     value = -64545352389.2352345670;
-    auto lit3 = Literal::make<datatypes::xsd::Double>(value);
+    auto lit3 = Literal::make_typed<datatypes::xsd::Double>(value);
     CHECK(lit3.value<datatypes::xsd::Double>() == value);
 
     value = 1;
-    auto lit4 = Literal::make<datatypes::xsd::Double>(value);
+    auto lit4 = Literal::make_typed<datatypes::xsd::Double>(value);
     CHECK(lit4.value<datatypes::xsd::Double>() == value);
     CHECK(lit4.lexical_form() == rdf_dbl_1_0);
 
     value = 1;
-    auto lit6 = Literal{std::to_string(value), type_iri};
+    auto lit6 = Literal::make_typed(std::to_string(value), type_iri);
     CHECK(lit6.value<datatypes::xsd::Double>() == value);
     CHECK(lit6.lexical_form() == rdf_dbl_1_0);
 
     value = 987456321123456.123586987;
-    auto lit7 = Literal{std::to_string(value), type_iri};
+    auto lit7 = Literal::make_typed(std::to_string(value), type_iri);
     CHECK(lit7.value<datatypes::xsd::Double>() == value);
 
-    auto lit8 = Literal{"NaN", type_iri};
+    auto lit8 = Literal::make_typed("NaN", type_iri);
     CHECK(std::isnan(lit8.value<datatypes::xsd::Double>()));
 
-    auto lit9 = Literal{"INF", type_iri};
+    auto lit9 = Literal::make_typed("INF", type_iri);
     CHECK(std::isinf(lit9.value<datatypes::xsd::Double>()));
 
     value = INFINITY;
-    auto lit10 = Literal::make<datatypes::xsd::Double>(value);
+    auto lit10 = Literal::make_typed<datatypes::xsd::Double>(value);
     CHECK(std::isinf(lit10.value<datatypes::xsd::Double>()));
 
     value = NAN;
-    auto lit11 = Literal::make<datatypes::xsd::Double>(value);
+    auto lit11 = Literal::make_typed<datatypes::xsd::Double>(value);
     CHECK(std::isnan(lit11.value<datatypes::xsd::Double>()));
 
     value = 2.22e-308;
-    auto lit12 = Literal{"2.22e-308", type_iri};
+    auto lit12 = Literal::make_typed("2.22e-308", type_iri);
     CHECK(lit12.value<datatypes::xsd::Double>() == value);
 
-    auto lit13 = Literal{"+INF", type_iri};
+    auto lit13 = Literal::make_typed("+INF", type_iri);
     CHECK(std::isinf(lit13.value<datatypes::xsd::Double>()));
 
-    auto lit14 = Literal{"-INF", type_iri};
+    auto lit14 = Literal::make_typed("-INF", type_iri);
     CHECK(std::isinf(lit14.value<datatypes::xsd::Double>()));
     CHECK(lit14.value<datatypes::xsd::Double>() == -std::numeric_limits<type>::infinity());
 
     value = -INFINITY;
-    auto lit15 = Literal::make<datatypes::xsd::Double>(value);
+    auto lit15 = Literal::make_typed<datatypes::xsd::Double>(value);
     CHECK(std::isinf(lit15.value<datatypes::xsd::Double>()));
     CHECK(lit15.value<datatypes::xsd::Double>() == -std::numeric_limits<type>::infinity());
 
@@ -86,19 +86,19 @@ TEST_CASE("Datatype Double") {
     // suppress warnings regarding attribute ‘nodiscard’
     Literal no_discard_dummy;
 
-    CHECK_THROWS(no_discard_dummy = Literal("454sdsd", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("454sdsd", type_iri));
 }
 
 TEST_CASE("round-trip") {
     datatypes::xsd::Double::cpp_type const value = -0.1234567890001;
-    auto const lit = Literal::make<datatypes::xsd::Double>(value);
+    auto const lit = Literal::make_typed<datatypes::xsd::Double>(value);
     std::cout << lit.lexical_form() << std::endl;
     CHECK(lit.value<datatypes::xsd::Double>() == value);
 }
 
 TEST_CASE("double inlining") {
     double value = 9999;
-    auto lit = Literal::make<datatypes::xsd::Double>(value);
+    auto lit = Literal::make_typed<datatypes::xsd::Double>(value);
     CHECK(lit.backend_handle().is_inlined());
     CHECK(lit.value<datatypes::xsd::Double>() == value);
 }

--- a/tests/datatype/tests_Float.cpp
+++ b/tests/datatype/tests_Float.cpp
@@ -32,59 +32,59 @@ TEST_CASE("Datatype Float") {
     std::string const rdf_float_1_0{"1.0E0"};
 
     type value = 1.00f;
-    auto lit1 = Literal::make<datatypes::xsd::Float>(value);
+    auto lit1 = Literal::make_typed<datatypes::xsd::Float>(value);
     CHECK(lit1.value<datatypes::xsd::Float>() == value);
     CHECK(lit1.lexical_form() == rdf_float_1_0);
 
     value = 32568.2350f;
-    auto lit2 = Literal::make<datatypes::xsd::Float>(value);
+    auto lit2 = Literal::make_typed<datatypes::xsd::Float>(value);
     CHECK(lit2.value<datatypes::xsd::Float>() == value);
 
     value = -14523.2350f;
-    auto lit3 = Literal::make<datatypes::xsd::Float>(value);
+    auto lit3 = Literal::make_typed<datatypes::xsd::Float>(value);
     CHECK(lit3.value<datatypes::xsd::Float>() == value);
 
     value = 1;
-    auto lit4 = Literal::make<datatypes::xsd::Float>(value);
+    auto lit4 = Literal::make_typed<datatypes::xsd::Float>(value);
     CHECK(lit4.value<datatypes::xsd::Float>() == value);
     CHECK(lit4.lexical_form() == rdf_float_1_0);
 
     value = 1;
-    auto lit6 = Literal{std::to_string(value), type_iri};
+    auto lit6 = Literal::make_typed(std::to_string(value), type_iri);
     CHECK(lit6.value<datatypes::xsd::Float>() == value);
     CHECK(lit6.lexical_form() == rdf_float_1_0);
 
     value = 32568.2350f;
-    auto lit7 = Literal{std::to_string(value), type_iri};
+    auto lit7 = Literal::make_typed(std::to_string(value), type_iri);
     CHECK(lit7.value<datatypes::xsd::Float>() == value);
 
-    auto lit8 = Literal{"NaN", type_iri};
+    auto lit8 = Literal::make_typed("NaN", type_iri);
     CHECK(std::isnan(lit8.value<datatypes::xsd::Float>()));
 
-    auto lit9 = Literal{"INF", type_iri};
+    auto lit9 = Literal::make_typed("INF", type_iri);
     CHECK(std::isinf(lit9.value<datatypes::xsd::Float>()));
 
     value = INFINITY;
-    auto lit10 = Literal::make<datatypes::xsd::Float>(value);
+    auto lit10 = Literal::make_typed<datatypes::xsd::Float>(value);
     CHECK(std::isinf(lit10.value<datatypes::xsd::Float>()));
 
     value = NAN;
-    auto lit11 = Literal::make<datatypes::xsd::Float>(value);
+    auto lit11 = Literal::make_typed<datatypes::xsd::Float>(value);
     CHECK(std::isnan(lit11.value<datatypes::xsd::Float>()));
 
     value = 1.17e-38;
-    auto lit12 = Literal{"1.17e-38", type_iri};
+    auto lit12 = Literal::make_typed("1.17e-38", type_iri);
     CHECK(lit12.value<datatypes::xsd::Float>() == value);
 
-    auto lit13 = Literal{"+INF", type_iri};
+    auto lit13 = Literal::make_typed("+INF", type_iri);
     CHECK(std::isinf(lit13.value<datatypes::xsd::Float>()));
 
-    auto lit14 = Literal{"-INF", type_iri};
+    auto lit14 = Literal::make_typed("-INF", type_iri);
     CHECK(std::isinf(lit14.value<datatypes::xsd::Float>()));
     CHECK(lit14.value<datatypes::xsd::Float>() == -std::numeric_limits<type>::infinity());
 
     value = -INFINITY;
-    auto lit15 = Literal::make<datatypes::xsd::Float>(value);
+    auto lit15 = Literal::make_typed<datatypes::xsd::Float>(value);
     CHECK(std::isinf(lit15.value<datatypes::xsd::Float>()));
     CHECK(lit15.value<datatypes::xsd::Float>() == -std::numeric_limits<type>::infinity());
 
@@ -101,12 +101,12 @@ TEST_CASE("Datatype Float") {
     // suppress warnings regarding attribute ‘nodiscard’
     Literal no_discard_dummy;
 
-    CHECK_THROWS(no_discard_dummy = Literal("454sdsd", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("454sdsd", type_iri));
 }
 
 TEST_CASE("round-trip") {
     datatypes::xsd::Float::cpp_type const value = -0.123456789f;
-    auto const lit = Literal::make<datatypes::xsd::Float>(value);
+    auto const lit = Literal::make_typed<datatypes::xsd::Float>(value);
     std::cout << lit.lexical_form() << std::endl;
     CHECK(lit.value<datatypes::xsd::Float>() == value);
 }

--- a/tests/datatype/tests_Int.cpp
+++ b/tests/datatype/tests_Int.cpp
@@ -20,40 +20,40 @@ TEST_CASE("Datatype Int") {
     CHECK(std::is_same_v<type, int32_t>);
 
     int32_t value = 1;
-    auto lit1 = Literal::make<datatypes::xsd::Int>(value);
+    auto lit1 = Literal::make_typed<datatypes::xsd::Int>(value);
     CHECK(lit1.value<datatypes::xsd::Int>() == value);
     CHECK(lit1.lexical_form() == std::to_string(value));
 
     value = -2147483648;
-    auto lit2 = Literal::make<datatypes::xsd::Int>(value);
+    auto lit2 = Literal::make_typed<datatypes::xsd::Int>(value);
     CHECK(lit2.value<datatypes::xsd::Int>() == value);
     CHECK(lit2.lexical_form() == std::to_string(value));
 
     value = 2147483647;
-    auto lit3 = Literal::make<datatypes::xsd::Int>(value);
+    auto lit3 = Literal::make_typed<datatypes::xsd::Int>(value);
     CHECK(lit3.value<datatypes::xsd::Int>() == value);
     CHECK(lit3.lexical_form() == std::to_string(value));
 
     value = 1;
-    auto lit4 = Literal{std::to_string(value), type_iri};
+    auto lit4 = Literal::make_typed(std::to_string(value), type_iri);
     CHECK(lit4.value<datatypes::xsd::Int>() == value);
 
     value = 2147483647;
-    auto lit5 = Literal{std::to_string(value), type_iri};
+    auto lit5 = Literal::make_typed(std::to_string(value), type_iri);
     CHECK(lit5.value<datatypes::xsd::Int>() == value);
 
     value = std::numeric_limits<int32_t>::min();
-    auto lit6 = Literal::make<datatypes::xsd::Int>(value);
+    auto lit6 = Literal::make_typed<datatypes::xsd::Int>(value);
     CHECK(lit6.value<datatypes::xsd::Int>() == value);
     CHECK(lit6.lexical_form() == std::to_string(value));
 
     value = std::numeric_limits<int32_t>::max();
-    auto lit7 = Literal::make<datatypes::xsd::Int>(value);
+    auto lit7 = Literal::make_typed<datatypes::xsd::Int>(value);
     CHECK(lit7.value<datatypes::xsd::Int>() == value);
     CHECK(lit7.lexical_form() == std::to_string(value));
 
     value = 0;
-    auto lit8 = Literal::make<datatypes::xsd::Int>(value);
+    auto lit8 = Literal::make_typed<datatypes::xsd::Int>(value);
     CHECK(lit8.value<datatypes::xsd::Int>() == value);
     CHECK(lit8.lexical_form() == std::to_string(value));
 
@@ -68,21 +68,21 @@ TEST_CASE("Datatype Int") {
     // suppress warnings regarding attribute ‘nodiscard’
     Literal no_discard_dummy;
 
-    CHECK_THROWS(no_discard_dummy = Literal("2147483649", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("2147483649", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("-2147483650", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("-2147483650", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("qwerty", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("qwerty", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("-2147483648.0001", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("-2147483648.0001", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("a23dg.59566", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("a23dg.59566", type_iri));
 }
 
 TEST_CASE("32bit positive int inlining") {
     auto const i = std::numeric_limits<xsd::Int::cpp_type>::max();
-    auto const lit1 = Literal::make<xsd::Int>(i);
-    auto const lit2 = Literal::make(std::to_string(i), IRI{xsd::Int::identifier});
+    auto const lit1 = Literal::make_typed<xsd::Int>(i);
+    auto const lit2 = Literal::make_typed(std::to_string(i), IRI{xsd::Int::identifier});
     CHECK(lit1.backend_handle().is_inlined());
     CHECK(lit2.backend_handle().is_inlined());
     CHECK(lit1 == lit2);
@@ -95,8 +95,8 @@ TEST_CASE("32bit positive int inlining") {
 
 TEST_CASE("32bit negative int inlining") {
     auto const i = std::numeric_limits<xsd::Int::cpp_type>::min();
-    auto const lit1 = Literal::make<xsd::Int>(i);
-    auto const lit2 = Literal::make(std::to_string(i), IRI{xsd::Int::identifier});
+    auto const lit1 = Literal::make_typed<xsd::Int>(i);
+    auto const lit2 = Literal::make_typed(std::to_string(i), IRI{xsd::Int::identifier});
     CHECK(lit1.backend_handle().is_inlined());
     CHECK(lit2.backend_handle().is_inlined());
     CHECK(lit1 == lit2);

--- a/tests/datatype/tests_Integer.cpp
+++ b/tests/datatype/tests_Integer.cpp
@@ -27,39 +27,39 @@ TEST_CASE("Datatype Integer") {
     CHECK(type_iri.identifier() == correct_type_iri_cstr);
 
     int64_t value = 1.00;
-    auto lit1 = Literal::make<datatypes::xsd::Integer>(value);
+    auto lit1 = Literal::make_typed<datatypes::xsd::Integer>(value);
     CHECK(lit1.value<datatypes::xsd::Integer>() == value);
     CHECK(lit1.lexical_form() == std::to_string(value));
 
     value = -2147483648;
-    auto lit2 = Literal::make<datatypes::xsd::Integer>(value);
+    auto lit2 = Literal::make_typed<datatypes::xsd::Integer>(value);
     CHECK(lit2.value<datatypes::xsd::Integer>() == value);
     CHECK(lit2.lexical_form() == std::to_string(value));
 
     value = 2147483647;
-    auto lit3 = Literal::make<datatypes::xsd::Integer>(value);
+    auto lit3 = Literal::make_typed<datatypes::xsd::Integer>(value);
     CHECK(lit3.value<datatypes::xsd::Integer>() == value);
     CHECK(lit3.lexical_form() == std::to_string(value));
 
     //Testing Literal Constructor
     value = 1;
-    auto lit4 = Literal{std::to_string(value), type_iri};
+    auto lit4 = Literal::make_typed(std::to_string(value), type_iri);
     CHECK(lit4.value<datatypes::xsd::Integer>() == value);
 
     value = 2147483647;
-    auto lit5 = Literal{std::to_string(value), type_iri};
+    auto lit5 = Literal::make_typed(std::to_string(value), type_iri);
     CHECK(lit5.value<datatypes::xsd::Integer>() == value);
 
-    auto lit6 = Literal{"+1", type_iri};
+    auto lit6 = Literal::make_typed("+1", type_iri);
     CHECK(lit6.value<datatypes::xsd::Integer>() == 1);
 
     value = std::numeric_limits<int64_t>::max();
-    auto lit7 = Literal::make<datatypes::xsd::Integer>(value);
+    auto lit7 = Literal::make_typed<datatypes::xsd::Integer>(value);
     CHECK(lit7.value<datatypes::xsd::Integer>() == value);
     CHECK(lit7.lexical_form() == std::to_string(value));
 
     value = std::numeric_limits<int64_t>::min();
-    auto lit8 = Literal::make<datatypes::xsd::Integer>(value);
+    auto lit8 = Literal::make_typed<datatypes::xsd::Integer>(value);
     CHECK(lit8.value<datatypes::xsd::Integer>() == value);
     CHECK(lit8.lexical_form() == std::to_string(value));
 
@@ -73,33 +73,33 @@ TEST_CASE("Datatype Integer") {
     // suppress warnings regarding attribute ‘nodiscard’
     Literal no_discard_dummy;
 
-    CHECK_THROWS(no_discard_dummy = Literal("a23dg", type_iri));
-    CHECK_THROWS(no_discard_dummy = Literal("2.2e-308", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("a23dg", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("2.2e-308", type_iri));
 }
 
 TEST_CASE("Datatype Integer overread UB") {
     std::string const s = "123456";
     std::string_view const sv{ s.data(), 3 };
 
-    Literal const lit{ sv, datatypes::xsd::Integer::identifier };
+    auto const lit = Literal::make_typed(sv, IRI{datatypes::xsd::Integer::identifier});
     CHECK(lit.value<datatypes::xsd::Integer>() == 123);
 }
 
 TEST_CASE("other int types serializing") {
     using namespace datatypes::xsd;
 
-    auto lit1 = Literal::make<Int>(std::numeric_limits<Int::cpp_type>::min());
+    auto lit1 = Literal::make_typed<Int>(std::numeric_limits<Int::cpp_type>::min());
     CHECK(lit1.lexical_form() == std::to_string(std::numeric_limits<Int::cpp_type>::min()));
 }
 
 TEST_CASE("integer inlining") {
     SUBCASE("small") {
-        auto lit = Literal::make<xsd::Integer>((1l << 41) - 1);
+        auto lit = Literal::make_typed<xsd::Integer>((1l << 41) - 1);
         CHECK(lit.backend_handle().is_inlined());
     }
 
     SUBCASE("too large") {
-        auto lit = Literal::make<xsd::Integer>(xsd::Integer::cpp_type{"9999999999999999999999"});
+        auto lit = Literal::make_typed<xsd::Integer>(xsd::Integer::cpp_type{"9999999999999999999999"});
         CHECK(!lit.backend_handle().is_inlined());
     }
 }

--- a/tests/datatype/tests_LangString.cpp
+++ b/tests/datatype/tests_LangString.cpp
@@ -8,17 +8,17 @@ using namespace rdf4cpp::rdf;
 TEST_CASE("rdf:langString") {
     static_assert(!datatypes::InlineableLiteralDatatype<datatypes::rdf::LangString>, "beware: making rdf:langString inlineable requires additional code in Literal");
 
-    CHECK_THROWS(Literal{"hello", IRI{datatypes::rdf::LangString::identifier}});
-    CHECK_THROWS(Literal::make("hello", IRI{datatypes::rdf::LangString::identifier}));
+    Literal dummy;
+    CHECK_THROWS(dummy = Literal::make_typed("hello", IRI{datatypes::rdf::LangString::identifier}));
 
-    Literal const lit1{"hello", "en"};
-    Literal const lit2 = Literal::make<datatypes::rdf::LangString>(datatypes::registry::LangStringRepr{"hello", "en"});
+    auto const lit1 = Literal::make_lang_tagged("hello", "en");
+    auto const lit2 = Literal::make_typed<datatypes::rdf::LangString>(datatypes::registry::LangStringRepr{"hello", "en"});
 
     CHECK(lit1 == lit2);
 
-    Literal const lit3{"hello", "de-DE"};
-    Literal const lit4{"hallo", "de-DE"};
-    Literal const lit5{"hallo", "de-de"};
+    auto const lit3 = Literal::make_lang_tagged("hello", "de-DE");
+    auto const lit4 = Literal::make_lang_tagged("hallo", "de-DE");
+    auto const lit5 = Literal::make_lang_tagged("hallo", "de-de");
     CHECK(lit1 != lit3);
     CHECK(lit1 != lit4);
     CHECK(lit3 != lit4);

--- a/tests/datatype/tests_Long.cpp
+++ b/tests/datatype/tests_Long.cpp
@@ -20,26 +20,26 @@ TEST_CASE("Datatype Long") {
     CHECK(std::is_same_v<type, int64_t>);
 
     int64_t value = 1;
-    auto lit1 = Literal::make<datatypes::xsd::Long>(value);
+    auto lit1 = Literal::make_typed<datatypes::xsd::Long>(value);
     CHECK(lit1.value<datatypes::xsd::Long>() == value);
     CHECK(lit1.lexical_form() == std::to_string(value));
 
     value = std::numeric_limits<int64_t>::min();
-    auto lit2 = Literal::make<datatypes::xsd::Long>(value);
+    auto lit2 = Literal::make_typed<datatypes::xsd::Long>(value);
     CHECK(lit2.value<datatypes::xsd::Long>() == value);
     CHECK(lit2.lexical_form() == std::to_string(value));
 
     value = std::numeric_limits<int64_t>::max();
-    auto lit3 = Literal::make<datatypes::xsd::Long>(value);
+    auto lit3 = Literal::make_typed<datatypes::xsd::Long>(value);
     CHECK(lit3.value<datatypes::xsd::Long>() == value);
     CHECK(lit3.lexical_form() == std::to_string(value));
 
     value = 1;
-    auto lit4 = Literal{std::to_string(value), type_iri};
+    auto lit4 = Literal::make_typed(std::to_string(value), type_iri);
     CHECK(lit4.value<datatypes::xsd::Long>() == value);
 
     value = std::numeric_limits<int64_t>::min();
-    auto lit5 = Literal{std::to_string(value), type_iri};
+    auto lit5 = Literal::make_typed(std::to_string(value), type_iri);
     CHECK(lit5.value<datatypes::xsd::Long>() == value);
 
     CHECK(lit1 != lit2);
@@ -50,19 +50,19 @@ TEST_CASE("Datatype Long") {
     // suppress warnings regarding attribute ‘nodiscard’
     Literal no_discard_dummy;
 
-    CHECK_THROWS(no_discard_dummy = Literal("a23dg.59566", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("a23dg.59566", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("\n", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("\n", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("qwerty", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("qwerty", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("1.00001", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("1.00001", type_iri));
 }
 
 TEST_CASE("small 64bit positive int inlining") {
     auto const i = (1l << 41) - 1;
-    auto const lit1 = Literal::make<xsd::Long>(i);
-    auto const lit2 = Literal::make(std::to_string(i), IRI{xsd::Long::identifier});
+    auto const lit1 = Literal::make_typed<xsd::Long>(i);
+    auto const lit2 = Literal::make_typed(std::to_string(i), IRI{xsd::Long::identifier});
     CHECK(lit1.backend_handle().is_inlined());
     CHECK(lit2.backend_handle().is_inlined());
     CHECK(lit1 == lit2);
@@ -75,8 +75,8 @@ TEST_CASE("small 64bit positive int inlining") {
 
 TEST_CASE("negative 64bit int inlining") {
     auto const i = -256;
-    auto const lit1 = Literal::make<xsd::Long>(i);
-    auto const lit2 = Literal::make(std::to_string(i), IRI{xsd::Long::identifier});
+    auto const lit1 = Literal::make_typed<xsd::Long>(i);
+    auto const lit2 = Literal::make_typed(std::to_string(i), IRI{xsd::Long::identifier});
     CHECK(lit1.backend_handle().is_inlined());
     CHECK(lit2.backend_handle().is_inlined());
     CHECK(lit1 == lit2);

--- a/tests/datatype/tests_NegativeInteger.cpp
+++ b/tests/datatype/tests_NegativeInteger.cpp
@@ -15,26 +15,26 @@ TEST_CASE("Datatype NegativeInteger") {
     CHECK(type_iri.identifier() == correct_type_iri_cstr);
 
     int64_t value = -1;
-    auto lit1 = Literal::make<datatypes::xsd::NegativeInteger>(value);
+    auto lit1 = Literal::make_typed<datatypes::xsd::NegativeInteger>(value);
     CHECK(lit1.value<datatypes::xsd::NegativeInteger>() == value);
     CHECK(lit1.lexical_form() == std::to_string(value));
 
     value = -18446744073709;
-    auto lit2 = Literal::make<datatypes::xsd::NegativeInteger>(value);
+    auto lit2 = Literal::make_typed<datatypes::xsd::NegativeInteger>(value);
     CHECK(lit2.value<datatypes::xsd::NegativeInteger>() == value);
     CHECK(lit2.lexical_form() == std::to_string(value));
 
     value = -2147483647;
-    auto lit3 = Literal::make<datatypes::xsd::NegativeInteger>(value);
+    auto lit3 = Literal::make_typed<datatypes::xsd::NegativeInteger>(value);
     CHECK(lit3.value<datatypes::xsd::NegativeInteger>() == value);
     CHECK(lit3.lexical_form() == std::to_string(value));
 
     value = -1;
-    auto lit4 = Literal{std::to_string(value), type_iri};
+    auto lit4 = Literal::make_typed(std::to_string(value), type_iri);
     CHECK(lit4.value<datatypes::xsd::NegativeInteger>() == value);
 
     value = -18446744073709;
-    auto lit5 = Literal{std::to_string(value), type_iri};
+    auto lit5 = Literal::make_typed(std::to_string(value), type_iri);
     CHECK(lit5.value<datatypes::xsd::NegativeInteger>() == value);
 
     CHECK(lit1 != lit2);
@@ -45,23 +45,23 @@ TEST_CASE("Datatype NegativeInteger") {
     // suppress warnings regarding attribute ‘nodiscard’
     Literal no_discard_dummy;
 
-    CHECK_THROWS(no_discard_dummy = Literal("a23dg", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("a23dg", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("0", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("0", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("100", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("100", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("a23dg.59566", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("a23dg.59566", type_iri));
 }
 
 TEST_CASE("xsd:negativeInteger inlining") {
     using datatypes::xsd::NegativeInteger;
 
-    auto one_lit = Literal::make<NegativeInteger>(-1);
+    auto one_lit = Literal::make_typed<NegativeInteger>(-1);
     CHECK(one_lit.backend_handle().is_inlined());
     CHECK(one_lit.value<NegativeInteger>() == -1);
 
-    auto large_lit = Literal::make<NegativeInteger>(-(1l << 42));
+    auto large_lit = Literal::make_typed<NegativeInteger>(-(1l << 42));
     CHECK(large_lit.backend_handle().is_inlined());
     CHECK(large_lit.value<NegativeInteger>() == (-(1l << 42)));
 }

--- a/tests/datatype/tests_NonNegativeInteger.cpp
+++ b/tests/datatype/tests_NonNegativeInteger.cpp
@@ -15,26 +15,26 @@ TEST_CASE("Datatype NonNegativeInteger") {
     CHECK(type_iri.identifier() == correct_type_iri_cstr);
 
     int64_t value = 1;
-    auto lit1 = Literal::make<datatypes::xsd::NonNegativeInteger>(value);
+    auto lit1 = Literal::make_typed<datatypes::xsd::NonNegativeInteger>(value);
     CHECK(lit1.value<datatypes::xsd::NonNegativeInteger>() == value);
     CHECK(lit1.lexical_form() == std::to_string(value));
 
     value = 18446744073709;
-    auto lit2 = Literal::make<datatypes::xsd::NonNegativeInteger>(value);
+    auto lit2 = Literal::make_typed<datatypes::xsd::NonNegativeInteger>(value);
     CHECK(lit2.value<datatypes::xsd::NonNegativeInteger>() == value);
     CHECK(lit2.lexical_form() == std::to_string(value));
 
     value = 0;
-    auto lit3 = Literal::make<datatypes::xsd::NonNegativeInteger>(value);
+    auto lit3 = Literal::make_typed<datatypes::xsd::NonNegativeInteger>(value);
     CHECK(lit3.value<datatypes::xsd::NonNegativeInteger>() == value);
     CHECK(lit3.lexical_form() == std::to_string(value));
 
     value = 1;
-    auto lit4 = Literal{std::to_string(value), type_iri};
+    auto lit4 = Literal::make_typed(std::to_string(value), type_iri);
     CHECK(lit4.value<datatypes::xsd::NonNegativeInteger>() == value);
 
     value = 18446744073709;
-    auto lit5 = Literal{std::to_string(value), type_iri};
+    auto lit5 = Literal::make_typed(std::to_string(value), type_iri);
     CHECK(lit5.value<datatypes::xsd::NonNegativeInteger>() == value);
 
     CHECK(lit1 != lit2);
@@ -45,27 +45,27 @@ TEST_CASE("Datatype NonNegativeInteger") {
     // suppress warnings regarding attribute ‘nodiscard’
     Literal no_discard_dummy;
 
-    CHECK_THROWS(no_discard_dummy = Literal("qwerty", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("qwerty", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("-1", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("-1", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("a23dg.59566", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("a23dg.59566", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("-0.01", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("-0.01", type_iri));
 }
 
 TEST_CASE("xsd:nonNegativeInteger inlining") {
     using datatypes::xsd::NonNegativeInteger;
 
-    auto zero_lit = Literal::make<NonNegativeInteger>(0);
+    auto zero_lit = Literal::make_typed<NonNegativeInteger>(0);
     CHECK(zero_lit.backend_handle().is_inlined());
     CHECK(zero_lit.value<NonNegativeInteger>() == 0);
 
-    auto one_lit = Literal::make<NonNegativeInteger>(1);
+    auto one_lit = Literal::make_typed<NonNegativeInteger>(1);
     CHECK(one_lit.backend_handle().is_inlined());
     CHECK(one_lit.value<NonNegativeInteger>() == 1);
 
-    auto large_lit = Literal::make<NonNegativeInteger>((1ul << 42) - 1);
+    auto large_lit = Literal::make_typed<NonNegativeInteger>((1ul << 42) - 1);
     CHECK(large_lit.backend_handle().is_inlined());
     CHECK(large_lit.value<NonNegativeInteger>() == ((1ul << 42) - 1));
 }

--- a/tests/datatype/tests_NonPositiveInteger.cpp
+++ b/tests/datatype/tests_NonPositiveInteger.cpp
@@ -15,26 +15,26 @@ TEST_CASE("Datatype NonPositiveInteger") {
     CHECK(type_iri.identifier() == correct_type_iri_cstr);
 
     int64_t value = -1;
-    auto lit1 = Literal::make<datatypes::xsd::NonPositiveInteger>(value);
+    auto lit1 = Literal::make_typed<datatypes::xsd::NonPositiveInteger>(value);
     CHECK(lit1.value<datatypes::xsd::NonPositiveInteger>() == value);
     CHECK(lit1.lexical_form() == std::to_string(value));
 
     value = -18446744073709;
-    auto lit2 = Literal::make<datatypes::xsd::NonPositiveInteger>(value);
+    auto lit2 = Literal::make_typed<datatypes::xsd::NonPositiveInteger>(value);
     CHECK(lit2.value<datatypes::xsd::NonPositiveInteger>() == value);
     CHECK(lit2.lexical_form() == std::to_string(value));
 
     value = 0;
-    auto lit3 = Literal::make<datatypes::xsd::NonPositiveInteger>(value);
+    auto lit3 = Literal::make_typed<datatypes::xsd::NonPositiveInteger>(value);
     CHECK(lit3.value<datatypes::xsd::NonPositiveInteger>() == value);
     CHECK(lit3.lexical_form() == std::to_string(value));
 
     value = -1;
-    auto lit4 = Literal{std::to_string(value), type_iri};
+    auto lit4 = Literal::make_typed(std::to_string(value), type_iri);
     CHECK(lit4.value<datatypes::xsd::NonPositiveInteger>() == value);
 
     value = -18446744073709;
-    auto lit5 = Literal{std::to_string(value), type_iri};
+    auto lit5 = Literal::make_typed(std::to_string(value), type_iri);
     CHECK(lit5.value<datatypes::xsd::NonPositiveInteger>() == value);
 
     CHECK(lit1 != lit2);
@@ -45,27 +45,27 @@ TEST_CASE("Datatype NonPositiveInteger") {
     // suppress warnings regarding attribute ‘nodiscard’
     Literal no_discard_dummy;
 
-    CHECK_THROWS(no_discard_dummy = Literal("qwerty", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("qwerty", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("1", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("1", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("a23dg.59566", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("a23dg.59566", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("0.01", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("0.01", type_iri));
 }
 
 TEST_CASE("xsd:nonPositiveInteger inlining") {
     using datatypes::xsd::NonPositiveInteger;
 
-    auto zero_lit = Literal::make<NonPositiveInteger>(0);
+    auto zero_lit = Literal::make_typed<NonPositiveInteger>(0);
     CHECK(zero_lit.backend_handle().is_inlined());
     CHECK(zero_lit.value<NonPositiveInteger>() == 0);
 
-    auto one_lit = Literal::make<NonPositiveInteger>(-1);
+    auto one_lit = Literal::make_typed<NonPositiveInteger>(-1);
     CHECK(one_lit.backend_handle().is_inlined());
     CHECK(one_lit.value<NonPositiveInteger>() == -1);
 
-    auto large_lit = Literal::make<NonPositiveInteger>(-(1l << 42) + 1);
+    auto large_lit = Literal::make_typed<NonPositiveInteger>(-(1l << 42) + 1);
     CHECK(large_lit.backend_handle().is_inlined());
     CHECK(large_lit.value<NonPositiveInteger>() == (-(1l << 42) + 1));
 }

--- a/tests/datatype/tests_PositiveInteger.cpp
+++ b/tests/datatype/tests_PositiveInteger.cpp
@@ -15,26 +15,26 @@ TEST_CASE("Datatype PositiveInteger") {
     CHECK(type_iri.identifier() == correct_type_iri_cstr);
 
     uint64_t value = 1;
-    auto lit1 = Literal::make<datatypes::xsd::PositiveInteger>(value);
+    auto lit1 = Literal::make_typed<datatypes::xsd::PositiveInteger>(value);
     CHECK(lit1.value<datatypes::xsd::PositiveInteger>() == value);
     CHECK(lit1.lexical_form() == std::to_string(value));
 
     value = 18446744073709;
-    auto lit2 = Literal::make<datatypes::xsd::PositiveInteger>(value);
+    auto lit2 = Literal::make_typed<datatypes::xsd::PositiveInteger>(value);
     CHECK(lit2.value<datatypes::xsd::PositiveInteger>() == value);
     CHECK(lit2.lexical_form() == std::to_string(value));
 
     value = 2147483647;
-    auto lit3 = Literal::make<datatypes::xsd::PositiveInteger>(value);
+    auto lit3 = Literal::make_typed<datatypes::xsd::PositiveInteger>(value);
     CHECK(lit3.value<datatypes::xsd::PositiveInteger>() == value);
     CHECK(lit3.lexical_form() == std::to_string(value));
 
     value = 1;
-    auto lit4 = Literal{std::to_string(value), type_iri};
+    auto lit4 = Literal::make_typed(std::to_string(value), type_iri);
     CHECK(lit4.value<datatypes::xsd::PositiveInteger>() == value);
 
     value = 18446744073709;
-    auto lit5 = Literal{std::to_string(value), type_iri};
+    auto lit5 = Literal::make_typed(std::to_string(value), type_iri);
     CHECK(lit5.value<datatypes::xsd::PositiveInteger>() == value);
 
     CHECK(lit1 != lit2);
@@ -45,23 +45,23 @@ TEST_CASE("Datatype PositiveInteger") {
     // suppress warnings regarding attribute ‘nodiscard’
     Literal no_discard_dummy;
 
-    CHECK_THROWS(no_discard_dummy = Literal("-1", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("-1", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("0", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("0", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("a23dg.59566", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("a23dg.59566", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("-0.01", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("-0.01", type_iri));
 }
 
 TEST_CASE("xsd:positiveInteger inlining") {
     using datatypes::xsd::PositiveInteger;
 
-    auto one_lit = Literal::make<PositiveInteger>(1);
+    auto one_lit = Literal::make_typed<PositiveInteger>(1);
     CHECK(one_lit.backend_handle().is_inlined());
     CHECK(one_lit.value<PositiveInteger>() == 1);
 
-    auto large_lit = Literal::make<PositiveInteger>(1l << 42);
+    auto large_lit = Literal::make_typed<PositiveInteger>(1l << 42);
     CHECK(large_lit.backend_handle().is_inlined());
     CHECK(large_lit.value<PositiveInteger>() == (1l << 42));
 }

--- a/tests/datatype/tests_Short.cpp
+++ b/tests/datatype/tests_Short.cpp
@@ -19,40 +19,40 @@ TEST_CASE("Datatype Short") {
     CHECK(std::is_same_v<type, int16_t>);
 
     int16_t value = 1;
-    auto lit1 = Literal::make<datatypes::xsd::Short>(value);
+    auto lit1 = Literal::make_typed<datatypes::xsd::Short>(value);
     CHECK(lit1.value<datatypes::xsd::Short>() == value);
     CHECK(lit1.lexical_form() == std::to_string(value));
 
     value = -32768;
-    auto lit2 = Literal::make<datatypes::xsd::Short>(value);
+    auto lit2 = Literal::make_typed<datatypes::xsd::Short>(value);
     CHECK(lit2.value<datatypes::xsd::Short>() == value);
     CHECK(lit2.lexical_form() == std::to_string(value));
 
     value = 32767;
-    auto lit3 = Literal::make<datatypes::xsd::Short>(value);
+    auto lit3 = Literal::make_typed<datatypes::xsd::Short>(value);
     CHECK(lit3.value<datatypes::xsd::Short>() == value);
     CHECK(lit3.lexical_form() == std::to_string(value));
 
     value = 1;
-    auto lit4 = Literal{std::to_string(value), type_iri};
+    auto lit4 = Literal::make_typed(std::to_string(value), type_iri);
     CHECK(lit4.value<datatypes::xsd::Short>() == value);
 
     value = -32768;
-    auto lit5 = Literal{std::to_string(value), type_iri};
+    auto lit5 = Literal::make_typed(std::to_string(value), type_iri);
     CHECK(lit5.value<datatypes::xsd::Short>() == value);
 
     value = std::numeric_limits<int16_t>::min();
-    auto lit6 = Literal::make<datatypes::xsd::Int>(value);
+    auto lit6 = Literal::make_typed<datatypes::xsd::Int>(value);
     CHECK(lit6.value<datatypes::xsd::Int>() == value);
     CHECK(lit6.lexical_form() == std::to_string(value));
 
     value = std::numeric_limits<int16_t>::max();
-    auto lit7 = Literal::make<datatypes::xsd::Int>(value);
+    auto lit7 = Literal::make_typed<datatypes::xsd::Int>(value);
     CHECK(lit7.value<datatypes::xsd::Int>() == value);
     CHECK(lit7.lexical_form() == std::to_string(value));
 
     value = 0;
-    auto lit8 = Literal::make<datatypes::xsd::Int>(value);
+    auto lit8 = Literal::make_typed<datatypes::xsd::Int>(value);
     CHECK(lit8.value<datatypes::xsd::Int>() == value);
     CHECK(lit8.lexical_form() == std::to_string(value));
 
@@ -67,13 +67,13 @@ TEST_CASE("Datatype Short") {
     // suppress warnings regarding attribute ‘nodiscard’
     Literal no_discard_dummy;
 
-    CHECK_THROWS(no_discard_dummy = Literal("32768", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("32768", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("-32769", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("-32769", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("qwerty", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("qwerty", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("-32768.0001", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("-32768.0001", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("a23dg.59566", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("a23dg.59566", type_iri));
 }

--- a/tests/datatype/tests_String.cpp
+++ b/tests/datatype/tests_String.cpp
@@ -30,62 +30,62 @@ TEST_CASE("Datatype String") {
 
 
     std::string value = "123";
-    auto lit1 = Literal::make<datatypes::xsd::String>(value);
+    auto lit1 = Literal::make_typed<datatypes::xsd::String>(value);
     CHECK(lit1.value<datatypes::xsd::String>() == value);
     CHECK(lit1.lexical_form() == value);
 
     value = "a";
-    auto lit2 = Literal::make<datatypes::xsd::String>(value);
+    auto lit2 = Literal::make_typed<datatypes::xsd::String>(value);
     CHECK(lit2.value<datatypes::xsd::String>() == value);
     CHECK(lit2.lexical_form() == value);
 
     value = "b";
-    auto lit3 = Literal::make<datatypes::xsd::String>(value);
+    auto lit3 = Literal::make_typed<datatypes::xsd::String>(value);
     CHECK(lit3.value<datatypes::xsd::String>() == value);
     CHECK(lit3.lexical_form() == value);
 
     value = "123";
-    auto lit4 = Literal{value, type_iri};
+    auto lit4 = Literal::make_typed(value, type_iri);
     CHECK(lit4.value<datatypes::xsd::String>() == value);
 
     value = "a";
-    auto lit5 = Literal{value, type_iri};
+    auto lit5 = Literal::make_typed(value, type_iri);
     CHECK(lit5.value<datatypes::xsd::String>() == value);
 
     value = "\n";
-    auto lit6 = Literal{value, type_iri};
+    auto lit6 = Literal::make_typed(value, type_iri);
     CHECK(lit6.value<datatypes::xsd::String>() == value);
 
     value = "\t";
-    auto lit7 = Literal{value, type_iri};
+    auto lit7 = Literal::make_typed(value, type_iri);
     CHECK(lit7.value<datatypes::xsd::String>() == value);
 
     value = "\r";
-    auto lit8 = Literal{value, type_iri};
+    auto lit8 = Literal::make_typed(value, type_iri);
     CHECK(lit8.value<datatypes::xsd::String>() == value);
 
     value = "\\";
-    auto lit9 = Literal{value, type_iri};
+    auto lit9 = Literal::make_typed(value, type_iri);
     CHECK(lit9.value<datatypes::xsd::String>() == value);
 
     value = "\"";
-    auto lit10 = Literal{value, type_iri};
+    auto lit10 = Literal::make_typed(value, type_iri);
     CHECK(lit10.value<datatypes::xsd::String>() == value);
 
     value = "Lorem Ipsum is simply dummy text of the printing and typesetting industry.\n Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.";
-    auto lit11 = Literal{value, type_iri};
+    auto lit11 = Literal::make_typed(value, type_iri);
     CHECK(lit11.value<datatypes::xsd::String>() == value);
 
     value = "Lorem Ipsum is simply dummy text of the printing and typesetting industry.\t Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.";
-    auto lit12 = Literal{value, type_iri};
+    auto lit12 = Literal::make_typed(value, type_iri);
     CHECK(lit12.value<datatypes::xsd::String>() == value);
 
     value = "Lorem Ipsum is simply dummy text of the printing and typesetting industry.\" Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.";
-    auto lit13 = Literal{value, type_iri};
+    auto lit13 = Literal::make_typed(value, type_iri);
     CHECK(lit13.value<datatypes::xsd::String>() == value);
 
     value = "Lorem Ipsum is simply dummy text of the printing and typesetting industry.\\ Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.";
-    auto lit14 = Literal{value, type_iri};
+    auto lit14 = Literal::make_typed(value, type_iri);
     CHECK(lit14.value<datatypes::xsd::String>() == value);
 
     CHECK(lit1 != lit2);
@@ -98,6 +98,6 @@ TEST_CASE("Datatype String overread UB") {
     std::string const s = "Hello World";
     std::string_view const sv{ s.data(), 5 };
 
-    Literal const lit{ sv, datatypes::xsd::String::identifier };
+    auto const lit = Literal::make_typed(sv, IRI{datatypes::xsd::String::identifier});
     CHECK(lit.value<datatypes::xsd::String>() == "Hello");
 }

--- a/tests/datatype/tests_UnsignedByte.cpp
+++ b/tests/datatype/tests_UnsignedByte.cpp
@@ -19,22 +19,22 @@ TEST_CASE("Datatype UnsignedByte") {
     CHECK(std::is_same_v<type, uint8_t>);
 
     uint8_t value = 1;
-    auto lit1 = Literal::make<datatypes::xsd::UnsignedByte>(value);
+    auto lit1 = Literal::make_typed<datatypes::xsd::UnsignedByte>(value);
     CHECK(lit1.value<datatypes::xsd::UnsignedByte>() == value);
     CHECK(lit1.lexical_form() == std::to_string(value));
 
     value = 0;
-    auto lit2 = Literal::make<datatypes::xsd::UnsignedByte>(value);
+    auto lit2 = Literal::make_typed<datatypes::xsd::UnsignedByte>(value);
     CHECK(lit2.value<datatypes::xsd::UnsignedByte>() == value);
     CHECK(lit2.lexical_form() == std::to_string(value));
 
     value = 255;
-    auto lit3 = Literal::make<datatypes::xsd::UnsignedByte>(value);
+    auto lit3 = Literal::make_typed<datatypes::xsd::UnsignedByte>(value);
     CHECK(lit3.value<datatypes::xsd::UnsignedByte>() == value);
     CHECK(lit3.lexical_form() == std::to_string(value));
 
     value = 1;
-    auto lit4 = Literal::make<datatypes::xsd::UnsignedByte>(value);
+    auto lit4 = Literal::make_typed<datatypes::xsd::UnsignedByte>(value);
     CHECK(lit4.value<datatypes::xsd::UnsignedByte>() == value);
     CHECK(lit4.lexical_form() == std::to_string(value));
 
@@ -45,13 +45,13 @@ TEST_CASE("Datatype UnsignedByte") {
     // suppress warnings regarding attribute ‘nodiscard’
     Literal no_discard_dummy;
 
-    CHECK_THROWS(no_discard_dummy = Literal("256", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("256", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("-1", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("-1", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("a23dg.59566", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("a23dg.59566", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("-0.00001", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("-0.00001", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("qwerty", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("qwerty", type_iri));
 }

--- a/tests/datatype/tests_UnsignedInt.cpp
+++ b/tests/datatype/tests_UnsignedInt.cpp
@@ -19,30 +19,30 @@ TEST_CASE("Datatype UnsignedInt") {
     CHECK(std::is_same_v<type, uint32_t>);
 
     uint32_t value = 1;
-    auto lit1 = Literal::make<datatypes::xsd::UnsignedInt>(value);
+    auto lit1 = Literal::make_typed<datatypes::xsd::UnsignedInt>(value);
     CHECK(lit1.value<datatypes::xsd::UnsignedInt>() == value);
     CHECK(lit1.lexical_form() == std::to_string(value));
 
     value = 0;
-    auto lit2 = Literal::make<datatypes::xsd::UnsignedInt>(value);
+    auto lit2 = Literal::make_typed<datatypes::xsd::UnsignedInt>(value);
     CHECK(lit2.value<datatypes::xsd::UnsignedInt>() == value);
     CHECK(lit2.lexical_form() == std::to_string(value));
 
     value = std::numeric_limits<uint32_t>::max();
-    auto lit3 = Literal::make<datatypes::xsd::UnsignedInt>(value);
+    auto lit3 = Literal::make_typed<datatypes::xsd::UnsignedInt>(value);
     CHECK(lit3.value<datatypes::xsd::UnsignedInt>() == value);
     CHECK(lit3.lexical_form() == std::to_string(value));
 
     value = 1;
-    auto lit4 = Literal{std::to_string(value), type_iri};
+    auto lit4 = Literal::make_typed(std::to_string(value), type_iri);
     CHECK(lit4.value<datatypes::xsd::UnsignedInt>() == value);
 
     value = 0;
-    auto lit5 = Literal{std::to_string(value), type_iri};
+    auto lit5 = Literal::make_typed(std::to_string(value), type_iri);
     CHECK(lit5.value<datatypes::xsd::UnsignedInt>() == value);
 
     value = std::numeric_limits<uint32_t>::min();
-    auto lit6 = Literal::make<datatypes::xsd::UnsignedInt>(value);
+    auto lit6 = Literal::make_typed<datatypes::xsd::UnsignedInt>(value);
     CHECK(lit6.value<datatypes::xsd::UnsignedInt>() == value);
     CHECK(lit6.lexical_form() == std::to_string(value));
 
@@ -56,11 +56,11 @@ TEST_CASE("Datatype UnsignedInt") {
     // suppress warnings regarding attribute ‘nodiscard’
     Literal no_discard_dummy;
 
-    CHECK_THROWS(no_discard_dummy = Literal("4294967296", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("4294967296", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("-1", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("-1", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("a23dg.59566", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("a23dg.59566", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("-0.01", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("-0.01", type_iri));
 }

--- a/tests/datatype/tests_UnsignedLong.cpp
+++ b/tests/datatype/tests_UnsignedLong.cpp
@@ -19,30 +19,30 @@ TEST_CASE("Datatype UnsignedLong") {
     CHECK(std::is_same_v<type, uint64_t>);
 
     uint64_t value = 1;
-    auto lit1 = Literal::make<datatypes::xsd::UnsignedLong>(value);
+    auto lit1 = Literal::make_typed<datatypes::xsd::UnsignedLong>(value);
     CHECK(lit1.value<datatypes::xsd::UnsignedLong>() == value);
     CHECK(lit1.lexical_form() == std::to_string(value));
 
     value = 0;
-    auto lit2 = Literal::make<datatypes::xsd::UnsignedLong>(value);
+    auto lit2 = Literal::make_typed<datatypes::xsd::UnsignedLong>(value);
     CHECK(lit2.value<datatypes::xsd::UnsignedLong>() == value);
     CHECK(lit2.lexical_form() == std::to_string(value));
 
     value = std::numeric_limits<uint64_t>::max();
-    auto lit3 = Literal::make<datatypes::xsd::UnsignedLong>(value);
+    auto lit3 = Literal::make_typed<datatypes::xsd::UnsignedLong>(value);
     CHECK(lit3.value<datatypes::xsd::UnsignedLong>() == value);
     CHECK(lit3.lexical_form() == std::to_string(value));
 
     value = 1;
-    auto lit4 = Literal{std::to_string(value), type_iri};
+    auto lit4 = Literal::make_typed(std::to_string(value), type_iri);
     CHECK(lit4.value<datatypes::xsd::UnsignedLong>() == value);
 
     value = 0;
-    auto lit5 = Literal{std::to_string(value), type_iri};
+    auto lit5 = Literal::make_typed(std::to_string(value), type_iri);
     CHECK(lit5.value<datatypes::xsd::UnsignedLong>() == value);
 
     value = std::numeric_limits<uint64_t>::min();
-    auto lit6 = Literal::make<datatypes::xsd::UnsignedLong>(value);
+    auto lit6 = Literal::make_typed<datatypes::xsd::UnsignedLong>(value);
     CHECK(lit6.value<datatypes::xsd::UnsignedLong>() == value);
     CHECK(lit6.lexical_form() == std::to_string(value));
 
@@ -56,11 +56,11 @@ TEST_CASE("Datatype UnsignedLong") {
     // suppress warnings regarding attribute ‘nodiscard’
     Literal no_discard_dummy;
 
-    CHECK_THROWS(no_discard_dummy = Literal("a23dg.59566", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("a23dg.59566", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("qwerty", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("qwerty", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("53.59566", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("53.59566", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("0.01", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("0.01", type_iri));
 }

--- a/tests/datatype/tests_UnsignedShort.cpp
+++ b/tests/datatype/tests_UnsignedShort.cpp
@@ -19,30 +19,30 @@ TEST_CASE("Datatype UnsignedShort") {
     CHECK(std::is_same_v<type, uint16_t>);
 
     uint16_t value = 1;
-    auto lit1 = Literal::make<datatypes::xsd::UnsignedShort>(value);
+    auto lit1 = Literal::make_typed<datatypes::xsd::UnsignedShort>(value);
     CHECK(lit1.value<datatypes::xsd::UnsignedShort>() == value);
     CHECK(lit1.lexical_form() == std::to_string(value));
 
     value = 0;
-    auto lit2 = Literal::make<datatypes::xsd::UnsignedShort>(value);
+    auto lit2 = Literal::make_typed<datatypes::xsd::UnsignedShort>(value);
     CHECK(lit2.value<datatypes::xsd::UnsignedShort>() == value);
     CHECK(lit2.lexical_form() == std::to_string(value));
 
     value = std::numeric_limits<uint16_t>::max();
-    auto lit3 = Literal::make<datatypes::xsd::UnsignedShort>(value);
+    auto lit3 = Literal::make_typed<datatypes::xsd::UnsignedShort>(value);
     CHECK(lit3.value<datatypes::xsd::UnsignedShort>() == value);
     CHECK(lit3.lexical_form() == std::to_string(value));
 
     value = 1;
-    auto lit4 = Literal{std::to_string(value), type_iri};
+    auto lit4 = Literal::make_typed(std::to_string(value), type_iri);
     CHECK(lit4.value<datatypes::xsd::UnsignedShort>() == value);
 
     value = 0;
-    auto lit5 = Literal{std::to_string(value), type_iri};
+    auto lit5 = Literal::make_typed(std::to_string(value), type_iri);
     CHECK(lit5.value<datatypes::xsd::UnsignedShort>() == value);
 
     value = std::numeric_limits<uint16_t>::min();
-    auto lit6 = Literal::make<datatypes::xsd::UnsignedShort>(value);
+    auto lit6 = Literal::make_typed<datatypes::xsd::UnsignedShort>(value);
     CHECK(lit6.value<datatypes::xsd::UnsignedShort>() == value);
     CHECK(lit6.lexical_form() == std::to_string(value));
 
@@ -55,11 +55,11 @@ TEST_CASE("Datatype UnsignedShort") {
     // suppress warnings regarding attribute ‘nodiscard’
     Literal no_discard_dummy;
 
-    CHECK_THROWS(no_discard_dummy = Literal("-1", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("-1", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("65536", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("65536", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("a23dg.59566", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("a23dg.59566", type_iri));
 
-    CHECK_THROWS(no_discard_dummy = Literal("-0.01", type_iri));
+    CHECK_THROWS(no_discard_dummy = Literal::make_typed("-0.01", type_iri));
 }

--- a/tests/datatype/tests_owl_Rational.cpp
+++ b/tests/datatype/tests_owl_Rational.cpp
@@ -21,35 +21,36 @@ TEST_SUITE("owl:rational") {
 
         SUBCASE("to string") {
             cpp_type const value1{1, 2};
-            auto const lit1 = Literal::make<Rational>(value1);
+            auto const lit1 = Literal::make_typed<Rational>(value1);
             CHECK(lit1.value<Rational>() == value1);
             CHECK(lit1.lexical_form() == "1/2");
 
             cpp_type const value2{-1, 10};
-            auto const lit2 = Literal::make<Rational>(value2);
+            auto const lit2 = Literal::make_typed<Rational>(value2);
             CHECK(lit2.value<Rational>() == value2);
             CHECK(lit2.lexical_form() == "-1/10");
 
             cpp_type const non_canonical{-10, -20};
-            auto const lit3 = Literal::make<Rational>(non_canonical);
+            auto const lit3 = Literal::make_typed<Rational>(non_canonical);
             CHECK(lit3.lexical_form() == "1/2");
         }
 
         SUBCASE("from string") {
-            Literal const lit1{"1/10", IRI{owl_rational}};
-            Literal const lit2 = Literal::make<Rational>(cpp_type{1, 10});
-            Literal const lit3{"-1/10", IRI{owl_rational}};
-            Literal const lit4 = Literal::make<Rational>(cpp_type{-1, 10});
+            auto const lit1 = Literal::make_typed("1/10", IRI{owl_rational});
+            auto const lit2 = Literal::make_typed<Rational>(cpp_type{1, 10});
+            auto const lit3 = Literal::make_typed("-1/10", IRI{owl_rational});
+            auto const lit4 = Literal::make_typed<Rational>(cpp_type{-1, 10});
 
             CHECK(lit1 == lit2);
             CHECK(lit3 == lit4);
             CHECK(lit1 == -lit3);
 
-            CHECK_THROWS(Literal{" 2/ 5", IRI{owl_rational}});
-            CHECK_THROWS(Literal{"+10/5", IRI{owl_rational}});
-            CHECK_THROWS(Literal{"asd", IRI{owl_rational}});
-            CHECK_THROWS(Literal{"5/-20", IRI{owl_rational}});
-            CHECK_THROWS(Literal{"0x123/99", IRI{owl_rational}});
+            Literal dummy;
+            CHECK_THROWS(dummy = Literal::make_typed(" 2/ 5", IRI{owl_rational}));
+            CHECK_THROWS(dummy = Literal::make_typed("+10/5", IRI{owl_rational}));
+            CHECK_THROWS(dummy = Literal::make_typed("asd", IRI{owl_rational}));
+            CHECK_THROWS(dummy = Literal::make_typed("5/-20", IRI{owl_rational}));
+            CHECK_THROWS(dummy = Literal::make_typed("0x123/99", IRI{owl_rational}));
         }
     }
 }

--- a/tests/nodes/tests_Literal.cpp
+++ b/tests/nodes/tests_Literal.cpp
@@ -24,7 +24,7 @@ TEST_CASE("Literal - Check for lexical form with IRI") {
 
     SUBCASE("string datatype") {
         auto iri = IRI{"http://www.w3.org/2001/XMLSchema#string"};
-        auto lit1 = Literal{"Bunny", iri};
+        auto lit1 = Literal::make_typed("Bunny", iri);
 
         CHECK(not lit1.is_blank_node());
         CHECK(lit1.is_literal());
@@ -37,7 +37,7 @@ TEST_CASE("Literal - Check for lexical form with IRI") {
     }
     SUBCASE("int datatype") {
         auto iri = IRI{"http://www.w3.org/2001/XMLSchema#int"};
-        auto lit1 = Literal{"101", iri};
+        auto lit1 = Literal::make_typed("101", iri);
 
         CHECK(not lit1.is_blank_node());
         CHECK(lit1.is_literal());
@@ -50,7 +50,7 @@ TEST_CASE("Literal - Check for lexical form with IRI") {
     }
     SUBCASE("date datatype") {
         auto iri = IRI{"http://www.w3.org/2001/XMLSchema#date"};
-        auto lit1 = Literal{"2021-11-21", iri};
+        auto lit1 = Literal::make_typed("2021-11-21", iri);
 
         CHECK(not lit1.is_blank_node());
         CHECK(lit1.is_literal());
@@ -63,7 +63,7 @@ TEST_CASE("Literal - Check for lexical form with IRI") {
     }
     SUBCASE("decimal datatype") {
         auto iri = IRI{"http://www.w3.org/2001/XMLSchema#decimal"};
-        auto lit1 = Literal{"2.0", iri};
+        auto lit1 = Literal::make_typed("2.0", iri);
 
         CHECK(not lit1.is_blank_node());
         CHECK(lit1.is_literal());
@@ -76,7 +76,7 @@ TEST_CASE("Literal - Check for lexical form with IRI") {
     }
     SUBCASE("boolean datatype - true") {
         auto iri = IRI{"http://www.w3.org/2001/XMLSchema#boolean"};
-        auto lit1 = Literal{"true", iri};
+        auto lit1 = Literal::make_typed("true", iri);
 
         CHECK(not lit1.is_blank_node());
         CHECK(lit1.is_literal());
@@ -89,7 +89,7 @@ TEST_CASE("Literal - Check for lexical form with IRI") {
     }
     SUBCASE("boolean datatype - false") {
         auto iri = IRI{"http://www.w3.org/2001/XMLSchema#boolean"};
-        auto lit1 = Literal{"false", iri};
+        auto lit1 = Literal::make_typed("false", iri);
 
         CHECK(not lit1.is_blank_node());
         CHECK(lit1.is_literal());
@@ -102,7 +102,7 @@ TEST_CASE("Literal - Check for lexical form with IRI") {
     }
     SUBCASE("boolean datatype - 0") {
         auto iri = IRI{"http://www.w3.org/2001/XMLSchema#boolean"};
-        auto lit1 = Literal{"0", iri};
+        auto lit1 = Literal::make_typed("0", iri);
 
         CHECK(not lit1.is_blank_node());
         CHECK(lit1.is_literal());
@@ -115,7 +115,7 @@ TEST_CASE("Literal - Check for lexical form with IRI") {
     }
     SUBCASE("boolean datatype - 1") {
         auto iri = IRI{"http://www.w3.org/2001/XMLSchema#boolean"};
-        auto lit1 = Literal{"1", iri};
+        auto lit1 = Literal::make_typed("1", iri);
 
         CHECK(not lit1.is_blank_node());
         CHECK(lit1.is_literal());
@@ -131,7 +131,7 @@ TEST_CASE("Literal - Check for lexical form with IRI") {
 TEST_CASE("Literal - Check for lexical form with language tag") {
 
     auto iri = IRI{"http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"};
-    auto lit1 = Literal{"Bunny", "en"};
+    auto lit1 = Literal::make_lang_tagged("Bunny", "en");
 
     CHECK(not lit1.is_blank_node());
     CHECK(lit1.is_literal());
@@ -145,16 +145,16 @@ TEST_CASE("Literal - Check for lexical form with language tag") {
 
 TEST_CASE("Literal - ctor edge-case") {
     IRI const iri{"http://www.w3.org/2001/XMLSchema#int"};
-    Literal const lit1{"1", iri};
-    Literal const lit2{"2", iri};
+    auto const lit1 = Literal::make_typed("1", iri);
+    auto const lit2 = Literal::make_typed("2", iri);
 
-    Literal const expected{"3", iri};
+    auto const expected = Literal::make_typed("3", iri);
     CHECK(lit1 + lit2 == expected);
 }
 
 TEST_CASE("Literal - check fixed id") {
     IRI const iri{datatypes::registry::xsd_string};
-    Literal const lit{"hello", iri};
+    auto const lit = Literal::make_typed("hello", iri);
 
     CHECK(lit.backend_handle().node_id().literal_type().is_fixed());
     CHECK(lit.datatype().backend_handle().node_id().value() < datatypes::registry::min_dynamic_datatype_id);
@@ -164,10 +164,10 @@ TEST_CASE("Literal - check fixed id") {
 TEST_CASE("Literal - casting") {
     using namespace datatypes::xsd;
 
-    auto const lit1 = Literal::make<datatypes::xsd::Int>(123);
+    auto const lit1 = Literal::make_typed<datatypes::xsd::Int>(123);
 
     SUBCASE("id cast") {
-        auto const lit1 = Literal::make<String>("hello");
+        auto const lit1 = Literal::make_typed<String>("hello");
         auto const lit2 = lit1.template cast<String>();
 
         CHECK(lit2.datatype() == IRI{String::identifier});
@@ -175,7 +175,7 @@ TEST_CASE("Literal - casting") {
     }
 
     SUBCASE("str -> any") {
-        auto const lit1 = Literal::make<String>("1.2");
+        auto const lit1 = Literal::make_typed<String>("1.2");
         auto const lit2 = lit1.template cast<Float>();
 
         CHECK(lit2.datatype() == IRI{Float::identifier});
@@ -184,7 +184,7 @@ TEST_CASE("Literal - casting") {
 
     SUBCASE("str -> boolean") {
         SUBCASE("word-form") {
-            auto const lit1 = Literal::make<String>("true");
+            auto const lit1 = Literal::make_typed<String>("true");
             auto const lit2 = lit1.template cast<Boolean>();
 
             CHECK(lit2.datatype() == IRI{Boolean::identifier});
@@ -192,7 +192,7 @@ TEST_CASE("Literal - casting") {
         }
 
         SUBCASE("numeric form") {
-            auto const lit1 = Literal::make<String>("1");
+            auto const lit1 = Literal::make_typed<String>("1");
             auto const lit2 = lit1.template cast<Boolean>();
 
             CHECK(lit2.datatype() == IRI{Boolean::identifier});
@@ -203,14 +203,14 @@ TEST_CASE("Literal - casting") {
     SUBCASE("any -> str") {
         SUBCASE("decimal") {
             SUBCASE("integral") {
-                auto const lit1 = Literal::make<Decimal>(Decimal::cpp_type{"1005.0"});
+                auto const lit1 = Literal::make_typed<Decimal>(Decimal::cpp_type{"1005.0"});
                 auto const lit2 = lit1.cast<String>();
 
                 CHECK(lit2.value<String>() == "1005");
             }
 
             SUBCASE("non-integral") {
-                auto const lit1 = Literal::make<Decimal>(1.5);
+                auto const lit1 = Literal::make_typed<Decimal>(1.5);
                 auto const lit2 = lit1.template cast<String>();
 
                 CHECK(lit2.template value<String>() == "1.5");
@@ -219,42 +219,42 @@ TEST_CASE("Literal - casting") {
 
         SUBCASE("float") {
             SUBCASE("fixed notation - non-integral") {
-                auto const lit1 = Literal::make<Float>(10.5f);
+                auto const lit1 = Literal::make_typed<Float>(10.5f);
                 auto const lit2 = lit1.template cast<String>();
 
                 CHECK(lit2.template value<String>() == "10.5");
             }
 
             SUBCASE("fixed notation - integral") {
-                auto const lit1 = Literal::make<Float>(100000.f);
+                auto const lit1 = Literal::make_typed<Float>(100000.f);
                 auto const lit2 = lit1.template cast<String>();
 
                 CHECK(lit2.template value<String>() == "100000");
             }
 
             SUBCASE("large - scientific") {
-                auto const lit1 = Literal::make<Float>(1000001.f);
+                auto const lit1 = Literal::make_typed<Float>(1000001.f);
                 auto const lit2 = lit1.template cast<String>();
 
                 CHECK(lit2.template value<String>() == "1.000001E6");
             }
 
             SUBCASE("small - scientific") {
-                auto const lit1 = Literal::make<Float>(0.0000009f);
+                auto const lit1 = Literal::make_typed<Float>(0.0000009f);
                 auto const lit2 = lit1.template cast<String>();
 
                 CHECK(lit2.template value<String>() == "9.0E-7");
             }
 
             SUBCASE("zero") {
-                auto const lit1 = Literal::make<Float>(0.0f);
+                auto const lit1 = Literal::make_typed<Float>(0.0f);
                 auto const lit2 = lit1.template cast<String>();
 
                 CHECK(lit2.template value<String>() == "0");
             }
 
             SUBCASE("minus zero") {
-                auto const lit1 = Literal::make<Float>(-0.0f);
+                auto const lit1 = Literal::make_typed<Float>(-0.0f);
                 auto const lit2 = lit1.template cast<String>();
 
                 CHECK(lit2.template value<String>() == "-0");
@@ -263,42 +263,42 @@ TEST_CASE("Literal - casting") {
 
         SUBCASE("double") {
             SUBCASE("fixed notation - non-integral") {
-                auto const lit1 = Literal::make<Double>(10.5);
+                auto const lit1 = Literal::make_typed<Double>(10.5);
                 auto const lit2 = lit1.template cast<String>();
 
                 CHECK(lit2.template value<String>() == "10.5");
             }
 
             SUBCASE("fixed notation - integral") {
-                auto const lit1 = Literal::make<Double>(100000.0);
+                auto const lit1 = Literal::make_typed<Double>(100000.0);
                 auto const lit2 = lit1.template cast<String>();
 
                 CHECK(lit2.template value<String>() == "100000");
             }
 
             SUBCASE("large - scientific") {
-                auto const lit1 = Literal::make<Double>(1000001.0);
+                auto const lit1 = Literal::make_typed<Double>(1000001.0);
                 auto const lit2 = lit1.template cast<String>();
 
                 CHECK(lit2.template value<String>() == "1.000001E6");
             }
 
             SUBCASE("small - scientific") {
-                auto const lit1 = Literal::make<Double>(0.0000009);
+                auto const lit1 = Literal::make_typed<Double>(0.0000009);
                 auto const lit2 = lit1.template cast<String>();
 
                 CHECK(lit2.template value<String>() == "9.0E-7");
             }
 
             SUBCASE("zero") {
-                auto const lit1 = Literal::make<Double>(0.0);
+                auto const lit1 = Literal::make_typed<Double>(0.0);
                 auto const lit2 = lit1.template cast<String>();
 
                 CHECK(lit2.template value<String>() == "0");
             }
 
             SUBCASE("minus zero") {
-                auto const lit1 = Literal::make<Double>(-0.0);
+                auto const lit1 = Literal::make_typed<Double>(-0.0);
                 auto const lit2 = lit1.template cast<String>();
 
                 CHECK(lit2.template value<String>() == "-0");
@@ -307,7 +307,7 @@ TEST_CASE("Literal - casting") {
     }
 
     SUBCASE("any -> bool") {
-        auto const lit1 = Literal::make<Float>(1.4);
+        auto const lit1 = Literal::make_typed<Float>(1.4);
         auto const lit2 = lit1.template cast<Boolean>();
 
         CHECK(lit2.datatype() == IRI{Boolean::identifier});
@@ -315,7 +315,7 @@ TEST_CASE("Literal - casting") {
     }
 
     SUBCASE("downcast: dbl -> flt") {
-        auto const lit1 = Literal::make<Double>(1.4);
+        auto const lit1 = Literal::make_typed<Double>(1.4);
         auto const lit2 = lit1.template cast<Float>();
 
         CHECK(lit2.datatype() == IRI{Float::identifier});
@@ -323,7 +323,7 @@ TEST_CASE("Literal - casting") {
     }
 
     SUBCASE("dec -> flt") {
-        auto const lit1 = Literal::make<Decimal>(1.0);
+        auto const lit1 = Literal::make_typed<Decimal>(1.0);
         auto const lit2 = lit1.template cast<Float>();
 
         CHECK(lit2.datatype() == IRI{Float::identifier});
@@ -331,7 +331,7 @@ TEST_CASE("Literal - casting") {
     }
 
     SUBCASE("dec -> dbl") {
-        auto const lit1 = Literal::make<Decimal>(1.0);
+        auto const lit1 = Literal::make_typed<Decimal>(1.0);
         auto const lit2 = lit1.template cast<Double>();
 
         CHECK(lit2.datatype() == IRI{Double::identifier});
@@ -339,7 +339,7 @@ TEST_CASE("Literal - casting") {
     }
 
     SUBCASE("dec -> int") {
-        auto const lit1 = Literal::make<Decimal>(1.2);
+        auto const lit1 = Literal::make_typed<Decimal>(1.2);
         auto const lit2 = lit1.template cast<Int>();
 
         CHECK(lit2.datatype() == IRI{Int::identifier});
@@ -347,7 +347,7 @@ TEST_CASE("Literal - casting") {
     }
 
     SUBCASE("downcast: int -> dec") {
-        auto const lit1 = Literal::make<Integer>(1);
+        auto const lit1 = Literal::make_typed<Integer>(1);
         auto const lit2 = lit1.template cast<Decimal>();
 
         CHECK(lit2.datatype() == IRI{Decimal::identifier});
@@ -355,7 +355,7 @@ TEST_CASE("Literal - casting") {
     }
 
     SUBCASE("int -> flt") {
-        auto const lit1 = Literal::make<Integer>(1);
+        auto const lit1 = Literal::make_typed<Integer>(1);
         auto const lit2 = lit1.template cast<Float>();
 
         CHECK(lit2.datatype() == IRI{Float::identifier});
@@ -363,7 +363,7 @@ TEST_CASE("Literal - casting") {
     }
 
     SUBCASE("int -> dbl") {
-        auto const lit1 = Literal::make<Integer>(1);
+        auto const lit1 = Literal::make_typed<Integer>(1);
         auto const lit2 = lit1.template cast<Double>();
 
         CHECK(lit2.datatype() == IRI{Double::identifier});
@@ -371,7 +371,7 @@ TEST_CASE("Literal - casting") {
     }
 
     SUBCASE("id cast") {
-        auto const lit1 = Literal::make<Int>(5);
+        auto const lit1 = Literal::make_typed<Int>(5);
         auto const lit2 = lit1.template cast<Int>();
 
         CHECK(lit1 == lit2);
@@ -380,7 +380,7 @@ TEST_CASE("Literal - casting") {
     SUBCASE("bool -> numeric") {
         SUBCASE("integers") {
             SUBCASE("regular case") {
-                auto const lit1 = Literal::make<Boolean>(true);
+                auto const lit1 = Literal::make_typed<Boolean>(true);
                 auto const lit2 = lit1.template cast<Byte>();
                 CHECK(!lit2.null());
                 CHECK(lit2.datatype() == IRI{Byte::identifier});
@@ -388,7 +388,7 @@ TEST_CASE("Literal - casting") {
             }
 
             SUBCASE("partially representable - representable case") {
-                auto const lit3 = Literal::make<Boolean>(false);
+                auto const lit3 = Literal::make_typed<Boolean>(false);
                 auto const lit4 = lit3.template cast<NonPositiveInteger>();
                 CHECK(!lit4.null());
                 CHECK(lit4.datatype() == IRI{NonPositiveInteger::identifier});
@@ -396,14 +396,14 @@ TEST_CASE("Literal - casting") {
             }
 
             SUBCASE("partially representable - unrepresentable case") {
-                auto const lit3 = Literal::make<Boolean>(true);
+                auto const lit3 = Literal::make_typed<Boolean>(true);
                 auto const lit4 = lit3.template cast<NegativeInteger>();
                 CHECK(lit4.null());
             }
         }
 
         SUBCASE("decimal") {
-            auto const lit1 = Literal::make<Boolean>(false);
+            auto const lit1 = Literal::make_typed<Boolean>(false);
             auto const lit2 = lit1.template cast<Decimal>();
             CHECK(!lit2.null());
             CHECK(lit2.datatype() == IRI{Decimal::identifier});
@@ -411,7 +411,7 @@ TEST_CASE("Literal - casting") {
         }
 
         SUBCASE("float") {
-            auto const lit1 = Literal::make<Boolean>(true);
+            auto const lit1 = Literal::make_typed<Boolean>(true);
             auto const lit2 = lit1.template cast<Float>();
             CHECK(!lit2.null());
             CHECK(lit2.datatype() == IRI{Float::identifier});
@@ -419,7 +419,7 @@ TEST_CASE("Literal - casting") {
         }
 
         SUBCASE("double") {
-            auto const lit1 = Literal::make<Boolean>(false);
+            auto const lit1 = Literal::make_typed<Boolean>(false);
             auto const lit2 = lit1.template cast<Double>();
             CHECK(!lit2.null());
             CHECK(lit2.datatype() == IRI{Double::identifier});
@@ -428,7 +428,7 @@ TEST_CASE("Literal - casting") {
     }
 
     SUBCASE("cross hierarchy: int -> unsignedInt") {
-        auto const lit1 = Literal::make<Int>(1);
+        auto const lit1 = Literal::make_typed<Int>(1);
         auto const lit2 = lit1.template cast<UnsignedInt>();
 
         CHECK(lit2.datatype() == IRI{UnsignedInt::identifier});
@@ -439,19 +439,19 @@ TEST_CASE("Literal - casting") {
         CHECK(lit1.template cast<Integer>().datatype() == IRI{Integer::identifier});
         CHECK(lit1.template cast<Float>().datatype() == IRI{Float::identifier});
 
-        auto const lit2 = Literal::make<Integer>(420);
-        CHECK(lit2.template cast<Int>() == Literal::make<Int>(420));
+        auto const lit2 = Literal::make_typed<Integer>(420);
+        CHECK(lit2.template cast<Int>() == Literal::make_typed<Int>(420));
     }
 
     SUBCASE("value too large") {
-        auto const lit1 = Literal::make<Int>(67000);
+        auto const lit1 = Literal::make_typed<Int>(67000);
         auto const lit2 = lit1.template cast<Short>();
 
         CHECK(lit2.null());
     }
 
     SUBCASE("negative to unsigned") {
-        auto const lit1 = Literal::make<Int>(-10);
+        auto const lit1 = Literal::make_typed<Int>(-10);
         auto const lit2 = lit1.template cast<UnsignedInt>();
 
         CHECK(lit2.null());

--- a/tests/nodes/tests_Literal.cpp
+++ b/tests/nodes/tests_Literal.cpp
@@ -8,7 +8,7 @@ using namespace rdf4cpp::rdf;
 TEST_CASE("Literal - Check for only lexical form") {
 
     auto iri = IRI{"http://www.w3.org/2001/XMLSchema#string"};
-    auto lit1 = Literal{"Bunny"};
+    auto lit1 = Literal::make_simple("Bunny");
 
     CHECK(not lit1.is_blank_node());
     CHECK(lit1.is_literal());

--- a/tests/nodes/tests_Literal.cpp
+++ b/tests/nodes/tests_Literal.cpp
@@ -459,5 +459,5 @@ TEST_CASE("Literal - casting") {
 }
 
 TEST_CASE("indirect casting precision") {
-    CHECK(Literal::make<datatypes::xsd::Double>(2e-1) + Literal::make<datatypes::xsd::Decimal>(datatypes::xsd::Decimal::cpp_type{"0.2"}) == Literal::make<datatypes::xsd::Double>(4e-1));
+    CHECK(Literal::make_typed<datatypes::xsd::Double>(2e-1) + Literal::make_typed<datatypes::xsd::Decimal>(datatypes::xsd::Decimal::cpp_type{"0.2"}) == Literal::make_typed<datatypes::xsd::Double>(4e-1));
 }

--- a/tests/nodes/tests_Literal_ops.cpp
+++ b/tests/nodes/tests_Literal_ops.cpp
@@ -12,44 +12,44 @@ TEST_CASE("Literal - logical ops") {
     SUBCASE("Literal - logical ops - results") {
         SUBCASE("Literal - logical ops - bool results - and") {
             {
-                auto const lhs = Literal::make<datatypes::xsd::Boolean>(true);
-                auto const rhs = Literal::make<datatypes::xsd::Boolean>(false);
+                auto const lhs = Literal::make_typed<datatypes::xsd::Boolean>(true);
+                auto const rhs = Literal::make_typed<datatypes::xsd::Boolean>(false);
 
                 auto const res = lhs && rhs;
                 auto const res2 = rhs && lhs;
-                CHECK(res == Literal::make<datatypes::xsd::Boolean>(false));
-                CHECK(res2 == Literal::make<datatypes::xsd::Boolean>(false));
+                CHECK(res == Literal::make_typed<datatypes::xsd::Boolean>(false));
+                CHECK(res2 == Literal::make_typed<datatypes::xsd::Boolean>(false));
             }
             {
-                auto const lhs = Literal::make<datatypes::xsd::Boolean>(true);
-                auto const rhs = Literal::make<datatypes::xsd::Boolean>(true);
+                auto const lhs = Literal::make_typed<datatypes::xsd::Boolean>(true);
+                auto const rhs = Literal::make_typed<datatypes::xsd::Boolean>(true);
 
                 auto const res = lhs && rhs;
                 auto const res2 = rhs && lhs;
-                CHECK(res == Literal::make<datatypes::xsd::Boolean>(true));
-                CHECK(res2 == Literal::make<datatypes::xsd::Boolean>(true));
+                CHECK(res == Literal::make_typed<datatypes::xsd::Boolean>(true));
+                CHECK(res2 == Literal::make_typed<datatypes::xsd::Boolean>(true));
             }
             {
-                auto const lhs = Literal::make<datatypes::xsd::Boolean>(false);
-                auto const rhs = Literal::make<datatypes::xsd::Boolean>(false);
+                auto const lhs = Literal::make_typed<datatypes::xsd::Boolean>(false);
+                auto const rhs = Literal::make_typed<datatypes::xsd::Boolean>(false);
 
                 auto const res = lhs && rhs;
                 auto const res2 = rhs && lhs;
-                CHECK(res == Literal::make<datatypes::xsd::Boolean>(false));
-                CHECK(res2 == Literal::make<datatypes::xsd::Boolean>(false));
-            }
-            {
-                auto const lhs = Literal{};
-                auto const rhs = Literal::make<datatypes::xsd::Boolean>(false);
-
-                auto const res = lhs && rhs;
-                auto const res2 = rhs && lhs;
-                CHECK(res == Literal::make<datatypes::xsd::Boolean>(false));
-                CHECK(res2 == Literal::make<datatypes::xsd::Boolean>(false));
+                CHECK(res == Literal::make_typed<datatypes::xsd::Boolean>(false));
+                CHECK(res2 == Literal::make_typed<datatypes::xsd::Boolean>(false));
             }
             {
                 auto const lhs = Literal{};
-                auto const rhs = Literal::make<datatypes::xsd::Boolean>(true);
+                auto const rhs = Literal::make_typed<datatypes::xsd::Boolean>(false);
+
+                auto const res = lhs && rhs;
+                auto const res2 = rhs && lhs;
+                CHECK(res == Literal::make_typed<datatypes::xsd::Boolean>(false));
+                CHECK(res2 == Literal::make_typed<datatypes::xsd::Boolean>(false));
+            }
+            {
+                auto const lhs = Literal{};
+                auto const rhs = Literal::make_typed<datatypes::xsd::Boolean>(true);
 
                 auto const res = lhs && rhs;
                 auto const res2 = rhs && lhs;
@@ -69,35 +69,35 @@ TEST_CASE("Literal - logical ops") {
 
         SUBCASE("Literal - logical ops - bool results - or") {
             {
-                auto const lhs = Literal::make<datatypes::xsd::Boolean>(true);
-                auto const rhs = Literal::make<datatypes::xsd::Boolean>(false);
+                auto const lhs = Literal::make_typed<datatypes::xsd::Boolean>(true);
+                auto const rhs = Literal::make_typed<datatypes::xsd::Boolean>(false);
 
                 auto const res = lhs || rhs;
                 auto const res2 = rhs || lhs;
-                CHECK(res == Literal::make<datatypes::xsd::Boolean>(true));
-                CHECK(res2 == Literal::make<datatypes::xsd::Boolean>(true));
+                CHECK(res == Literal::make_typed<datatypes::xsd::Boolean>(true));
+                CHECK(res2 == Literal::make_typed<datatypes::xsd::Boolean>(true));
             }
             {
-                auto const lhs = Literal::make<datatypes::xsd::Boolean>(true);
-                auto const rhs = Literal::make<datatypes::xsd::Boolean>(true);
+                auto const lhs = Literal::make_typed<datatypes::xsd::Boolean>(true);
+                auto const rhs = Literal::make_typed<datatypes::xsd::Boolean>(true);
 
                 auto const res = lhs || rhs;
                 auto const res2 = rhs || lhs;
-                CHECK(res == Literal::make<datatypes::xsd::Boolean>(true));
-                CHECK(res2 == Literal::make<datatypes::xsd::Boolean>(true));
+                CHECK(res == Literal::make_typed<datatypes::xsd::Boolean>(true));
+                CHECK(res2 == Literal::make_typed<datatypes::xsd::Boolean>(true));
             }
             {
-                auto const lhs = Literal::make<datatypes::xsd::Boolean>(false);
-                auto const rhs = Literal::make<datatypes::xsd::Boolean>(false);
+                auto const lhs = Literal::make_typed<datatypes::xsd::Boolean>(false);
+                auto const rhs = Literal::make_typed<datatypes::xsd::Boolean>(false);
 
                 auto const res = lhs || rhs;
                 auto const res2 = rhs || lhs;
-                CHECK(res == Literal::make<datatypes::xsd::Boolean>(false));
-                CHECK(res2 == Literal::make<datatypes::xsd::Boolean>(false));
+                CHECK(res == Literal::make_typed<datatypes::xsd::Boolean>(false));
+                CHECK(res2 == Literal::make_typed<datatypes::xsd::Boolean>(false));
             }
             {
                 auto const lhs = Literal{};
-                auto const rhs = Literal::make<datatypes::xsd::Boolean>(false);
+                auto const rhs = Literal::make_typed<datatypes::xsd::Boolean>(false);
 
                 auto const res = lhs || rhs;
                 auto const res2 = rhs || lhs;
@@ -106,12 +106,12 @@ TEST_CASE("Literal - logical ops") {
             }
             {
                 auto const lhs = Literal{};
-                auto const rhs = Literal::make<datatypes::xsd::Boolean>(true);
+                auto const rhs = Literal::make_typed<datatypes::xsd::Boolean>(true);
 
                 auto const res = lhs || rhs;
                 auto const res2 = rhs || lhs;
-                CHECK(res == Literal::make<datatypes::xsd::Boolean>(true));
-                CHECK(res2 == Literal::make<datatypes::xsd::Boolean>(true));
+                CHECK(res == Literal::make_typed<datatypes::xsd::Boolean>(true));
+                CHECK(res2 == Literal::make_typed<datatypes::xsd::Boolean>(true));
             }
             {
                 auto const lhs = Literal{};
@@ -126,12 +126,12 @@ TEST_CASE("Literal - logical ops") {
 
         SUBCASE("Literal - logical ops - bool results - not") {
             {
-                auto const op = Literal::make<datatypes::xsd::Boolean>(true);
-                CHECK(!op == Literal::make<datatypes::xsd::Boolean>(false));
+                auto const op = Literal::make_typed<datatypes::xsd::Boolean>(true);
+                CHECK(!op == Literal::make_typed<datatypes::xsd::Boolean>(false));
             }
             {
-                auto const op = Literal::make<datatypes::xsd::Boolean>(false);
-                CHECK(!op == Literal::make<datatypes::xsd::Boolean>(true));
+                auto const op = Literal::make_typed<datatypes::xsd::Boolean>(false);
+                CHECK(!op == Literal::make_typed<datatypes::xsd::Boolean>(true));
             }
             {
                 auto const op = Literal{};
@@ -143,18 +143,18 @@ TEST_CASE("Literal - logical ops") {
 
 #define GENERATE_BINOP_TESTCASE(lhs_type, lhs, op, rhs_type, rhs, expected_type, expected) \
     SUBCASE(#lhs_type " " #op " " #rhs_type) {                                             \
-        auto const lhs_lit = Literal::make<datatypes::xsd::lhs_type>(lhs);                 \
-        auto const rhs_lit = Literal::make<datatypes::xsd::rhs_type>(rhs);                 \
+        auto const lhs_lit = Literal::make_typed<datatypes::xsd::lhs_type>(lhs);                 \
+        auto const rhs_lit = Literal::make_typed<datatypes::xsd::rhs_type>(rhs);                 \
                                                                                            \
-        auto const expected_lit = Literal::make<datatypes::xsd::expected_type>(expected);  \
+        auto const expected_lit = Literal::make_typed<datatypes::xsd::expected_type>(expected);  \
         CHECK(lhs_lit op rhs_lit == expected_lit);                                         \
     }
 
 #define GENERATE_UNOP_TESTCASE(type, value, op, expected_type, expected)                  \
     SUBCASE(#op " type") {                                                                \
-        auto const value_lit = Literal::make<datatypes::xsd::type>(value);                \
+        auto const value_lit = Literal::make_typed<datatypes::xsd::type>(value);                \
                                                                                           \
-        auto const expected_lit = Literal::make<datatypes::xsd::expected_type>(expected); \
+        auto const expected_lit = Literal::make_typed<datatypes::xsd::expected_type>(expected); \
         CHECK(op value_lit == expected_lit);                                              \
     }
 
@@ -192,22 +192,22 @@ TEST_CASE("Literal - numeric ops") {
     GENERATE_BINOP_TESTCASE(Int, int_max, *, Int, 2, Integer, static_cast<int64_t>(int_max) * 2);
 
     SUBCASE("boolean not add") {
-        auto const lhs = Literal::make<datatypes::xsd::Boolean>(true);
-        auto const rhs = Literal::make<datatypes::xsd::Boolean>(false);
+        auto const lhs = Literal::make_typed<datatypes::xsd::Boolean>(true);
+        auto const rhs = Literal::make_typed<datatypes::xsd::Boolean>(false);
 
         CHECK((lhs + rhs).null());
     }
 
     SUBCASE("add literal type mismatch") {
-        auto const lhs = Literal::make<datatypes::xsd::Float>(1.f);
-        auto const rhs = Literal::make<datatypes::xsd::Boolean>(false);
+        auto const lhs = Literal::make_typed<datatypes::xsd::Float>(1.f);
+        auto const rhs = Literal::make_typed<datatypes::xsd::Boolean>(false);
 
         CHECK((lhs + rhs).null());
     }
 
     SUBCASE("op with null") {
         {
-            auto const lhs = Literal::make<datatypes::xsd::Float>(2.f);
+            auto const lhs = Literal::make_typed<datatypes::xsd::Float>(2.f);
             auto const rhs = Literal{};
 
             CHECK((lhs + rhs).null());

--- a/tests/nodes/tests_Node.cpp
+++ b/tests/nodes/tests_Node.cpp
@@ -48,8 +48,8 @@ TEST_SUITE("comparisions") {
         IRI iri1 = IRI{"http://www.example.org/test2"};
         IRI iri2 = IRI{"http://www.example.org/test1"};
         IRI iri3 = IRI{"http://www.example.org/oest"};
-        Literal lit1 = Literal::make<String>("testlit1");
-        Literal lit2 = Literal::make<String>("testlit2");
+        Literal lit1 = Literal::make_typed<String>("testlit1");
+        Literal lit2 = Literal::make_typed<String>("testlit2");
         CHECK(iri2 < iri1);
         CHECK(iri3 < iri1);
         CHECK(iri3 < iri2);
@@ -60,74 +60,74 @@ TEST_SUITE("comparisions") {
     TEST_CASE("filter compare tests") {
         SUBCASE("nulls") {
             CHECK(Literal{} <=> Literal{} == std::partial_ordering::equivalent);
-            CHECK(Literal{} <=> Literal::make<Int>(1) == std::partial_ordering::unordered);
-            CHECK(Literal::make<Decimal>(1.0) <=> Literal{} == std::partial_ordering::unordered);
+            CHECK(Literal{} <=> Literal::make_typed<Int>(1) == std::partial_ordering::unordered);
+            CHECK(Literal::make_typed<Decimal>(1.0) <=> Literal{} == std::partial_ordering::unordered);
         }
 
         SUBCASE("inconvertibility") {
-            CHECK(Literal::make<String>("hello") <=> Literal::make<Int>(5) == std::partial_ordering::unordered);
-            CHECK(Literal::make<Float>(1.f) <=> Literal::make<String>("world") == std::partial_ordering::unordered);
+            CHECK(Literal::make_typed<String>("hello") <=> Literal::make_typed<Int>(5) == std::partial_ordering::unordered);
+            CHECK(Literal::make_typed<Float>(1.f) <=> Literal::make_typed<String>("world") == std::partial_ordering::unordered);
         }
 
         SUBCASE("incomparability") {
-            CHECK(Literal::make<Incomparable>(1) <=> Literal::make<Incomparable>(1) == std::partial_ordering::unordered);
-            CHECK(Literal::make<Int>(1) <=> Literal::make<Incomparable>(1) == std::partial_ordering::unordered);
-            CHECK(Literal::make<Incomparable>(1) <=> Literal::make<Int>(1) == std::partial_ordering::unordered);
+            CHECK(Literal::make_typed<Incomparable>(1) <=> Literal::make_typed<Incomparable>(1) == std::partial_ordering::unordered);
+            CHECK(Literal::make_typed<Int>(1) <=> Literal::make_typed<Incomparable>(1) == std::partial_ordering::unordered);
+            CHECK(Literal::make_typed<Incomparable>(1) <=> Literal::make_typed<Int>(1) == std::partial_ordering::unordered);
         }
 
         SUBCASE("conversion") {
-            CHECK(Literal::make<Int>(1) <=> Literal::make<Integer>(10) == std::partial_ordering::less);
-            CHECK(Literal::make<Integer>(0) <=> Literal::make<Float>(1.2f) == std::partial_ordering::less);
-            CHECK(Literal::make<Float>(1.f) <=> Literal::make<Decimal>(1.0) == std::partial_ordering::equivalent);
+            CHECK(Literal::make_typed<Int>(1) <=> Literal::make_typed<Integer>(10) == std::partial_ordering::less);
+            CHECK(Literal::make_typed<Integer>(0) <=> Literal::make_typed<Float>(1.2f) == std::partial_ordering::less);
+            CHECK(Literal::make_typed<Float>(1.f) <=> Literal::make_typed<Decimal>(1.0) == std::partial_ordering::equivalent);
         }
     }
 
     TEST_CASE("order by compare tests") {
         // Incomparable <=> Incomparable
         SUBCASE("incomparability") {
-            CHECK(Literal::make<Incomparable>(5).compare_with_extensions(Literal::make<Incomparable>(10)) == std::weak_ordering::greater);
+            CHECK(Literal::make_typed<Incomparable>(5).compare_with_extensions(Literal::make_typed<Incomparable>(10)) == std::weak_ordering::greater);
 
             // reason: float has fixed id and any fixed id type is always less than a dynamic one
-            CHECK(Literal::make<Float>(10.f).compare_with_extensions(Literal::make<Incomparable>(1)) == std::weak_ordering::less);
+            CHECK(Literal::make_typed<Float>(10.f).compare_with_extensions(Literal::make_typed<Incomparable>(1)) == std::weak_ordering::less);
 
             // reason: decimal has fixed id and any fixed id type is always less than a dynamic one
-            CHECK(Literal::make<Incomparable>(1).compare_with_extensions(Literal::make<Decimal>(10.0)) == std::weak_ordering::greater);
+            CHECK(Literal::make_typed<Incomparable>(1).compare_with_extensions(Literal::make_typed<Decimal>(10.0)) == std::weak_ordering::greater);
         }
 
         SUBCASE("nulls") {
             CHECK(Literal{}.compare_with_extensions(Literal{}) == std::weak_ordering::equivalent);
 
             // null <=> other (expecting null < any other a)
-            CHECK(Literal{}.compare_with_extensions(Literal::make<Int>(1)) == std::weak_ordering::less);
-            CHECK(Literal::make<String>("123").compare_with_extensions(Literal{}) == std::weak_ordering::greater);
+            CHECK(Literal{}.compare_with_extensions(Literal::make_typed<Int>(1)) == std::weak_ordering::less);
+            CHECK(Literal::make_typed<String>("123").compare_with_extensions(Literal{}) == std::weak_ordering::greater);
         }
 
         SUBCASE("test type ordering extensions") {
             // expected: string < float < decimal < integer < int
 
-            CHECK(Literal::make<Decimal>(1.0).compare_with_extensions(Literal::make<Float>(1)) == std::weak_ordering::greater);
-            CHECK(Literal::make<Decimal>(1.0).compare_with_extensions(Literal::make<Int>(1)) == std::weak_ordering::less);
-            CHECK(Literal::make<Decimal>(1.0).compare_with_extensions(Literal::make<Integer>(1)) == std::weak_ordering::less);
-            CHECK(Literal::make<Decimal>(1.0).compare_with_extensions(Literal::make<String>("hello")) == std::weak_ordering::greater);
+            CHECK(Literal::make_typed<Decimal>(1.0).compare_with_extensions(Literal::make_typed<Float>(1)) == std::weak_ordering::greater);
+            CHECK(Literal::make_typed<Decimal>(1.0).compare_with_extensions(Literal::make_typed<Int>(1)) == std::weak_ordering::less);
+            CHECK(Literal::make_typed<Decimal>(1.0).compare_with_extensions(Literal::make_typed<Integer>(1)) == std::weak_ordering::less);
+            CHECK(Literal::make_typed<Decimal>(1.0).compare_with_extensions(Literal::make_typed<String>("hello")) == std::weak_ordering::greater);
 
-            CHECK(Literal::make<Float>(1.f).compare_with_extensions(Literal::make<Int>(1)) == std::weak_ordering::less);
-            CHECK(Literal::make<Float>(1.f).compare_with_extensions(Literal::make<Integer>(1)) == std::weak_ordering::less);
-            CHECK(Literal::make<Float>(1.f).compare_with_extensions(Literal::make<String>("hello")) == std::weak_ordering::greater);
+            CHECK(Literal::make_typed<Float>(1.f).compare_with_extensions(Literal::make_typed<Int>(1)) == std::weak_ordering::less);
+            CHECK(Literal::make_typed<Float>(1.f).compare_with_extensions(Literal::make_typed<Integer>(1)) == std::weak_ordering::less);
+            CHECK(Literal::make_typed<Float>(1.f).compare_with_extensions(Literal::make_typed<String>("hello")) == std::weak_ordering::greater);
 
-            CHECK(Literal::make<Int>(1).compare_with_extensions(Literal::make<Integer>(1)) == std::weak_ordering::greater);
-            CHECK(Literal::make<Int>(1).compare_with_extensions(Literal::make<String>("hello")) == std::weak_ordering::greater);
+            CHECK(Literal::make_typed<Int>(1).compare_with_extensions(Literal::make_typed<Integer>(1)) == std::weak_ordering::greater);
+            CHECK(Literal::make_typed<Int>(1).compare_with_extensions(Literal::make_typed<String>("hello")) == std::weak_ordering::greater);
         }
 
         SUBCASE("test ordering extensions ignored when not equal") {
-            CHECK(Literal::make<Float>(2.f).compare_with_extensions(Literal::make<Integer>(1)) == std::weak_ordering::greater);
+            CHECK(Literal::make_typed<Float>(2.f).compare_with_extensions(Literal::make_typed<Integer>(1)) == std::weak_ordering::greater);
         }
     }
 
     TEST_CASE("std::set") {
-        Literal const lit = Literal::make<Int>(5);
-        Literal const lit2 = Literal::make<Int>(5); // duplicate to check if it's filtered out
-        Literal const lit3 = Literal::make<Integer>(10);
-        Literal const lit4 = Literal::make<String>("hello world");
+        Literal const lit = Literal::make_typed<Int>(5);
+        Literal const lit2 = Literal::make_typed<Int>(5); // duplicate to check if it's filtered out
+        Literal const lit3 = Literal::make_typed<Integer>(10);
+        Literal const lit4 = Literal::make_typed<String>("hello world");
         IRI const iri{"some random iri"};
         IRI const null_iri{};
         Node const node{};
@@ -148,10 +148,10 @@ TEST_SUITE("comparisions") {
     }
 
     TEST_CASE("std::unordered_set") {
-        Literal const lit = Literal::make<Int>(5);
-        Literal const lit2 = Literal::make<Int>(5); // duplicate to check if it's filtered out
-        Literal const lit3 = Literal::make<Integer>(10);
-        Literal const lit4 = Literal::make<String>("hello world");
+        Literal const lit = Literal::make_typed<Int>(5);
+        Literal const lit2 = Literal::make_typed<Int>(5); // duplicate to check if it's filtered out
+        Literal const lit3 = Literal::make_typed<Integer>(10);
+        Literal const lit4 = Literal::make_typed<String>("hello world");
         IRI const iri{"some random iri"};
         IRI const null_iri{};
         Node const node{};
@@ -178,8 +178,8 @@ TEST_CASE("effective boolean value") {
     Node const iri = IRI{"http://hello.com"};
     Node const bnode = BlankNode{"asd"};
     Node const var = query::Variable{"x"};
-    Node const falsy_lit = Literal::make<datatypes::xsd::Float>(0.f);
-    Node const truthy_lit = Literal::make<datatypes::xsd::Integer>(100);
+    Node const falsy_lit = Literal::make_typed<datatypes::xsd::Float>(0.f);
+    Node const truthy_lit = Literal::make_typed<datatypes::xsd::Integer>(100);
     Node const null_lit = Literal{};
     Node const null_bnode = BlankNode{};
 

--- a/tests/parser/tests_IStreamQuadIterator.cpp
+++ b/tests/parser/tests_IStreamQuadIterator.cpp
@@ -51,7 +51,7 @@ TEST_SUITE("IStreamQuadIterator") {
         CHECK(qit != IStreamQuadIterator{});
         CHECK(qit->value().subject() == IRI{"http://www.example.org/s2"});
         CHECK(qit->value().predicate() == IRI{"http://www.example.org/p3"});
-        CHECK(qit->value().object() == Literal{"test"});
+        CHECK(qit->value().object() == Literal::make_simple("test"));
 
         ++qit;
         CHECK(qit == IStreamQuadIterator{});
@@ -70,7 +70,7 @@ TEST_SUITE("IStreamQuadIterator") {
             CHECK(qit != IStreamQuadIterator{});
             CHECK(qit->value().subject() == IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/12"});
             CHECK(qit->value().predicate() == IRI{"http://purl.org/dc/elements/1.1/subject"});
-            CHECK(qit->value().object() == Literal{"search"});
+            CHECK(qit->value().object() == Literal::make_simple("search"));
 
             ++qit;
             CHECK(qit != IStreamQuadIterator{});
@@ -100,7 +100,7 @@ TEST_SUITE("IStreamQuadIterator") {
             CHECK(qit != IStreamQuadIterator{});
             CHECK(qit->value().subject() == IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/12"});
             CHECK(qit->value().predicate() == IRI{"http://purl.org/dc/elements/1.1/subject"});
-            CHECK(qit->value().object() == Literal{"search"});
+            CHECK(qit->value().object() == Literal::make_simple("search"));
 
             ++qit;
             CHECK(qit != IStreamQuadIterator{});
@@ -241,7 +241,7 @@ TEST_SUITE("IStreamQuadIterator") {
         CHECK(qit->has_value());
         CHECK(qit->value() == Quad{IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/12"},
                                    IRI{"https://hello.com#predicate"},
-                                   Literal{"search"}});
+                                   Literal::make_simple("search")});
 
         ++qit;
         CHECK(qit == IStreamQuadIterator{});
@@ -270,7 +270,7 @@ TEST_SUITE("IStreamQuadIterator") {
         CHECK(qit->has_value());
         CHECK(qit->value() == Quad{IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/12"},
                                    IRI{"http://purl.org/dc/elements/1.1/subject"},
-                                   Literal{"search"}});
+                                   Literal::make_simple("search")});
 
         ++qit;
         CHECK(qit != IStreamQuadIterator{});

--- a/tests/parser/tests_IStreamQuadIterator.cpp
+++ b/tests/parser/tests_IStreamQuadIterator.cpp
@@ -148,7 +148,7 @@ TEST_SUITE("IStreamQuadIterator") {
         CHECK(qit != IStreamQuadIterator{});
         CHECK(qit->value() == Quad{IRI{"http://www.w3.org/TR/rdf-syntax-grammar"},
                                    IRI{"http://purl.org/dc/elements/1.1/title"},
-                                   Literal::make<datatypes::xsd::String>("RDF/XML Syntax Specification (Revised)")});
+                                   Literal::make_typed<datatypes::xsd::String>("RDF/XML Syntax Specification (Revised)")});
 
 
         ++qit;
@@ -170,7 +170,7 @@ TEST_SUITE("IStreamQuadIterator") {
         CHECK(qit != IStreamQuadIterator{});
         CHECK(qit->value() == Quad{IRI{"http://www.w3.org/TR/rdf-syntax-grammar"},
                                    IRI{"http://purl.org/dc/elements/1.1/title"},
-                                   Literal::make<datatypes::xsd::String>("RDF/XML Syntax Specification (Revised)")});
+                                   Literal::make_typed<datatypes::xsd::String>("RDF/XML Syntax Specification (Revised)")});
 
         ++qit;
         CHECK(qit != IStreamQuadIterator{});
@@ -182,7 +182,7 @@ TEST_SUITE("IStreamQuadIterator") {
         CHECK(qit != IStreamQuadIterator{});
         CHECK(qit->value() == Quad{BlankNode{"b2"},
                                    IRI{"http://example.org/stuff/1.0/fullname"},
-                                   Literal::make<datatypes::xsd::String>("Dave Beckett")});
+                                   Literal::make_typed<datatypes::xsd::String>("Dave Beckett")});
 
         ++qit;
         CHECK(qit == IStreamQuadIterator{});

--- a/tests/query/tests_QuadPattern.cpp
+++ b/tests/query/tests_QuadPattern.cpp
@@ -92,8 +92,8 @@ TEST_CASE("QuadPattern - Check validity") {
             IRI{"http://example.com/2"},
             BlankNode{"b1"},
             BlankNode{"b2"},
-            Literal{"l1"},
-            Literal{"l2"},
+            Literal::make_simple("l1"),
+            Literal::make_simple("l2"),
             query::Variable{"v1"},
             query::Variable{"v2", true},
     };

--- a/tests/query/tests_TriplePattern.cpp
+++ b/tests/query/tests_TriplePattern.cpp
@@ -148,7 +148,7 @@ TEST_CASE("TriplePattern - Check for variable as subject") {
         }
 
         SUBCASE("Check for literal as object") {
-            auto literal = Literal{"str1"};
+            auto literal = Literal::make_simple("str1");
             auto obj = Node{literal};
 
             validate_triple_pattern(sub, pred, obj, true);
@@ -180,7 +180,7 @@ TEST_CASE("TriplePattern - Check for variable as subject") {
         }
 
         SUBCASE("Check for literal as object") {
-            auto literal = Literal{"str1"};
+            auto literal = Literal::make_simple("str1");
             auto obj = Node{literal};
 
             validate_triple_pattern(sub, pred, obj, true);
@@ -212,14 +212,14 @@ TEST_CASE("TriplePattern - Check for variable as subject") {
         }
 
         SUBCASE("Check for literal as object") {
-            auto literal = Literal{"str1"};
+            auto literal = Literal::make_simple("str1");
             auto obj = Node{literal};
 
             validate_triple_pattern(sub, pred, obj, false);
         }
     }
     SUBCASE("Check for literal as predicate") {
-        auto literal1 = Literal{"name"};
+        auto literal1 = Literal::make_simple("name");
         auto pred = Node{literal1};
 
         SUBCASE("Check for variable as object") {
@@ -244,7 +244,7 @@ TEST_CASE("TriplePattern - Check for variable as subject") {
         }
 
         SUBCASE("Check for literal as object") {
-            auto literal2 = Literal{"str1"};
+            auto literal2 = Literal::make_simple("str1");
             auto obj = Node{literal2};
 
             validate_triple_pattern(sub, pred, obj, false);
@@ -283,7 +283,7 @@ TEST_CASE("TriplePattern - Check for blank node as subject") {
         }
 
         SUBCASE("Check for literal as object") {
-            auto literal = Literal{"str1"};
+            auto literal = Literal::make_simple("str1");
             auto obj = Node{literal};
 
             validate_triple_pattern(sub, pred, obj, true);
@@ -315,7 +315,7 @@ TEST_CASE("TriplePattern - Check for blank node as subject") {
         }
 
         SUBCASE("Check for literal as object") {
-            auto literal = Literal{"str1"};
+            auto literal = Literal::make_simple("str1");
             auto obj = Node{literal};
 
             validate_triple_pattern(sub, pred, obj, true);
@@ -347,14 +347,14 @@ TEST_CASE("TriplePattern - Check for blank node as subject") {
         }
 
         SUBCASE("Check for literal as object") {
-            auto literal = Literal{"str1"};
+            auto literal = Literal::make_simple("str1");
             auto obj = Node{literal};
 
             validate_triple_pattern(sub, pred, obj, false);
         }
     }
     SUBCASE("Check for literal as predicate") {
-        auto literal1 = Literal{"name"};
+        auto literal1 = Literal::make_simple("name");
         auto pred = Node{literal1};
 
         SUBCASE("Check for variable as object") {
@@ -379,7 +379,7 @@ TEST_CASE("TriplePattern - Check for blank node as subject") {
         }
 
         SUBCASE("Check for literal as object") {
-            auto literal2 = Literal{"str1"};
+            auto literal2 = Literal::make_simple("str1");
             auto obj = Node{literal2};
 
             validate_triple_pattern(sub, pred, obj, false);
@@ -418,7 +418,7 @@ TEST_CASE("TriplePattern - Check for iri as subject") {
         }
 
         SUBCASE("Check for literal as object") {
-            auto literal = Literal{"str1"};
+            auto literal = Literal::make_simple("str1");
             auto obj = Node{literal};
 
             validate_triple_pattern(sub, pred, obj, true);
@@ -450,7 +450,7 @@ TEST_CASE("TriplePattern - Check for iri as subject") {
         }
 
         SUBCASE("Check for literal as object") {
-            auto literal = Literal{"str1"};
+            auto literal = Literal::make_simple("str1");
             auto obj = Node{literal};
 
             validate_triple_pattern(sub, pred, obj, true);
@@ -482,14 +482,14 @@ TEST_CASE("TriplePattern - Check for iri as subject") {
         }
 
         SUBCASE("Check for literal as object") {
-            auto literal = Literal{"str1"};
+            auto literal = Literal::make_simple("str1");
             auto obj = Node{literal};
 
             validate_triple_pattern(sub, pred, obj, false);
         }
     }
     SUBCASE("Check for literal as predicate") {
-        auto literal1 = Literal{"name"};
+        auto literal1 = Literal::make_simple("name");
         auto pred = Node{literal1};
 
         SUBCASE("Check for variable as object") {
@@ -514,7 +514,7 @@ TEST_CASE("TriplePattern - Check for iri as subject") {
         }
 
         SUBCASE("Check for literal as object") {
-            auto literal2 = Literal{"str1"};
+            auto literal2 = Literal::make_simple("str1");
             auto obj = Node{literal2};
 
             validate_triple_pattern(sub, pred, obj, false);
@@ -524,7 +524,7 @@ TEST_CASE("TriplePattern - Check for iri as subject") {
 
 TEST_CASE("TriplePattern - Check for literal as subject") {
 
-    auto literal1 = Literal{"str1"};
+    auto literal1 = Literal::make_simple("str1");
     auto sub = Node{literal1};
 
     SUBCASE("Check for variable as predicate") {
@@ -553,7 +553,7 @@ TEST_CASE("TriplePattern - Check for literal as subject") {
         }
 
         SUBCASE("Check for literal as object") {
-            auto literal = Literal{"str1"};
+            auto literal = Literal::make_simple("str1");
             auto obj = Node{literal};
 
             validate_triple_pattern(sub, pred, obj, false);
@@ -585,7 +585,7 @@ TEST_CASE("TriplePattern - Check for literal as subject") {
         }
 
         SUBCASE("Check for literal as object") {
-            auto literal = Literal{"str1"};
+            auto literal = Literal::make_simple("str1");
             auto obj = Node{literal};
 
             validate_triple_pattern(sub, pred, obj, false);
@@ -617,14 +617,14 @@ TEST_CASE("TriplePattern - Check for literal as subject") {
         }
 
         SUBCASE("Check for literal as object") {
-            auto literal = Literal{"str1"};
+            auto literal = Literal::make_simple("str1");
             auto obj = Node{literal};
 
             validate_triple_pattern(sub, pred, obj, false);
         }
     }
     SUBCASE("Check for literal as predicate") {
-        auto literal2 = Literal{"name"};
+        auto literal2 = Literal::make_simple("name");
         auto pred = Node{literal2};
 
         SUBCASE("Check for variable as object") {
@@ -649,7 +649,7 @@ TEST_CASE("TriplePattern - Check for literal as subject") {
         }
 
         SUBCASE("Check for literal as object") {
-            auto literal3 = Literal{"str1"};
+            auto literal3 = Literal::make_simple("str1");
             auto obj = Node{literal3};
 
             validate_triple_pattern(sub, pred, obj, false);


### PR DESCRIPTION
Fixes the constructor ambiguity in `Literal`.
For the sake of uniformeness also added make functions to `Node`, `BlankNode` and `IRI`.