### PR TITLE
Fix: literal misc functions defects

### DIFF
--- a/examples/literal_datatypes.cpp
+++ b/examples/literal_datatypes.cpp
@@ -22,8 +22,8 @@ void lexical_access() {
     Literal lang_string = Literal::make_lang_tagged("Hello", "en-US");
     assert(lang_string.lexical_form() == "Hello");
     assert(lang_string.language_tag() == "en-US");
-    assert(lang_string.lang_matches("*"));
-    assert(lang_string.lang_matches("en"));
+    assert(lang_string.language_tag_matches_range("*"));
+    assert(lang_string.language_tag_matches_range("en"));
     assert(std::string{lang_string} == R"#("Hello"@en-US)#");
 }
 
@@ -57,7 +57,7 @@ void value_transformations() {
     lit = lit.cast<datatypes::xsd::String>();
     assert(lit.value<datatypes::xsd::String>() == "63");
 
-    lit = lit.ebv_as_literal();
+    lit = lit.as_ebv();
     assert(lit.value<datatypes::xsd::Boolean>() == true);
 }
 

--- a/src/rdf4cpp/rdf/Literal.cpp
+++ b/src/rdf4cpp/rdf/Literal.cpp
@@ -354,6 +354,10 @@ bool Literal::is_iri() const noexcept { return false; }
 bool Literal::is_numeric() const noexcept {
     using namespace datatypes::registry;
 
+    if (this->null()) {
+        return false;
+    }
+
     return this->handle_.node_id().literal_type().is_numeric()
            || DatatypeRegistry::get_numerical_ops(this->datatype_id()) != nullptr;
 }

--- a/src/rdf4cpp/rdf/Literal.cpp
+++ b/src/rdf4cpp/rdf/Literal.cpp
@@ -72,14 +72,17 @@ Literal Literal::make_typed_unchecked(std::any const &value, datatypes::registry
 }
 
 Literal Literal::make_string_like_copy_lang_tag(std::string_view str, Literal const &lang_tag_src, Node::NodeStorage &node_storage) noexcept {
-    auto const lt_dt = lang_tag_src.datatype_id();
-
-    if (lt_dt == datatypes::rdf::LangString::datatype_id) {
+    if (lang_tag_src.datatype_eq<datatypes::rdf::LangString>()) {
         return Literal::make_lang_tagged_unchecked(str, lang_tag_src.language_tag(), node_storage);
     }
 
-    assert(lt_dt == datatypes::xsd::String::datatype_id);
+    assert(lang_tag_src.datatype_eq<datatypes::xsd::String>());
     return Literal::make_simple_unchecked(str, node_storage);
+}
+
+bool Literal::dynamic_datatype_eq_impl(std::string_view datatype) const noexcept {
+    assert(!this->is_fixed());
+    return this->datatype().identifier() == datatype;
 }
 
 Literal Literal::make_simple(std::string_view lexical_form, Node::NodeStorage &node_storage) {
@@ -148,12 +151,36 @@ Literal Literal::to_node_storage(Node::NodeStorage &node_storage) const noexcept
     return Literal{NodeBackendHandle{new_lit_id, storage::node::identifier::RDFNodeType::Literal, node_storage.id()}};
 }
 
-bool Literal::datatype_matches(IRI const &datatype) const noexcept {
+bool Literal::datatype_eq(IRI const &datatype) const noexcept {
     return this->datatype_id() == datatypes::registry::DatatypeIDView{datatype};
 }
 
-bool Literal::datatype_matches(Literal const &other) const noexcept {
-    return this->datatype_id() == other.datatype_id();
+bool Literal::datatype_eq(Literal const &other) const noexcept {
+    if (auto const this_type = this->handle_.node_id().literal_type(); this_type.is_fixed()) {
+        if (auto const other_type = other.handle_.node_id().literal_type(); other_type.is_fixed()) {
+            return this_type == other_type;
+        }
+
+        return false;
+    }
+
+    return this->datatype() == other.datatype();
+}
+
+Literal Literal::as_datatype_eq(IRI const &datatype, NodeStorage &node_storage) const noexcept {
+    if (this->null()) {
+        return Literal{};
+    }
+
+    return Literal::make_boolean(this->datatype_eq(datatype), node_storage);
+}
+
+Literal Literal::as_datatype_eq(Literal const &other, NodeStorage &node_storage) const noexcept {
+    if (this->null() || other.null()) {
+        return Literal{};
+    }
+
+    return Literal::make_boolean(this->datatype_eq(other), node_storage);
 }
 
 IRI Literal::datatype() const noexcept {
@@ -213,11 +240,51 @@ Literal Literal::as_simplified_lexical_form(NodeStorage &node_storage) const noe
 }
 
 std::string_view Literal::language_tag() const noexcept {
-    if (this->datatype_id() == datatypes::rdf::LangString::datatype_id) {
+    if (this->datatype_eq<datatypes::rdf::LangString>()) {
         return handle_.literal_backend().language_tag;
     }
 
     return "";
+}
+
+Literal Literal::as_language_tag(Node::NodeStorage &node_storage) const noexcept {
+    if (this->null()) {
+        return Literal{};
+    }
+
+    return Literal::make_simple_unchecked(this->language_tag(), node_storage);
+}
+
+util::TriBool Literal::language_tag_eq(std::string_view const lang_tag) const noexcept {
+    if (!this->datatype_eq<datatypes::rdf::LangString>()) {
+        return util::TriBool::Err;
+    }
+
+    return this->language_tag() == lang_tag;
+}
+
+util::TriBool Literal::language_tag_eq(Literal const &other) const noexcept {
+    if (!this->datatype_eq<datatypes::rdf::LangString>() || !other.datatype_eq<datatypes::rdf::LangString>()) {
+        return util::TriBool::Err;
+    }
+
+    return this->language_tag() == other.language_tag();
+}
+
+Literal Literal::as_language_tag_eq(std::string_view const lang_tag, Node::NodeStorage &node_storage) const noexcept {
+    if (this->null()) {
+        return Literal{};
+    }
+
+    return Literal::make_boolean(this->language_tag_eq(lang_tag), node_storage);
+}
+
+Literal Literal::as_language_tag_eq(Literal const &other, Node::NodeStorage &node_storage) const noexcept {
+    if (this->null() || other.null()) {
+        return Literal{};
+    }
+
+    return Literal::make_boolean(this->language_tag_eq(other), node_storage);
 }
 
 Literal::operator std::string() const noexcept {
@@ -266,7 +333,7 @@ Literal::operator std::string() const noexcept {
         auto const &literal = handle_.literal_backend();
         quoted_lexical_into_stream(oss, literal.lexical_form);
 
-        if (this->datatype_id() == datatypes::rdf::LangString::datatype_id) {
+        if (this->datatype_eq<datatypes::rdf::LangString>()) {
             if (!literal.language_tag.empty()) {
                 oss << "@" << literal.language_tag;
             }
@@ -354,7 +421,7 @@ Literal Literal::cast(IRI const &target, Node::NodeStorage &node_storage) const 
 
     if (target_dtid == Boolean::datatype_id) {
         // any -> bool
-        return this->ebv_as_literal(node_storage);
+        return this->as_ebv(node_storage);
     }
 
     auto const *target_e = DatatypeRegistry::get_entry(target_dtid);
@@ -646,12 +713,20 @@ util::TriBool Literal::eq(Literal const &other) const noexcept {
     return util::partial_weak_ordering_eq(this->compare(other), std::weak_ordering::equivalent);
 }
 
+Literal Literal::as_eq(Literal const &other, NodeStorage &node_storage) const noexcept {
+    return Literal::make_boolean(this->eq(other), node_storage);
+}
+
 util::TriBool Literal::operator==(Literal const &other) const noexcept {
     return this->eq(other);
 }
 
 util::TriBool Literal::ne(Literal const &other) const noexcept {
     return !util::partial_weak_ordering_eq(this->compare(other), std::weak_ordering::equivalent);
+}
+
+Literal Literal::as_ne(Literal const &other, NodeStorage &node_storage) const noexcept {
+    return Literal::make_boolean(this->ne(other), node_storage);
 }
 
 util::TriBool Literal::operator!=(Literal const &other) const noexcept {
@@ -662,12 +737,20 @@ util::TriBool Literal::lt(Literal const &other) const noexcept {
     return util::partial_weak_ordering_eq(this->compare(other), std::weak_ordering::less);
 }
 
+Literal Literal::as_lt(Literal const &other, NodeStorage &node_storage) const noexcept {
+    return Literal::make_boolean(this->lt(other), node_storage);
+}
+
 util::TriBool Literal::operator<(Literal const &other) const noexcept {
     return this->lt(other);
 }
 
 util::TriBool Literal::le(Literal const &other) const noexcept {
     return !util::partial_weak_ordering_eq(this->compare(other), std::weak_ordering::greater);
+}
+
+Literal Literal::as_le(Literal const &other, NodeStorage &node_storage) const noexcept {
+    return Literal::make_boolean(this->le(other), node_storage);
 }
 
 util::TriBool Literal::operator<=(Literal const &other) const noexcept {
@@ -678,12 +761,20 @@ util::TriBool Literal::gt(Literal const &other) const noexcept {
     return util::partial_weak_ordering_eq(this->compare(other), std::weak_ordering::greater);
 }
 
+Literal Literal::as_gt(Literal const &other, NodeStorage &node_storage) const noexcept {
+    return Literal::make_boolean(this->gt(other), node_storage);
+}
+
 util::TriBool Literal::operator>(Literal const &other) const noexcept {
     return this->gt(other);
 }
 
 util::TriBool Literal::ge(Literal const &other) const noexcept {
     return !util::partial_weak_ordering_eq(this->compare(other), std::weak_ordering::less);
+}
+
+Literal Literal::as_ge(Literal const &other, NodeStorage &node_storage) const noexcept {
+    return Literal::make_boolean(this->ge(other), node_storage);
 }
 
 util::TriBool Literal::operator>=(Literal const &other) const noexcept {
@@ -694,24 +785,48 @@ bool Literal::eq_with_extensions(Literal const &other) const noexcept {
     return this->compare_with_extensions(other) == std::weak_ordering::equivalent;
 }
 
+Literal Literal::as_eq_with_extensions(Literal const &other, NodeStorage &node_storage) const noexcept {
+    return Literal::make_boolean(this->eq_with_extensions(other), node_storage);
+}
+
 bool Literal::ne_with_extensions(Literal const &other) const noexcept {
     return this->compare_with_extensions(other) != std::weak_ordering::equivalent;
+}
+
+Literal Literal::as_ne_with_extensions(Literal const &other, NodeStorage &node_storage) const noexcept {
+    return Literal::make_boolean(this->ne_with_extensions(other), node_storage);
 }
 
 bool Literal::lt_with_extensions(Literal const &other) const noexcept {
     return this->compare_with_extensions(other) == std::weak_ordering::less;
 }
 
+Literal Literal::as_lt_with_extensions(Literal const &other, NodeStorage &node_storage) const noexcept {
+    return Literal::make_boolean(this->lt_with_extensions(other), node_storage);
+}
+
 bool Literal::le_with_extensions(Literal const &other) const noexcept {
     return this->compare_with_extensions(other) != std::weak_ordering::greater;
+}
+
+Literal Literal::as_le_with_extensions(Literal const &other, NodeStorage &node_storage) const noexcept {
+    return Literal::make_boolean(this->le_with_extensions(other), node_storage);
 }
 
 bool Literal::gt_with_extensions(Literal const &other) const noexcept {
     return this->compare_with_extensions(other) == std::weak_ordering::greater;
 }
 
+Literal Literal::as_gt_with_extensions(Literal const &other, NodeStorage &node_storage) const noexcept {
+    return Literal::make_boolean(this->gt_with_extensions(other), node_storage);
+}
+
 bool Literal::ge_with_extensions(Literal const &other) const noexcept {
     return this->compare_with_extensions(other) != std::weak_ordering::less;
+}
+
+Literal Literal::as_ge_with_extensions(Literal const &other, NodeStorage &node_storage) const noexcept {
+    return Literal::make_boolean(this->ge_with_extensions(other), node_storage);
 }
 
 datatypes::registry::DatatypeIDView Literal::datatype_id() const noexcept {
@@ -740,12 +855,12 @@ bool Literal::is_fixed_not_numeric() const noexcept {
 }
 
 bool Literal::is_string_like() const noexcept {
-    if (this->null()) {
+    auto const type = this->handle_.node_id().literal_type();
+    if (!type.is_fixed()) {
         return false;
     }
 
-    auto const dt = this->datatype_id();
-    return dt == datatypes::xsd::String::datatype_id || dt == datatypes::rdf::LangString::datatype_id;
+    return type == datatypes::xsd::String::fixed_id || type == datatypes::rdf::LangString::fixed_id;
 }
 
 Literal Literal::add(Literal const &other, Node::NodeStorage &node_storage) const noexcept {
@@ -846,7 +961,7 @@ util::TriBool Literal::ebv() const noexcept {
     return ebv(this->value()) ? util::TriBool::True : util::TriBool::False;
 }
 
-Literal Literal::ebv_as_literal(NodeStorage &node_storage) const noexcept {
+Literal Literal::as_ebv(NodeStorage &node_storage) const noexcept {
     return Literal::make_boolean(this->ebv(), node_storage);
 }
 
@@ -888,6 +1003,10 @@ std::optional<size_t> Literal::strlen() const noexcept {
 }
 
 Literal Literal::as_strlen(Node::NodeStorage &node_storage) const noexcept {
+    if (this->null()) {
+        return Literal{};
+    }
+
     auto const len = this->strlen();
     if (!len.has_value()) {
         return Literal{};
@@ -896,38 +1015,34 @@ Literal Literal::as_strlen(Node::NodeStorage &node_storage) const noexcept {
     return Literal::make_typed_from_value<datatypes::xsd::Integer>(datatypes::xsd::Integer::cpp_type{*len}, node_storage);
 }
 
-util::TriBool Literal::lang_matches(std::string_view const lang_range) const noexcept {
+util::TriBool Literal::language_tag_matches_range(std::string_view const lang_range) const noexcept {
     if (!this->is_string_like()) {
         return util::TriBool::Err;
     }
 
-    auto const lang = this->language_tag();
-
-    if (lang_range.empty()) {
-        return lang.empty();
-    }
-
-    if (lang_range == "*") {
-        return !lang.empty();
-    }
-
-    auto const lang_ci = util::CiStringView{lang.data(), lang.size()};
-    auto const lang_range_ci = util::CiStringView{lang_range.data(), lang_range.size()};
-
-    return lang_ci.starts_with(lang_range_ci) && (lang_ci.size() == lang_range_ci.size() || lang_ci[lang_range_ci.size()] == '-');
+    return lang_matches(this->language_tag(), lang_range);
 }
 
-Literal Literal::as_lang_matches(std::string_view const lang_range, Node::NodeStorage &node_storage) const noexcept {
-    auto const res = this->lang_matches(lang_range);
-    return Literal::make_boolean(res, node_storage);
-}
-
-Literal Literal::as_lang_matches(Literal const &lang_range, Node::NodeStorage &node_storage) const noexcept {
-    if (lang_range.datatype_id() != datatypes::xsd::String::datatype_id) {
+Literal Literal::as_language_tag_matches_range(std::string_view lang_range, Node::NodeStorage &node_storage) const noexcept {
+    if (this->null()) {
         return Literal{};
     }
 
-    return this->as_lang_matches(lang_range.lexical_form(), node_storage);
+    auto const res = this->language_tag_matches_range(lang_range);
+    return Literal::make_boolean(res, node_storage);
+}
+
+Literal Literal::as_language_tag_matches_range(Literal const &lang_range, Node::NodeStorage &node_storage) const noexcept {
+    if (this->null()) {
+        return Literal{};
+    }
+
+    if (!lang_range.datatype_eq<datatypes::xsd::String>()) {
+        return Literal{};
+    }
+
+    auto const res = this->language_tag_matches_range(lang_range.lexical_form());
+    return Literal::make_boolean(res, node_storage);
 }
 
 static regex::Regex::flag_type translate_regex_flags(std::string_view const xpath_flags) {
@@ -954,16 +1069,24 @@ util::TriBool Literal::regex_matches(regex::Regex const &pattern) const noexcept
 }
 
 Literal Literal::as_regex_matches(regex::Regex const &pattern, Node::NodeStorage &node_storage) const noexcept {
+    if (this->null()) {
+        return Literal{};
+    }
+
     auto const res = this->regex_matches(pattern);
     return Literal::make_boolean(res, node_storage);
 }
 
 Literal Literal::as_regex_matches(Literal const &pattern, Literal const &flags, Node::NodeStorage &node_storage) const noexcept {
+    if (this->null()) {
+        return Literal{};
+    }
+
     if (!this->is_string_like() || !pattern.is_string_like() || !flags.is_string_like()) {
         return Literal{};
     }
 
-    if (pattern.datatype_id() == datatypes::rdf::LangString::datatype_id && this->language_tag() != pattern.language_tag()) {
+    if (pattern.datatype_eq<datatypes::rdf::LangString>() && this->language_tag() != pattern.language_tag()) {
         return Literal{};
     }
 
@@ -980,7 +1103,8 @@ Literal Literal::as_regex_matches(Literal const &pattern, Literal const &flags, 
         return Literal{};
     }
 
-    return this->as_regex_matches(*re, node_storage);
+    auto const res = this->regex_matches(*re);
+    return Literal::make_boolean(res, node_storage);
 }
 
 Literal Literal::regex_replace(regex::RegexReplacer const &replacer, Node::NodeStorage &node_storage) const noexcept {
@@ -999,7 +1123,7 @@ Literal Literal::regex_replace(Literal const &pattern, Literal const &replacemen
         return Literal{};
     }
 
-    if (pattern.datatype_id() == datatypes::rdf::LangString::datatype_id && this->language_tag() != pattern.language_tag()) {
+    if (pattern.datatype_eq<datatypes::rdf::LangString>() && this->language_tag() != pattern.language_tag()) {
         return Literal{};
     }
 
@@ -1041,16 +1165,25 @@ util::TriBool Literal::contains(std::string_view const needle) const noexcept {
 }
 
 Literal Literal::as_contains(std::string_view const needle, Node::NodeStorage &node_storage) const noexcept {
+    if (this->null()) {
+        return Literal{};
+    }
+
     auto const res = this->contains(needle);
     return Literal::make_boolean(res, node_storage);
 }
 
 Literal Literal::as_contains(Literal const &needle, Node::NodeStorage &node_storage) const noexcept {
-    if (needle.datatype_id() == datatypes::rdf::LangString::datatype_id && this->language_tag() != needle.language_tag()) {
+    if (this->null()) {
         return Literal{};
     }
 
-    return this->as_contains(needle.lexical_form(), node_storage);
+    if (needle.datatype_eq<datatypes::rdf::LangString>() && this->language_tag() != needle.language_tag()) {
+        return Literal{};
+    }
+
+    auto const res = this->contains(needle.lexical_form());
+    return Literal::make_boolean(res, node_storage);
 }
 
 Literal Literal::substr_before(std::string_view const needle, Node::NodeStorage &node_storage) const noexcept {
@@ -1074,7 +1207,7 @@ Literal Literal::substr_before(std::string_view const needle, Node::NodeStorage 
 }
 
 Literal Literal::substr_before(Literal const &needle, Node::NodeStorage &node_storage) const noexcept {
-    if (needle.datatype_id() == datatypes::rdf::LangString::datatype_id && this->language_tag() != needle.language_tag()) {
+    if (needle.datatype_eq<datatypes::rdf::LangString>() && this->language_tag() != needle.language_tag()) {
         return Literal{};
     }
 
@@ -1102,7 +1235,7 @@ Literal Literal::substr_after(std::string_view const needle, Node::NodeStorage &
 }
 
 Literal Literal::substr_after(Literal const &needle, Node::NodeStorage &node_storage) const noexcept {
-    if (needle.datatype_id() == datatypes::rdf::LangString::datatype_id && this->language_tag() != needle.language_tag()) {
+    if (needle.datatype_eq<datatypes::rdf::LangString>() && this->language_tag() != needle.language_tag()) {
         return Literal{};
     }
 
@@ -1119,20 +1252,29 @@ util::TriBool Literal::str_starts_with(std::string_view const needle) const noex
 }
 
 Literal Literal::as_str_starts_with(std::string_view const needle, Node::NodeStorage &node_storage) const noexcept {
+    if (this->null()) {
+        return Literal{};
+    }
+
     auto const res = this->str_starts_with(needle);
     return Literal::make_boolean(res, node_storage);
 }
 
 Literal Literal::as_str_starts_with(Literal const &needle, Node::NodeStorage &node_storage) const noexcept {
+    if (this->null()) {
+        return Literal{};
+    }
+
     if (!needle.is_string_like()) {
         return Literal{};
     }
 
-    if (needle.datatype_id() == datatypes::rdf::LangString::datatype_id && this->language_tag() != needle.language_tag()) {
+    if (needle.datatype_eq<datatypes::rdf::LangString>() && this->language_tag() != needle.language_tag()) {
         return Literal{};
     }
 
-    return this->as_str_starts_with(needle.lexical_form(), node_storage);
+    auto const res = this->str_starts_with(needle.lexical_form());
+    return Literal::make_boolean(res, node_storage);
 }
 
 util::TriBool Literal::str_ends_with(std::string_view const needle) const noexcept {
@@ -1145,20 +1287,29 @@ util::TriBool Literal::str_ends_with(std::string_view const needle) const noexce
 }
 
 Literal Literal::as_str_ends_with(std::string_view const needle, Node::NodeStorage &node_storage) const noexcept {
+    if (this->null()) {
+        return Literal{};
+    }
+
     auto const res = this->str_ends_with(needle);
     return Literal::make_boolean(res, node_storage);
 }
 
 Literal Literal::as_str_ends_with(Literal const &needle, Node::NodeStorage &node_storage) const noexcept {
+    if (this->null()) {
+        return Literal{};
+    }
+
     if (!needle.is_string_like()) {
         return Literal{};
     }
 
-    if (needle.datatype_id() == datatypes::rdf::LangString::datatype_id && this->language_tag() != needle.language_tag()) {
+    if (needle.datatype_eq<datatypes::rdf::LangString>() && this->language_tag() != needle.language_tag()) {
         return Literal{};
     }
 
-    return this->as_str_ends_with(needle.lexical_form(), node_storage);
+    auto const res = this->str_ends_with(needle.lexical_form());
+    return Literal::make_boolean(res, node_storage);
 }
 
 Literal Literal::uppercase(Node::NodeStorage &node_storage) const noexcept {
@@ -1192,13 +1343,10 @@ Literal Literal::concat(Literal const &other, Node::NodeStorage &node_storage) c
         return Literal{};
     }
 
-    auto const this_dt = this->datatype_id();
-    auto const other_dt = other.datatype_id();
-
     std::ostringstream combined;
     combined << this->lexical_form() << other.lexical_form();
 
-    if (this_dt == datatypes::rdf::LangString::datatype_id && other_dt == datatypes::rdf::LangString::datatype_id) {
+    if (this->datatype_eq<datatypes::rdf::LangString>() && other.datatype_eq<datatypes::rdf::LangString>()) {
         if (auto const lang = this->language_tag(); lang == other.language_tag())  {
             return Literal::make_lang_tagged_unchecked(combined.view(), lang, node_storage);
         }
@@ -1260,6 +1408,33 @@ Literal Literal::substr(Literal const &start, Literal const &len, Node::NodeStor
     return this->substr(start_ix, len_ix, node_storage);
 }
 
+bool lang_matches(std::string_view const lang_tag, std::string_view const lang_range) noexcept {
+    if (lang_range.empty()) {
+        return lang_tag.empty();
+    }
+
+    if (lang_range == "*") {
+        return !lang_tag.empty();
+    }
+
+    auto const lang_ci = util::CiStringView{lang_tag.data(), lang_tag.size()};
+    auto const lang_range_ci = util::CiStringView{lang_range.data(), lang_range.size()};
+
+    return lang_ci.starts_with(lang_range_ci) && (lang_ci.size() == lang_range_ci.size() || lang_ci[lang_range_ci.size()] == '-');
+}
+
+Literal lang_matches(Literal const &lang_tag, Literal const &lang_range, storage::node::NodeStorage &node_storage) noexcept {
+    if (lang_tag.null() || lang_range.null()) {
+        return Literal{};
+    }
+
+    if (!lang_tag.datatype_eq<datatypes::xsd::String>() || !lang_range.datatype_eq<datatypes::xsd::String>()) {
+        return Literal{};
+    }
+
+    auto const res = lang_matches(lang_tag.lexical_form(), lang_range.lexical_form());
+    return Literal::make_boolean(res, node_storage);
+}
 
 inline namespace shorthands {
 

--- a/src/rdf4cpp/rdf/Literal.cpp
+++ b/src/rdf4cpp/rdf/Literal.cpp
@@ -1420,6 +1420,7 @@ bool lang_matches(std::string_view const lang_tag, std::string_view const lang_r
     auto const lang_ci = util::CiStringView{lang_tag.data(), lang_tag.size()};
     auto const lang_range_ci = util::CiStringView{lang_range.data(), lang_range.size()};
 
+    // case-insensitive comparison
     return lang_ci.starts_with(lang_range_ci) && (lang_ci.size() == lang_range_ci.size() || lang_ci[lang_range_ci.size()] == '-');
 }
 

--- a/src/rdf4cpp/rdf/Literal.hpp
+++ b/src/rdf4cpp/rdf/Literal.hpp
@@ -15,6 +15,16 @@
 #include <rdf4cpp/rdf/util/CowString.hpp>
 
 namespace rdf4cpp::rdf {
+
+/**
+ * An RDF Literal.
+ *
+ * Functions behave based on the following rules:
+ * - public transformation functions (i.e. Literal -> Literal functions, that are usually called as_*) check for null and return back a null literal
+ * - public is_* functions check for null and return an appropriate value for null-literals
+ * - other public functions (i.e. Literal -> non-Literal) usually do not check for null (e.g. Literal::lexical_form),
+ *      but if the null-Literal has a meaningful value for that function it will behave correctly (e.g. for null-Literal <=> non-null-Literal)
+ */
 class Literal : public Node {
 private:
     /**

--- a/src/rdf4cpp/rdf/Literal.hpp
+++ b/src/rdf4cpp/rdf/Literal.hpp
@@ -122,6 +122,17 @@ private:
      */
     [[nodiscard]] static Literal make_string_like_copy_lang_tag(std::string_view str, Literal const &lang_tag_src, NodeStorage &node_storage) noexcept;
 
+    /**
+     * Checks if the dynamic datatype of this is equal to datatype
+     * @warning must only be called if this has dynamic datatype
+     *
+     * @param datatype datatype to check against
+     * @return true iff this dynamic datatype matches datatype
+     *
+     * @note this function only exists because IRI is an incomplete type in this header
+     *      which prevents the template version of datatype_eq from using IRIs
+     */
+    [[nodiscard]] bool dynamic_datatype_eq_impl(std::string_view datatype) const noexcept;
 protected:
     explicit Literal(Node::NodeBackendHandle handle) noexcept;
 
@@ -165,28 +176,28 @@ public:
     /**
      * Constructs a Literal from a lexical form and a datatype provided as a template parameter.
      * @tparam lexical_form the lexical form
-     * @param LiteralDatatype_t the datatype
+     * @param T the datatype
      * @param node_storage optional custom node_storage used to store the literal
      */
-    template<datatypes::LiteralDatatype LiteralDatatype_t>
+    template<datatypes::LiteralDatatype T>
     [[nodiscard]] static Literal make_typed(std::string_view lexical_form,
                                             NodeStorage &node_storage = NodeStorage::default_instance()) {
 
-        if constexpr (std::is_same_v<LiteralDatatype_t, datatypes::rdf::LangString>) {
+        if constexpr (std::is_same_v<T, datatypes::rdf::LangString>) {
             // see: https://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal
             throw std::invalid_argument{"cannot construct rdf:langString without a language tag, please call one of the other factory functions"};
         }
 
-        auto const value = LiteralDatatype_t::from_string(lexical_form);
+        auto const value = T::from_string(lexical_form);
 
-        if constexpr (datatypes::IsInlineable<LiteralDatatype_t>) {
-            if (auto const maybe_inlined = LiteralDatatype_t::try_into_inlined(value); maybe_inlined.has_value()) {
-                return Literal::make_inlined_typed_unchecked(*maybe_inlined, LiteralDatatype_t::datatype_id.get_fixed(), node_storage);
+        if constexpr (datatypes::IsInlineable<T>) {
+            if (auto const maybe_inlined = T::try_into_inlined(value); maybe_inlined.has_value()) {
+                return Literal::make_inlined_typed_unchecked(*maybe_inlined, T::datatype_id.get_fixed(), node_storage);
             }
         }
 
-        return Literal::make_noninlined_typed_unchecked(LiteralDatatype_t::to_canonical_string(value),
-                                                        IRI{LiteralDatatype_t::datatype_id, node_storage},
+        return Literal::make_noninlined_typed_unchecked(T::to_canonical_string(value),
+                                                        IRI{T::datatype_id, node_storage},
                                                         node_storage);
     }
 
@@ -195,29 +206,29 @@ public:
      * No runtime lookup of the type information is required.
      * If type information is available at compile time, you should use this version of the function.
      *
-     * @tparam LiteralDatatype_t the datatype
+     * @tparam T the datatype
      * @param compatible_value instance for which the literal is created
      * @param node_storage NodeStorage used
      * @return literal instance representing compatible_value
      */
-    template<datatypes::LiteralDatatype LiteralDatatype_t>
-    [[nodiscard]] static Literal make_typed_from_value(typename LiteralDatatype_t::cpp_type const &compatible_value,
+    template<datatypes::LiteralDatatype T>
+    [[nodiscard]] static Literal make_typed_from_value(typename T::cpp_type const &compatible_value,
                                                        NodeStorage &node_storage = NodeStorage::default_instance()) noexcept {
 
-        if constexpr (std::is_same_v<LiteralDatatype_t, datatypes::rdf::LangString>) {
+        if constexpr (std::is_same_v<T, datatypes::rdf::LangString>) {
             return Literal::make_lang_tagged_unchecked(compatible_value.lexical_form,
                                                        compatible_value.language_tag,
                                                        node_storage);
         }
 
-        if constexpr (datatypes::IsInlineable<LiteralDatatype_t>) {
-            if (auto const maybe_inlined = LiteralDatatype_t::try_into_inlined(compatible_value); maybe_inlined.has_value()) {
-                return Literal::make_inlined_typed_unchecked(*maybe_inlined, LiteralDatatype_t::datatype_id.get_fixed(), node_storage);
+        if constexpr (datatypes::IsInlineable<T>) {
+            if (auto const maybe_inlined = T::try_into_inlined(compatible_value); maybe_inlined.has_value()) {
+                return Literal::make_inlined_typed_unchecked(*maybe_inlined, T::datatype_id.get_fixed(), node_storage);
             }
         }
 
-        return Literal::make_noninlined_typed_unchecked(LiteralDatatype_t::to_canonical_string(compatible_value),
-                                                        IRI{LiteralDatatype_t::datatype_id, node_storage},
+        return Literal::make_noninlined_typed_unchecked(T::to_canonical_string(compatible_value),
+                                                        IRI{T::datatype_id, node_storage},
                                                         node_storage);
     }
 
@@ -249,8 +260,16 @@ public:
      * @return true iff this datatype is T
      */
     template<datatypes::LiteralDatatype T>
-    [[nodiscard]] bool datatype_matches() const noexcept {
-        return this->datatype_id() == T::datatype_id;
+    [[nodiscard]] bool datatype_eq() const noexcept {
+        if constexpr (datatypes::HasFixedId<T>) {
+            if (auto const type = this->handle_.node_id().literal_type(); type.is_fixed()) {
+                return type == T::fixed_id;
+            }
+
+            return false;
+        }
+
+        return this->dynamic_datatype_eq_impl(T::identifier);
     }
 
     /**
@@ -260,7 +279,7 @@ public:
      * @param datatype the datatype to compare against
      * @return true iff this datatype is datatype
      */
-    [[nodiscard]] bool datatype_matches(IRI const &datatype) const noexcept;
+    [[nodiscard]] bool datatype_eq(IRI const &datatype) const noexcept;
 
     /**
      * Checks if the datatype of this matches the datatype of other
@@ -269,7 +288,41 @@ public:
      * @param other other literal to check against
      * @return true iff this' datatype matches other's datatype
      */
-    [[nodiscard]] bool datatype_matches(Literal const &other) const noexcept;
+    [[nodiscard]] bool datatype_eq(Literal const &other) const noexcept;
+
+    /**
+     * Checks if the datatype of this matches the provided LiteralDatatype
+     * @note You should prefer this function over comparing datatypes using Literal::datatype
+     *
+     * @tparam T the datatype to compare against
+     * @return true as xsd:boolean iff this datatype is T or null-literal if this is null
+     */
+    template<datatypes::LiteralDatatype T>
+    [[nodiscard]] Literal as_datatype_eq(NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept {
+        if (this->null()) {
+            return Literal{};
+        }
+
+        return Literal::make_boolean(this->datatype_eq<T>(), node_storage);
+    }
+
+    /**
+     * Checks if the datatype of this matches the given IRI
+     * @note You should prefer this function over comparing datatypes using Literal::datatype
+     *
+     * @param datatype the datatype to compare against
+     * @return true as xsd:boolean iff this datatype is datatype or null-literal if this is null
+     */
+    [[nodiscard]] Literal as_datatype_eq(IRI const &datatype, NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
+
+    /**
+     * Checks if the datatype of this matches the datatype of other
+     * @note You should prefer this function over comparing datatypes using Literal::datatype
+     *
+     * @param other other literal to check against
+     * @return true as xsd:boolean iff this' datatype matches other's datatype or null-literal if this or other is null
+     */
+    [[nodiscard]] Literal as_datatype_eq(Literal const &other, NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
 
     /**
      * Tries to cast this literal to a literal of the given type IRI.
@@ -283,9 +336,9 @@ public:
     /**
      * Identical to Literal::cast except with compile time specified target type.
      */
-    template<datatypes::LiteralDatatype LiteralDatatype_t>
+    template<datatypes::LiteralDatatype T>
     [[nodiscard]] Literal cast(NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept {
-        return this->cast(IRI{LiteralDatatype_t::datatype_id, node_storage}, node_storage);
+        return this->cast(IRI{T::datatype_id, node_storage}, node_storage);
     }
 
     /**
@@ -327,6 +380,40 @@ public:
      */
     [[nodiscard]] std::string_view language_tag() const noexcept;
 
+    /**
+     * @return the language tag of this Literal as xsd:string. If the string is empty this has no lanugage tag.
+     */
+    [[nodiscard]] Literal as_language_tag(NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
+
+    /**
+     * @param lang_tag language tag to compare against
+     * @return if this->language_tag() == lang_tag or error if this is not langString
+     */
+    [[nodiscard]] util::TriBool language_tag_eq(std::string_view lang_tag) const noexcept;
+
+    /**
+     * @param other literal to compare against
+     * @return if this->language_tag() == other.language_tag() or error if:
+     *      - this is not rdf:langString
+     *      - other is not rdf:langString
+     */
+    [[nodiscard]] util::TriBool language_tag_eq(Literal const &other) const noexcept;
+
+    /**
+     * @param lang_tag language tag to compare against
+     * @return if this->language_tag() == lang_tag or null-literal if this is not langString
+     */
+    [[nodiscard]] Literal as_language_tag_eq(std::string_view lang_tag, NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
+
+    /**
+     * @param other literal to compare against
+     * @return if this->language_tag() == other.language_tag() or null-literal if:
+     *      - this is not rdf:langString
+     *      - other is not rdf:langString
+     */
+    [[nodiscard]] Literal as_language_tag_eq(Literal const &other, NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
+
+
     [[nodiscard]] explicit operator std::string() const noexcept;
 
     friend std::ostream &operator<<(std::ostream &os, const Literal &literal);
@@ -342,20 +429,20 @@ public:
      * @tparam T datatype of the returned instance
      * @return T instance with the value from this
      */
-    template<datatypes::LiteralDatatype LiteralDatatype_t>
-    typename LiteralDatatype_t::cpp_type value() const {
-        if (this->datatype_id() != LiteralDatatype_t::datatype_id) [[unlikely]] {
+    template<datatypes::LiteralDatatype T>
+    typename T::cpp_type value() const {
+        if (!this->datatype_eq<T>()) [[unlikely]] {
             throw std::runtime_error{"Literal::value error: incompatible type"};
         }
 
-        if constexpr (datatypes::IsInlineable<LiteralDatatype_t>) {
+        if constexpr (datatypes::IsInlineable<T>) {
             if (this->is_inlined()) {
                 auto const inlined_value = this->handle_.node_id().literal_id().value;
-                return LiteralDatatype_t::from_inlined(inlined_value);
+                return T::from_inlined(inlined_value);
             }
         }
 
-        if constexpr (std::is_same_v<LiteralDatatype_t, datatypes::rdf::LangString>) {
+        if constexpr (std::is_same_v<T, datatypes::rdf::LangString>) {
             auto const &lit = this->handle_.literal_backend();
 
             return datatypes::registry::LangStringRepr{
@@ -363,7 +450,7 @@ public:
                     .language_tag = lit.language_tag};
         }
 
-        return LiteralDatatype_t::from_string(this->lexical_form());
+        return T::from_string(this->lexical_form());
     }
 
     [[nodiscard]] bool is_literal() const noexcept;
@@ -399,29 +486,41 @@ public:
     [[nodiscard]] std::weak_ordering compare_with_extensions(Literal const &other) const noexcept;
 
     [[nodiscard]] util::TriBool eq(Literal const &other) const noexcept;
+    [[nodiscard]] Literal as_eq(Literal const &other, NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
     util::TriBool operator==(Literal const &other) const noexcept;
 
     [[nodiscard]] util::TriBool ne(Literal const &other) const noexcept;
+    [[nodiscard]] Literal as_ne(Literal const &other, NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
     util::TriBool operator!=(Literal const &other) const noexcept;
 
     [[nodiscard]] util::TriBool lt(Literal const &other) const noexcept;
+    [[nodiscard]] Literal as_lt(Literal const &other, NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
     util::TriBool operator<(Literal const &other) const noexcept;
 
     [[nodiscard]] util::TriBool le(Literal const &other) const noexcept;
+    [[nodiscard]] Literal as_le(Literal const &other, NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
     util::TriBool operator<=(Literal const &other) const noexcept;
 
     [[nodiscard]] util::TriBool gt(Literal const &other) const noexcept;
+    [[nodiscard]] Literal as_gt(Literal const &other, NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
     util::TriBool operator>(Literal const &other) const noexcept;
 
     [[nodiscard]] util::TriBool ge(Literal const &other) const noexcept;
+    [[nodiscard]] Literal as_ge(Literal const &other, NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
     util::TriBool operator>=(Literal const &other) const noexcept;
 
     [[nodiscard]] bool eq_with_extensions(Literal const &other) const noexcept;
+    [[nodiscard]] Literal as_eq_with_extensions(Literal const &other, NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
     [[nodiscard]] bool ne_with_extensions(Literal const &other) const noexcept;
+    [[nodiscard]] Literal as_ne_with_extensions(Literal const &other, NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
     [[nodiscard]] bool lt_with_extensions(Literal const &other) const noexcept;
+    [[nodiscard]] Literal as_lt_with_extensions(Literal const &other, NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
     [[nodiscard]] bool le_with_extensions(Literal const &other) const noexcept;
+    [[nodiscard]] Literal as_le_with_extensions(Literal const &other, NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
     [[nodiscard]] bool gt_with_extensions(Literal const &other) const noexcept;
+    [[nodiscard]] Literal as_gt_with_extensions(Literal const &other, NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
     [[nodiscard]] bool ge_with_extensions(Literal const &other) const noexcept;
+    [[nodiscard]] Literal as_ge_with_extensions(Literal const &other, NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
 
     [[nodiscard]] Literal add(Literal const &other, NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
     Literal operator+(Literal const &other) const noexcept;
@@ -482,7 +581,7 @@ public:
      * @param lang_range a basic language range
      * @return whether the language tag of this matches the given lang range if this is string-like, otherwise Err
      */
-    [[nodiscard]] util::TriBool lang_matches(std::string_view lang_range) const noexcept;
+    [[nodiscard]] util::TriBool language_tag_matches_range(std::string_view lang_range) const noexcept;
 
     /**
      * @see https://www.w3.org/TR/xpath-functions/#func-string-length
@@ -490,7 +589,7 @@ public:
      * @return whether the language tag of this matches the given lang range or the null literal if
      *      - this is not string-like
      */
-    [[nodiscard]] Literal as_lang_matches(std::string_view lang_range, NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
+    [[nodiscard]] Literal as_language_tag_matches_range(std::string_view lang_range, NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
 
     /**
      * @see https://www.w3.org/TR/xpath-functions/#func-string-length
@@ -499,7 +598,7 @@ public:
      *      - this is not string-like
      *      - lang_range is not xsd:string
      */
-    [[nodiscard]] Literal as_lang_matches(Literal const &lang_range, NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
+    [[nodiscard]] Literal as_language_tag_matches_range(Literal const &lang_range, NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
 
     /**
      * @see https://www.w3.org/TR/xpath-functions/#func-matches
@@ -759,10 +858,10 @@ public:
     [[nodiscard]] util::TriBool ebv() const noexcept;
 
     /**
-     * Converts this literal to it's effective boolean value
+     * Converts this literal to its effective boolean value
      * @return Literal containing the ebv
      */
-    [[nodiscard]] Literal ebv_as_literal(NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
+    [[nodiscard]] Literal as_ebv(NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
 
     [[nodiscard]] Literal logical_and(Literal const &other, NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
     Literal operator&&(Literal const &other) const noexcept;
@@ -775,6 +874,18 @@ public:
 
     friend class Node;
 };
+
+/**
+ * @return whether lang_tag matches the basic language range lang_range
+ */
+[[nodiscard]] bool lang_matches(std::string_view lang_tag, std::string_view lang_range) noexcept;
+
+/**
+ * @return whether lang_tag matches the basic language range lang_range as xsd:boolean or the null-literal if:
+ *      - lang_tag is not xsd:string
+ *      - lang_range is not xsd:string
+ */
+[[nodiscard]] Literal lang_matches(Literal const &lang_tag, Literal const &lang_range, storage::node::NodeStorage &node_storage = storage::node::NodeStorage::default_instance()) noexcept;
 
 inline namespace shorthands {
 

--- a/src/rdf4cpp/rdf/Node.cpp
+++ b/src/rdf4cpp/rdf/Node.cpp
@@ -173,8 +173,8 @@ util::TriBool Node::ebv() const noexcept {
     return Literal{handle_}.ebv();
 }
 
-Literal Node::ebv_as_literal(NodeStorage &node_storage) const noexcept {
-    return this->as_literal().ebv_as_literal(node_storage);
+Literal Node::as_ebv(NodeStorage &node_storage) const noexcept {
+    return this->as_literal().as_ebv(node_storage);
 }
 
 }  // namespace rdf4cpp::rdf

--- a/src/rdf4cpp/rdf/Node.hpp
+++ b/src/rdf4cpp/rdf/Node.hpp
@@ -108,7 +108,7 @@ public:
     /**
      * @return the effective boolean value of this as xsd:boolean (or null literal in case of Err)
      */
-    [[nodiscard]] Literal ebv_as_literal(NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
+    [[nodiscard]] Literal as_ebv(NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
 
 
     /**

--- a/src/rdf4cpp/rdf/util/CaseInsensitiveCharTraits.hpp
+++ b/src/rdf4cpp/rdf/util/CaseInsensitiveCharTraits.hpp
@@ -5,6 +5,10 @@
 
 namespace rdf4cpp::rdf::util {
 
+/**
+ * Case insensitive char traits.
+ * Identical to std::char_traits<char> except that CiCharTraits treats comparisons as case insensitive
+ */
 struct CiCharTraits : std::char_traits<char> {
     using char_type = std::char_traits<char>::char_type;
     using pos_type = std::char_traits<char>::pos_type;
@@ -55,6 +59,9 @@ struct CiCharTraits : std::char_traits<char> {
     }
 };
 
+/**
+ * Case insensitive view to a string
+ */
 using CiStringView = std::basic_string_view<char, CiCharTraits>;
 
 }  //namespace rdf4cpp::rdf::util

--- a/tests/nodes/tests_Literal.cpp
+++ b/tests/nodes/tests_Literal.cpp
@@ -501,48 +501,48 @@ TEST_CASE("Literal - misc functions") {
         CHECK(99_xsd_int .round() == 99_xsd_integer);
         CHECK(1.2_xsd_double .round() == 1.0_xsd_double);
         CHECK(1.5_xsd_double .round() == 2.0_xsd_double);
-        CHECK("hello"_xsd_string.round().null());
+        CHECK("hello"_xsd_string .round().null());
     }
 
     SUBCASE("floor") {
         CHECK(99_xsd_int .floor() == 99_xsd_integer);
         CHECK(1.2_xsd_double .floor() == 1.0_xsd_double);
         CHECK(1.5_xsd_double .floor() == 1.0_xsd_double);
-        CHECK("hello"_xsd_string.floor().null());
+        CHECK("hello"_xsd_string .floor().null());
     }
 
     SUBCASE("ceil") {
         CHECK(99_xsd_int .ceil() == 99_xsd_integer);
         CHECK(1.2_xsd_double .ceil() == 2.0_xsd_double);
         CHECK(1.5_xsd_double .ceil() == 2.0_xsd_double);
-        CHECK("hello"_xsd_string.ceil().null());
+        CHECK("hello"_xsd_string .ceil().null());
     }
 
     SUBCASE("strlen") {
-        CHECK("12345"_xsd_string.as_strlen() == 5_xsd_integer);
+        CHECK("12345"_xsd_string .as_strlen() == 5_xsd_integer);
         CHECK(1_xsd_int .as_strlen().null());
-        CHECK("123"_xsd_string.as_strlen() == 3_xsd_integer);
+        CHECK("123"_xsd_string .as_strlen() == 3_xsd_integer);
         CHECK(Literal::make_lang_tagged("hello", "en").as_strlen() == 5_xsd_integer);
 
-        CHECK("z\u00df\u6c34\U0001f34c"_xsd_string.as_strlen() == 4_xsd_integer);  // "zß水🍌"
+        CHECK("z\u00df\u6c34\U0001f34c"_xsd_string .as_strlen() == 4_xsd_integer);  // "zß水🍌"
     }
 
     SUBCASE("substr") {
         // from https://www.w3.org/TR/xpath-functions/#func-substring
-        CHECK("motor car"_xsd_string.substr(6_xsd_integer) == " car"_xsd_string);
-        CHECK("metadata"_xsd_string.substr(4_xsd_integer, 3_xsd_integer) == "ada"_xsd_string);
-        CHECK("12345"_xsd_string.substr("1.5"_xsd_decimal, "2.6"_xsd_decimal) == "234"_xsd_string);
-        CHECK("12345"_xsd_string.substr(0_xsd_integer, 3_xsd_integer) == "12"_xsd_string);
-        CHECK("12345"_xsd_string.substr(5_xsd_integer, -3_xsd_integer) == ""_xsd_string);
-        CHECK("12345"_xsd_string.substr(-3_xsd_integer, 5_xsd_integer) == "1"_xsd_string);
-        CHECK("12345"_xsd_string.substr(0_xsd_integer / 0.0_xsd_double, 3_xsd_integer) == ""_xsd_string);
-        CHECK("12345"_xsd_string.substr(1_xsd_integer, 0_xsd_integer / 0.0_xsd_double) == ""_xsd_string);
-        CHECK("12345"_xsd_string.substr(-42_xsd_integer, 1_xsd_integer / 0.0_xsd_double) == "12345"_xsd_string);
+        CHECK("motor car"_xsd_string .substr(6_xsd_integer) == " car"_xsd_string);
+        CHECK("metadata"_xsd_string .substr(4_xsd_integer, 3_xsd_integer) == "ada"_xsd_string);
+        CHECK("12345"_xsd_string .substr("1.5"_xsd_decimal, "2.6"_xsd_decimal) == "234"_xsd_string);
+        CHECK("12345"_xsd_string .substr(0_xsd_integer, 3_xsd_integer) == "12"_xsd_string);
+        CHECK("12345"_xsd_string .substr(5_xsd_integer, -3_xsd_integer) == ""_xsd_string);
+        CHECK("12345"_xsd_string .substr(-3_xsd_integer, 5_xsd_integer) == "1"_xsd_string);
+        CHECK("12345"_xsd_string .substr(0_xsd_integer / 0.0_xsd_double, 3_xsd_integer) == ""_xsd_string);
+        CHECK("12345"_xsd_string .substr(1_xsd_integer, 0_xsd_integer / 0.0_xsd_double) == ""_xsd_string);
+        CHECK("12345"_xsd_string .substr(-42_xsd_integer, 1_xsd_integer / 0.0_xsd_double) == "12345"_xsd_string);
 
         // from https://www.w3.org/TR/sparql11-query/#func-substr
-        CHECK("foobar"_xsd_string.substr(4_xsd_integer) == "bar"_xsd_string);
+        CHECK("foobar"_xsd_string .substr(4_xsd_integer) == "bar"_xsd_string);
         CHECK(Literal::make_lang_tagged("foobar", "en").substr(4_xsd_integer) == Literal::make_lang_tagged("bar", "en"));
-        CHECK("foobar"_xsd_string.substr(4_xsd_integer, 1_xsd_integer) == "b"_xsd_string);
+        CHECK("foobar"_xsd_string .substr(4_xsd_integer, 1_xsd_integer) == "b"_xsd_string);
         CHECK(Literal::make_lang_tagged("foobar", "en").substr(4_xsd_integer, 1_xsd_integer) == Literal::make_lang_tagged("b", "en"));
 
         // check correct casting
@@ -553,43 +553,43 @@ TEST_CASE("Literal - misc functions") {
     }
 
     SUBCASE("langMatches") {
-        CHECK(Literal::make_lang_tagged("Hello", "en").as_lang_matches("*"_xsd_string).ebv());
-        CHECK(Literal::make_lang_tagged("Bonjour", "fr").as_lang_matches("FR"_xsd_string).ebv());
-        CHECK(Literal::make_lang_tagged("Hello", "en-US").as_lang_matches("en-US"_xsd_string).ebv());
-        CHECK(5_xsd_int .as_lang_matches("*"_xsd_string).null());
-        CHECK("Hello"_xsd_string.as_lang_matches(""_xsd_string).ebv());
-        CHECK("Hello"_xsd_string.as_lang_matches("*"_xsd_string).ebv() == util::TriBool::False);
+        CHECK(Literal::make_lang_tagged("Hello", "en").as_language_tag_matches_range("*"_xsd_string).ebv());
+        CHECK(Literal::make_lang_tagged("Bonjour", "fr").as_language_tag_matches_range("FR"_xsd_string).ebv());
+        CHECK(Literal::make_lang_tagged("Hello", "en-US").as_language_tag_matches_range("en-US"_xsd_string).ebv());
+        CHECK(5_xsd_int .as_language_tag_matches_range("*"_xsd_string).null());
+        CHECK("Hello"_xsd_string .as_language_tag_matches_range(""_xsd_string).ebv());
+        CHECK("Hello"_xsd_string .as_language_tag_matches_range("*"_xsd_string).ebv() == util::TriBool::False);
     }
 
     SUBCASE("ucase") {
         // from https://www.w3.org/TR/sparql11-query/#func-ucase
-        CHECK("foo"_xsd_string.uppercase() == "FOO"_xsd_string);
+        CHECK("foo"_xsd_string .uppercase() == "FOO"_xsd_string);
         CHECK(Literal::make_lang_tagged("foo", "en").uppercase() == Literal::make_lang_tagged("FOO", "en"));
     }
 
     SUBCASE("lcase") {
         // from https://www.w3.org/TR/sparql11-query/#func-lcase
-        CHECK("BAR"_xsd_string.lowercase() == "bar"_xsd_string);
+        CHECK("BAR"_xsd_string .lowercase() == "bar"_xsd_string);
         CHECK(Literal::make_lang_tagged("BAR", "en").lowercase() == Literal::make_lang_tagged("bar", "en"));
     }
 
     SUBCASE("contains") {
         // from https://www.w3.org/TR/sparql11-query/#func-contains
-        CHECK("foobar"_xsd_string.as_contains("bar"_xsd_string).ebv());
+        CHECK("foobar"_xsd_string .as_contains("bar"_xsd_string).ebv());
         CHECK(Literal::make_lang_tagged("foobar", "en").as_contains(Literal::make_lang_tagged("foo", "en")).ebv());
         CHECK(Literal::make_lang_tagged("foobar", "en").as_contains("bar"_xsd_string).ebv());
 
         CHECK(Literal::make_lang_tagged("hello", "en").as_contains(Literal::make_lang_tagged("o", "fr")).null());
-        CHECK("123"_xsd_string.as_contains(Literal::make_lang_tagged("1", "en")).null());
+        CHECK("123"_xsd_string .as_contains(Literal::make_lang_tagged("1", "en")).null());
     }
 
     SUBCASE("substr_before") {
         // from https://www.w3.org/TR/sparql11-query/#func-strbefore
-        CHECK("abc"_xsd_string.substr_before("b"_xsd_string) == "a"_xsd_string);
+        CHECK("abc"_xsd_string .substr_before("b"_xsd_string) == "a"_xsd_string);
         CHECK(Literal::make_lang_tagged("abc", "en").substr_before("bc"_xsd_string) == Literal::make_lang_tagged("a", "en"));
         CHECK(Literal::make_lang_tagged("abc", "en").substr_before(Literal::make_lang_tagged("b", "cy")).null());
-        CHECK("abc"_xsd_string.substr_before(""_xsd_string) == ""_xsd_string);
-        CHECK("abc"_xsd_string.substr_before("xyz"_xsd_string) == ""_xsd_string);
+        CHECK("abc"_xsd_string .substr_before(""_xsd_string) == ""_xsd_string);
+        CHECK("abc"_xsd_string .substr_before("xyz"_xsd_string) == ""_xsd_string);
         CHECK(Literal::make_lang_tagged("abc", "en").substr_before(Literal::make_lang_tagged("z", "en")) == ""_xsd_string);
         CHECK(Literal::make_lang_tagged("abc", "en").substr_before("z"_xsd_string) == ""_xsd_string);
         CHECK(Literal::make_lang_tagged("abc", "en").substr_before(Literal::make_lang_tagged("", "en")) == Literal::make_lang_tagged("", "en"));
@@ -598,11 +598,11 @@ TEST_CASE("Literal - misc functions") {
 
     SUBCASE("substr_after") {
         // from https://www.w3.org/TR/sparql11-query/#func-strafter
-        CHECK("abc"_xsd_string.substr_after("b"_xsd_string) == "c"_xsd_string);
+        CHECK("abc"_xsd_string .substr_after("b"_xsd_string) == "c"_xsd_string);
         CHECK(Literal::make_lang_tagged("abc", "en").substr_after("ab"_xsd_string) == Literal::make_lang_tagged("c", "en"));
         CHECK(Literal::make_lang_tagged("abc", "en").substr_after(Literal::make_lang_tagged("b", "cy")).null());
-        CHECK("abc"_xsd_string.substr_after(""_xsd_string) == "abc"_xsd_string);
-        CHECK("abc"_xsd_string.substr_after("xyz"_xsd_string) == ""_xsd_string);
+        CHECK("abc"_xsd_string .substr_after(""_xsd_string) == "abc"_xsd_string);
+        CHECK("abc"_xsd_string .substr_after("xyz"_xsd_string) == ""_xsd_string);
         CHECK(Literal::make_lang_tagged("abc", "en").substr_after(Literal::make_lang_tagged("z", "en")) == ""_xsd_string);
         CHECK(Literal::make_lang_tagged("abc", "en").substr_after("z"_xsd_string) == ""_xsd_string);
         CHECK(Literal::make_lang_tagged("abc", "en").substr_after(Literal::make_lang_tagged("", "en")) == Literal::make_lang_tagged("abc", "en"));
@@ -611,27 +611,27 @@ TEST_CASE("Literal - misc functions") {
 
     SUBCASE("str_start_with") {
         // from https://www.w3.org/TR/sparql11-query/#func-strstarts
-        CHECK("foobar"_xsd_string.as_str_starts_with("foo"_xsd_string).ebv());
+        CHECK("foobar"_xsd_string .as_str_starts_with("foo"_xsd_string).ebv());
         CHECK(Literal::make_lang_tagged("foobar", "en").as_str_starts_with(Literal::make_lang_tagged("foo", "en")).ebv());
         CHECK(Literal::make_lang_tagged("foobar", "en").as_str_starts_with("foo"_xsd_string).ebv());
 
         CHECK(Literal::make_lang_tagged("foobar", "fr").as_str_starts_with(Literal::make_lang_tagged("foo", "en")).null());
-        CHECK("foobar"_xsd_string.as_str_starts_with(Literal::make_lang_tagged("foo", "en")).null());
+        CHECK("foobar"_xsd_string .as_str_starts_with(Literal::make_lang_tagged("foo", "en")).null());
     }
 
     SUBCASE("str_ends_with") {
         // from https://www.w3.org/TR/sparql11-query/#func-strstarts
-        CHECK("foobar"_xsd_string.as_str_ends_with("bar"_xsd_string).ebv());
+        CHECK("foobar"_xsd_string .as_str_ends_with("bar"_xsd_string).ebv());
         CHECK(Literal::make_lang_tagged("foobar", "en").as_str_ends_with(Literal::make_lang_tagged("bar", "en")).ebv());
         CHECK(Literal::make_lang_tagged("foobar", "en").as_str_ends_with("bar"_xsd_string).ebv());
 
         CHECK(Literal::make_lang_tagged("foobar", "fr").as_str_ends_with(Literal::make_lang_tagged("bar", "en")).null());
-        CHECK("foobar"_xsd_string.as_str_ends_with(Literal::make_lang_tagged("bar", "en")).null());
+        CHECK("foobar"_xsd_string .as_str_ends_with(Literal::make_lang_tagged("bar", "en")).null());
     }
 
     SUBCASE("concat") {
         // from https://www.w3.org/TR/sparql11-query/#func-concat
-        CHECK("foo"_xsd_string.concat("bar"_xsd_string) == "foobar"_xsd_string);
+        CHECK("foo"_xsd_string .concat("bar"_xsd_string) == "foobar"_xsd_string);
         CHECK(Literal::make_lang_tagged("foo", "en").concat(Literal::make_lang_tagged("bar", "en")) == Literal::make_lang_tagged("foobar", "en"));
         CHECK(Literal::make_lang_tagged("foo", "en").concat("bar"_xsd_string) == "foobar"_xsd_string);
 
@@ -641,9 +641,9 @@ TEST_CASE("Literal - misc functions") {
 
     SUBCASE("regex_match") {
         // from https://www.w3.org/TR/xpath-functions/#func-matches
-        CHECK("abracadabra"_xsd_string.as_regex_matches("bra"_xsd_string).ebv());
-        CHECK("abracadabra"_xsd_string.as_regex_matches("^a.*a$"_xsd_string).ebv());
-        CHECK("abracadabra"_xsd_string.as_regex_matches("^bra"_xsd_string).ebv() == util::TriBool::False);
+        CHECK("abracadabra"_xsd_string .as_regex_matches("bra"_xsd_string).ebv());
+        CHECK("abracadabra"_xsd_string .as_regex_matches("^a.*a$"_xsd_string).ebv());
+        CHECK("abracadabra"_xsd_string .as_regex_matches("^bra"_xsd_string).ebv() == util::TriBool::False);
 
         std::string_view const poem = "<poem author=\"Wilhelm Busch\">\n"
                                       "Kaum hat dies der Hahn gesehen,\n"
@@ -666,26 +666,26 @@ TEST_CASE("Literal - misc functions") {
 
     SUBCASE("regex_replace") {
         // from https://www.w3.org/TR/sparql11-query/#func-replace
-        CHECK("abcd"_xsd_string.regex_replace("b"_xsd_string, "Z"_xsd_string) == "aZcd"_xsd_string);
-        CHECK("abab"_xsd_string.regex_replace("B"_xsd_string, "Z"_xsd_string, "i"_xsd_string) == "aZaZ"_xsd_string);
-        CHECK("abab"_xsd_string.regex_replace("B."_xsd_string, "Z"_xsd_string, "i"_xsd_string) == "aZb"_xsd_string);
+        CHECK("abcd"_xsd_string .regex_replace("b"_xsd_string, "Z"_xsd_string) == "aZcd"_xsd_string);
+        CHECK("abab"_xsd_string .regex_replace("B"_xsd_string, "Z"_xsd_string, "i"_xsd_string) == "aZaZ"_xsd_string);
+        CHECK("abab"_xsd_string .regex_replace("B."_xsd_string, "Z"_xsd_string, "i"_xsd_string) == "aZb"_xsd_string);
 
         // from https://www.w3.org/TR/xpath-functions/#func-replace
-        CHECK("abracadabra"_xsd_string.regex_replace("bra"_xsd_string, "*"_xsd_string) == "a*cada*"_xsd_string);
-        CHECK("abracadabra"_xsd_string.regex_replace("a.*a"_xsd_string, "*"_xsd_string) == "*"_xsd_string);
-        CHECK("abracadabra"_xsd_string.regex_replace("a.*?a"_xsd_string, "*"_xsd_string) == "*c*bra"_xsd_string);
-        CHECK("abracadabra"_xsd_string.regex_replace("a"_xsd_string, ""_xsd_string) == "brcdbr"_xsd_string);
-        CHECK("abracadabra"_xsd_string.regex_replace("a(.)"_xsd_string, "a$1$1"_xsd_string) == "abbraccaddabbra"_xsd_string);
-        CHECK("AAAA"_xsd_string.regex_replace("A+"_xsd_string, "b"_xsd_string) == "b"_xsd_string);
-        CHECK("AAAA"_xsd_string.regex_replace("A+?"_xsd_string, "b"_xsd_string) == "bbbb"_xsd_string);
-        CHECK("darted"_xsd_string.regex_replace("^(.*?)d(.*)$"_xsd_string, "$1c$2"_xsd_string) == "carted"_xsd_string);
+        CHECK("abracadabra"_xsd_string .regex_replace("bra"_xsd_string, "*"_xsd_string) == "a*cada*"_xsd_string);
+        CHECK("abracadabra"_xsd_string .regex_replace("a.*a"_xsd_string, "*"_xsd_string) == "*"_xsd_string);
+        CHECK("abracadabra"_xsd_string .regex_replace("a.*?a"_xsd_string, "*"_xsd_string) == "*c*bra"_xsd_string);
+        CHECK("abracadabra"_xsd_string .regex_replace("a"_xsd_string, ""_xsd_string) == "brcdbr"_xsd_string);
+        CHECK("abracadabra"_xsd_string .regex_replace("a(.)"_xsd_string, "a$1$1"_xsd_string) == "abbraccaddabbra"_xsd_string);
+        CHECK("AAAA"_xsd_string .regex_replace("A+"_xsd_string, "b"_xsd_string) == "b"_xsd_string);
+        CHECK("AAAA"_xsd_string .regex_replace("A+?"_xsd_string, "b"_xsd_string) == "bbbb"_xsd_string);
+        CHECK("darted"_xsd_string .regex_replace("^(.*?)d(.*)$"_xsd_string, "$1c$2"_xsd_string) == "carted"_xsd_string);
 
         // 'The expression fn:replace("abracadabra", ".*?", "$1") raises an error, because the pattern matches the zero-length string'
         // TODO: figure out how implement correct behaviour here (currently returns ""^^xsd:string)
         //CHECK("abracadabra"_xsd_string .regex_replace(".*?"_xsd_string, "$1"_xsd_string).null());
 
-        CHECK("abcd"_xsd_string.as_regex_matches(".*"_xsd_string, "q"_xsd_string).ebv() == util::TriBool::False);
-        CHECK("Mr. B. Obama"_xsd_string.as_regex_matches("B. OBAMA"_xsd_string, "qi"_xsd_string).ebv());
+        CHECK("abcd"_xsd_string .as_regex_matches(".*"_xsd_string, "q"_xsd_string).ebv() == util::TriBool::False);
+        CHECK("Mr. B. Obama"_xsd_string .as_regex_matches("B. OBAMA"_xsd_string, "qi"_xsd_string).ebv());
 
         // check lang tag behaviour
         CHECK(Literal::make_lang_tagged("abcd", "en").regex_replace("b"_xsd_string, "Z"_xsd_string) == Literal::make_lang_tagged("aZcd", "en"));

--- a/tests/nodes/tests_Literal.cpp
+++ b/tests/nodes/tests_Literal.cpp
@@ -493,56 +493,56 @@ TEST_CASE("Literal - misc functions") {
     SUBCASE("abs") {
         CHECK((-1_xsd_int).abs() == 1_xsd_integer);
         CHECK((-100.0_xsd_double).abs() == 100.0_xsd_double);
-        CHECK(99.0_xsd_float .abs() == 99.0_xsd_float);
-        CHECK("hello"_xsd_string .abs().null());
+        CHECK((99.0_xsd_float).abs() == 99.0_xsd_float);
+        CHECK(("hello"_xsd_string).abs().null());
     }
 
     SUBCASE("round") {
-        CHECK(99_xsd_int .round() == 99_xsd_integer);
-        CHECK(1.2_xsd_double .round() == 1.0_xsd_double);
-        CHECK(1.5_xsd_double .round() == 2.0_xsd_double);
-        CHECK("hello"_xsd_string .round().null());
+        CHECK((99_xsd_int).round() == 99_xsd_integer);
+        CHECK((1.2_xsd_double).round() == 1.0_xsd_double);
+        CHECK((1.5_xsd_double).round() == 2.0_xsd_double);
+        CHECK(("hello"_xsd_string).round().null());
     }
 
     SUBCASE("floor") {
-        CHECK(99_xsd_int .floor() == 99_xsd_integer);
-        CHECK(1.2_xsd_double .floor() == 1.0_xsd_double);
-        CHECK(1.5_xsd_double .floor() == 1.0_xsd_double);
-        CHECK("hello"_xsd_string .floor().null());
+        CHECK((99_xsd_int).floor() == 99_xsd_integer);
+        CHECK((1.2_xsd_double).floor() == 1.0_xsd_double);
+        CHECK((1.5_xsd_double).floor() == 1.0_xsd_double);
+        CHECK(("hello"_xsd_string).floor().null());
     }
 
     SUBCASE("ceil") {
-        CHECK(99_xsd_int .ceil() == 99_xsd_integer);
-        CHECK(1.2_xsd_double .ceil() == 2.0_xsd_double);
-        CHECK(1.5_xsd_double .ceil() == 2.0_xsd_double);
-        CHECK("hello"_xsd_string .ceil().null());
+        CHECK((99_xsd_int).ceil() == 99_xsd_integer);
+        CHECK((1.2_xsd_double).ceil() == 2.0_xsd_double);
+        CHECK((1.5_xsd_double).ceil() == 2.0_xsd_double);
+        CHECK(("hello"_xsd_string).ceil().null());
     }
 
     SUBCASE("strlen") {
-        CHECK("12345"_xsd_string .as_strlen() == 5_xsd_integer);
+        CHECK(("12345"_xsd_string).as_strlen() == 5_xsd_integer);
         CHECK(1_xsd_int .as_strlen().null());
-        CHECK("123"_xsd_string .as_strlen() == 3_xsd_integer);
+        CHECK(("123"_xsd_string).as_strlen() == 3_xsd_integer);
         CHECK(Literal::make_lang_tagged("hello", "en").as_strlen() == 5_xsd_integer);
 
-        CHECK("z\u00df\u6c34\U0001f34c"_xsd_string .as_strlen() == 4_xsd_integer);  // "zß水🍌"
+        CHECK(("z\u00df\u6c34\U0001f34c"_xsd_string).as_strlen() == 4_xsd_integer);  // "zß水🍌"
     }
 
     SUBCASE("substr") {
         // from https://www.w3.org/TR/xpath-functions/#func-substring
-        CHECK("motor car"_xsd_string .substr(6_xsd_integer) == " car"_xsd_string);
-        CHECK("metadata"_xsd_string .substr(4_xsd_integer, 3_xsd_integer) == "ada"_xsd_string);
-        CHECK("12345"_xsd_string .substr("1.5"_xsd_decimal, "2.6"_xsd_decimal) == "234"_xsd_string);
-        CHECK("12345"_xsd_string .substr(0_xsd_integer, 3_xsd_integer) == "12"_xsd_string);
-        CHECK("12345"_xsd_string .substr(5_xsd_integer, -3_xsd_integer) == ""_xsd_string);
-        CHECK("12345"_xsd_string .substr(-3_xsd_integer, 5_xsd_integer) == "1"_xsd_string);
-        CHECK("12345"_xsd_string .substr(0_xsd_integer / 0.0_xsd_double, 3_xsd_integer) == ""_xsd_string);
-        CHECK("12345"_xsd_string .substr(1_xsd_integer, 0_xsd_integer / 0.0_xsd_double) == ""_xsd_string);
-        CHECK("12345"_xsd_string .substr(-42_xsd_integer, 1_xsd_integer / 0.0_xsd_double) == "12345"_xsd_string);
+        CHECK(("motor car"_xsd_string).substr(6_xsd_integer) == " car"_xsd_string);
+        CHECK(("metadata"_xsd_string).substr(4_xsd_integer, 3_xsd_integer) == "ada"_xsd_string);
+        CHECK(("12345"_xsd_string).substr("1.5"_xsd_decimal, "2.6"_xsd_decimal) == "234"_xsd_string);
+        CHECK(("12345"_xsd_string).substr(0_xsd_integer, 3_xsd_integer) == "12"_xsd_string);
+        CHECK(("12345"_xsd_string).substr(5_xsd_integer, -3_xsd_integer) == ""_xsd_string);
+        CHECK(("12345"_xsd_string).substr(-3_xsd_integer, 5_xsd_integer) == "1"_xsd_string);
+        CHECK(("12345"_xsd_string).substr(0_xsd_integer / 0.0_xsd_double, 3_xsd_integer) == ""_xsd_string);
+        CHECK(("12345"_xsd_string).substr(1_xsd_integer, 0_xsd_integer / 0.0_xsd_double) == ""_xsd_string);
+        CHECK(("12345"_xsd_string).substr(-42_xsd_integer, 1_xsd_integer / 0.0_xsd_double) == "12345"_xsd_string);
 
         // from https://www.w3.org/TR/sparql11-query/#func-substr
-        CHECK("foobar"_xsd_string .substr(4_xsd_integer) == "bar"_xsd_string);
+        CHECK(("foobar"_xsd_string).substr(4_xsd_integer) == "bar"_xsd_string);
         CHECK(Literal::make_lang_tagged("foobar", "en").substr(4_xsd_integer) == Literal::make_lang_tagged("bar", "en"));
-        CHECK("foobar"_xsd_string .substr(4_xsd_integer, 1_xsd_integer) == "b"_xsd_string);
+        CHECK(("foobar"_xsd_string).substr(4_xsd_integer, 1_xsd_integer) == "b"_xsd_string);
         CHECK(Literal::make_lang_tagged("foobar", "en").substr(4_xsd_integer, 1_xsd_integer) == Literal::make_lang_tagged("b", "en"));
 
         // check correct casting
@@ -557,39 +557,39 @@ TEST_CASE("Literal - misc functions") {
         CHECK(Literal::make_lang_tagged("Bonjour", "fr").as_language_tag_matches_range("FR"_xsd_string).ebv());
         CHECK(Literal::make_lang_tagged("Hello", "en-US").as_language_tag_matches_range("en-US"_xsd_string).ebv());
         CHECK(5_xsd_int .as_language_tag_matches_range("*"_xsd_string).null());
-        CHECK("Hello"_xsd_string .as_language_tag_matches_range(""_xsd_string).ebv());
-        CHECK("Hello"_xsd_string .as_language_tag_matches_range("*"_xsd_string).ebv() == util::TriBool::False);
+        CHECK(("Hello"_xsd_string).as_language_tag_matches_range(""_xsd_string).ebv());
+        CHECK(("Hello"_xsd_string).as_language_tag_matches_range("*"_xsd_string).ebv() == util::TriBool::False);
     }
 
     SUBCASE("ucase") {
         // from https://www.w3.org/TR/sparql11-query/#func-ucase
-        CHECK("foo"_xsd_string .uppercase() == "FOO"_xsd_string);
+        CHECK(("foo"_xsd_string).uppercase() == "FOO"_xsd_string);
         CHECK(Literal::make_lang_tagged("foo", "en").uppercase() == Literal::make_lang_tagged("FOO", "en"));
     }
 
     SUBCASE("lcase") {
         // from https://www.w3.org/TR/sparql11-query/#func-lcase
-        CHECK("BAR"_xsd_string .lowercase() == "bar"_xsd_string);
+        CHECK(("BAR"_xsd_string).lowercase() == "bar"_xsd_string);
         CHECK(Literal::make_lang_tagged("BAR", "en").lowercase() == Literal::make_lang_tagged("bar", "en"));
     }
 
     SUBCASE("contains") {
         // from https://www.w3.org/TR/sparql11-query/#func-contains
-        CHECK("foobar"_xsd_string .as_contains("bar"_xsd_string).ebv());
+        CHECK(("foobar"_xsd_string).as_contains("bar"_xsd_string).ebv());
         CHECK(Literal::make_lang_tagged("foobar", "en").as_contains(Literal::make_lang_tagged("foo", "en")).ebv());
         CHECK(Literal::make_lang_tagged("foobar", "en").as_contains("bar"_xsd_string).ebv());
 
         CHECK(Literal::make_lang_tagged("hello", "en").as_contains(Literal::make_lang_tagged("o", "fr")).null());
-        CHECK("123"_xsd_string .as_contains(Literal::make_lang_tagged("1", "en")).null());
+        CHECK(("123"_xsd_string).as_contains(Literal::make_lang_tagged("1", "en")).null());
     }
 
     SUBCASE("substr_before") {
         // from https://www.w3.org/TR/sparql11-query/#func-strbefore
-        CHECK("abc"_xsd_string .substr_before("b"_xsd_string) == "a"_xsd_string);
+        CHECK(("abc"_xsd_string).substr_before("b"_xsd_string) == "a"_xsd_string);
         CHECK(Literal::make_lang_tagged("abc", "en").substr_before("bc"_xsd_string) == Literal::make_lang_tagged("a", "en"));
         CHECK(Literal::make_lang_tagged("abc", "en").substr_before(Literal::make_lang_tagged("b", "cy")).null());
-        CHECK("abc"_xsd_string .substr_before(""_xsd_string) == ""_xsd_string);
-        CHECK("abc"_xsd_string .substr_before("xyz"_xsd_string) == ""_xsd_string);
+        CHECK(("abc"_xsd_string).substr_before(""_xsd_string) == ""_xsd_string);
+        CHECK(("abc"_xsd_string).substr_before("xyz"_xsd_string) == ""_xsd_string);
         CHECK(Literal::make_lang_tagged("abc", "en").substr_before(Literal::make_lang_tagged("z", "en")) == ""_xsd_string);
         CHECK(Literal::make_lang_tagged("abc", "en").substr_before("z"_xsd_string) == ""_xsd_string);
         CHECK(Literal::make_lang_tagged("abc", "en").substr_before(Literal::make_lang_tagged("", "en")) == Literal::make_lang_tagged("", "en"));
@@ -598,11 +598,11 @@ TEST_CASE("Literal - misc functions") {
 
     SUBCASE("substr_after") {
         // from https://www.w3.org/TR/sparql11-query/#func-strafter
-        CHECK("abc"_xsd_string .substr_after("b"_xsd_string) == "c"_xsd_string);
+        CHECK(("abc"_xsd_string).substr_after("b"_xsd_string) == "c"_xsd_string);
         CHECK(Literal::make_lang_tagged("abc", "en").substr_after("ab"_xsd_string) == Literal::make_lang_tagged("c", "en"));
         CHECK(Literal::make_lang_tagged("abc", "en").substr_after(Literal::make_lang_tagged("b", "cy")).null());
-        CHECK("abc"_xsd_string .substr_after(""_xsd_string) == "abc"_xsd_string);
-        CHECK("abc"_xsd_string .substr_after("xyz"_xsd_string) == ""_xsd_string);
+        CHECK(("abc"_xsd_string).substr_after(""_xsd_string) == "abc"_xsd_string);
+        CHECK(("abc"_xsd_string).substr_after("xyz"_xsd_string) == ""_xsd_string);
         CHECK(Literal::make_lang_tagged("abc", "en").substr_after(Literal::make_lang_tagged("z", "en")) == ""_xsd_string);
         CHECK(Literal::make_lang_tagged("abc", "en").substr_after("z"_xsd_string) == ""_xsd_string);
         CHECK(Literal::make_lang_tagged("abc", "en").substr_after(Literal::make_lang_tagged("", "en")) == Literal::make_lang_tagged("abc", "en"));
@@ -611,27 +611,27 @@ TEST_CASE("Literal - misc functions") {
 
     SUBCASE("str_start_with") {
         // from https://www.w3.org/TR/sparql11-query/#func-strstarts
-        CHECK("foobar"_xsd_string .as_str_starts_with("foo"_xsd_string).ebv());
+        CHECK(("foobar"_xsd_string).as_str_starts_with("foo"_xsd_string).ebv());
         CHECK(Literal::make_lang_tagged("foobar", "en").as_str_starts_with(Literal::make_lang_tagged("foo", "en")).ebv());
         CHECK(Literal::make_lang_tagged("foobar", "en").as_str_starts_with("foo"_xsd_string).ebv());
 
         CHECK(Literal::make_lang_tagged("foobar", "fr").as_str_starts_with(Literal::make_lang_tagged("foo", "en")).null());
-        CHECK("foobar"_xsd_string .as_str_starts_with(Literal::make_lang_tagged("foo", "en")).null());
+        CHECK(("foobar"_xsd_string).as_str_starts_with(Literal::make_lang_tagged("foo", "en")).null());
     }
 
     SUBCASE("str_ends_with") {
         // from https://www.w3.org/TR/sparql11-query/#func-strstarts
-        CHECK("foobar"_xsd_string .as_str_ends_with("bar"_xsd_string).ebv());
+        CHECK(("foobar"_xsd_string).as_str_ends_with("bar"_xsd_string).ebv());
         CHECK(Literal::make_lang_tagged("foobar", "en").as_str_ends_with(Literal::make_lang_tagged("bar", "en")).ebv());
         CHECK(Literal::make_lang_tagged("foobar", "en").as_str_ends_with("bar"_xsd_string).ebv());
 
         CHECK(Literal::make_lang_tagged("foobar", "fr").as_str_ends_with(Literal::make_lang_tagged("bar", "en")).null());
-        CHECK("foobar"_xsd_string .as_str_ends_with(Literal::make_lang_tagged("bar", "en")).null());
+        CHECK(("foobar"_xsd_string).as_str_ends_with(Literal::make_lang_tagged("bar", "en")).null());
     }
 
     SUBCASE("concat") {
         // from https://www.w3.org/TR/sparql11-query/#func-concat
-        CHECK("foo"_xsd_string .concat("bar"_xsd_string) == "foobar"_xsd_string);
+        CHECK(("foo"_xsd_string).concat("bar"_xsd_string) == "foobar"_xsd_string);
         CHECK(Literal::make_lang_tagged("foo", "en").concat(Literal::make_lang_tagged("bar", "en")) == Literal::make_lang_tagged("foobar", "en"));
         CHECK(Literal::make_lang_tagged("foo", "en").concat("bar"_xsd_string) == "foobar"_xsd_string);
 
@@ -641,9 +641,9 @@ TEST_CASE("Literal - misc functions") {
 
     SUBCASE("regex_match") {
         // from https://www.w3.org/TR/xpath-functions/#func-matches
-        CHECK("abracadabra"_xsd_string .as_regex_matches("bra"_xsd_string).ebv());
-        CHECK("abracadabra"_xsd_string .as_regex_matches("^a.*a$"_xsd_string).ebv());
-        CHECK("abracadabra"_xsd_string .as_regex_matches("^bra"_xsd_string).ebv() == util::TriBool::False);
+        CHECK(("abracadabra"_xsd_string).as_regex_matches("bra"_xsd_string).ebv());
+        CHECK(("abracadabra"_xsd_string).as_regex_matches("^a.*a$"_xsd_string).ebv());
+        CHECK(("abracadabra"_xsd_string).as_regex_matches("^bra"_xsd_string).ebv() == util::TriBool::False);
 
         std::string_view const poem = "<poem author=\"Wilhelm Busch\">\n"
                                       "Kaum hat dies der Hahn gesehen,\n"
@@ -666,26 +666,26 @@ TEST_CASE("Literal - misc functions") {
 
     SUBCASE("regex_replace") {
         // from https://www.w3.org/TR/sparql11-query/#func-replace
-        CHECK("abcd"_xsd_string .regex_replace("b"_xsd_string, "Z"_xsd_string) == "aZcd"_xsd_string);
-        CHECK("abab"_xsd_string .regex_replace("B"_xsd_string, "Z"_xsd_string, "i"_xsd_string) == "aZaZ"_xsd_string);
-        CHECK("abab"_xsd_string .regex_replace("B."_xsd_string, "Z"_xsd_string, "i"_xsd_string) == "aZb"_xsd_string);
+        CHECK(("abcd"_xsd_string).regex_replace("b"_xsd_string, "Z"_xsd_string) == "aZcd"_xsd_string);
+        CHECK(("abab"_xsd_string).regex_replace("B"_xsd_string, "Z"_xsd_string, "i"_xsd_string) == "aZaZ"_xsd_string);
+        CHECK(("abab"_xsd_string).regex_replace("B."_xsd_string, "Z"_xsd_string, "i"_xsd_string) == "aZb"_xsd_string);
 
         // from https://www.w3.org/TR/xpath-functions/#func-replace
-        CHECK("abracadabra"_xsd_string .regex_replace("bra"_xsd_string, "*"_xsd_string) == "a*cada*"_xsd_string);
-        CHECK("abracadabra"_xsd_string .regex_replace("a.*a"_xsd_string, "*"_xsd_string) == "*"_xsd_string);
-        CHECK("abracadabra"_xsd_string .regex_replace("a.*?a"_xsd_string, "*"_xsd_string) == "*c*bra"_xsd_string);
-        CHECK("abracadabra"_xsd_string .regex_replace("a"_xsd_string, ""_xsd_string) == "brcdbr"_xsd_string);
-        CHECK("abracadabra"_xsd_string .regex_replace("a(.)"_xsd_string, "a$1$1"_xsd_string) == "abbraccaddabbra"_xsd_string);
-        CHECK("AAAA"_xsd_string .regex_replace("A+"_xsd_string, "b"_xsd_string) == "b"_xsd_string);
-        CHECK("AAAA"_xsd_string .regex_replace("A+?"_xsd_string, "b"_xsd_string) == "bbbb"_xsd_string);
-        CHECK("darted"_xsd_string .regex_replace("^(.*?)d(.*)$"_xsd_string, "$1c$2"_xsd_string) == "carted"_xsd_string);
+        CHECK(("abracadabra"_xsd_string).regex_replace("bra"_xsd_string, "*"_xsd_string) == "a*cada*"_xsd_string);
+        CHECK(("abracadabra"_xsd_string).regex_replace("a.*a"_xsd_string, "*"_xsd_string) == "*"_xsd_string);
+        CHECK(("abracadabra"_xsd_string).regex_replace("a.*?a"_xsd_string, "*"_xsd_string) == "*c*bra"_xsd_string);
+        CHECK(("abracadabra"_xsd_string).regex_replace("a"_xsd_string, ""_xsd_string) == "brcdbr"_xsd_string);
+        CHECK(("abracadabra"_xsd_string).regex_replace("a(.)"_xsd_string, "a$1$1"_xsd_string) == "abbraccaddabbra"_xsd_string);
+        CHECK(("AAAA"_xsd_string).regex_replace("A+"_xsd_string, "b"_xsd_string) == "b"_xsd_string);
+        CHECK(("AAAA"_xsd_string).regex_replace("A+?"_xsd_string, "b"_xsd_string) == "bbbb"_xsd_string);
+        CHECK(("darted"_xsd_string).regex_replace("^(.*?)d(.*)$"_xsd_string, "$1c$2"_xsd_string) == "carted"_xsd_string);
 
         // 'The expression fn:replace("abracadabra", ".*?", "$1") raises an error, because the pattern matches the zero-length string'
         // TODO: figure out how implement correct behaviour here (currently returns ""^^xsd:string)
-        //CHECK("abracadabra"_xsd_string .regex_replace(".*?"_xsd_string, "$1"_xsd_string).null());
+        //CHECK(("abracadabra"_xsd_string).regex_replace(".*?"_xsd_string, "$1"_xsd_string).null());
 
-        CHECK("abcd"_xsd_string .as_regex_matches(".*"_xsd_string, "q"_xsd_string).ebv() == util::TriBool::False);
-        CHECK("Mr. B. Obama"_xsd_string .as_regex_matches("B. OBAMA"_xsd_string, "qi"_xsd_string).ebv());
+        CHECK(("abcd"_xsd_string).as_regex_matches(".*"_xsd_string, "q"_xsd_string).ebv() == util::TriBool::False);
+        CHECK(("Mr. B. Obama"_xsd_string).as_regex_matches("B. OBAMA"_xsd_string, "qi"_xsd_string).ebv());
 
         // check lang tag behaviour
         CHECK(Literal::make_lang_tagged("abcd", "en").regex_replace("b"_xsd_string, "Z"_xsd_string) == Literal::make_lang_tagged("aZcd", "en"));


### PR DESCRIPTION
Closes #142.

I also discovered some additional defects that were either not optimal in performance or missing a transformation function.

And the tests somehow got wrongly formatted (i.e. something like `5_literal.function()` is invalid because of c++ parsing stuff).