### PR TITLE
Feature: Port to Conan 2.0

### DIFF
--- a/.github/workflows/reusable_packaging_and_deployment.yml
+++ b/.github/workflows/reusable_packaging_and_deployment.yml
@@ -59,8 +59,13 @@ jobs:
           CXX: ${{ steps.install_cc.outputs.cxx }}
         run: |
           # build and test package
+          #debub begin
+          cmake --system-information
           conan_name=$(cmake --system-information | awk -F= '$1~/CMAKE_PROJECT_NAME:STATIC/{print$2}')
           conan_version=$(cmake --system-information | awk -F= '$1~/CMAKE_PROJECT_VERSION:STATIC/{print$2}')
+          echo "$conan_name {conan_name}"
+          echo "conan_version {conan_version}"
+          #debub end
           conan_user=ci
           conan_channel=testing
           

--- a/.github/workflows/reusable_packaging_and_deployment.yml
+++ b/.github/workflows/reusable_packaging_and_deployment.yml
@@ -40,17 +40,15 @@ jobs:
           CC: ${{ steps.install_cc.outputs.cc }}
           CXX: ${{ steps.install_cc.outputs.cxx }}
         run: |
-          pip3 install conan ${{ fromJSON('["", "gcovr"]')[inputs.with-coverage] }}
-          conan user
-          conan profile new --detect default
-          conan profile update settings.compiler.libcxx=libstdc++11 default
+          pip3 install "conan>=2.0" ${{ fromJSON('["", "gcovr"]')[inputs.with-coverage] }}
+          conan profile detect
 
       - name: Cache conan data
         id: cache-conan
         uses: actions/cache@v3
         with:
           path: ~/.conan/data
-          key: ${{ inputs.os }}-${{ inputs.compiler }}-conan
+          key: ${{ inputs.os }}-${{ inputs.compiler }}-conan2
 
       - name: Check out sources
         uses: actions/checkout@v3
@@ -61,8 +59,13 @@ jobs:
           CXX: ${{ steps.install_cc.outputs.cxx }}
         run: |
           # build and test package
-          conan create . $(conan inspect . --raw name)/$(conan inspect . --raw version)@ci/testing -pr:b=default --build missing
-          conan remove -f $(conan inspect . --raw name)/$(conan inspect . --raw version)@ci/testing
+          conan_name=$(cmake --system-information | awk -F= '$1~/CMAKE_PROJECT_NAME:STATIC/{print$2}')
+          conan_version=$(cmake --system-information | awk -F= '$1~/CMAKE_PROJECT_VERSION:STATIC/{print$2}')
+          conan_user=ci
+          conan_channel=testing
+          
+          conan create . --user ${conan_user} --channel ${conan_channel} -pr:b=default -pr:h=default --build missing
+          conan remove -c "${conan_name}/${conan_version}@${conan_user}/${conan_channel}"
 
   test-fetch-content-static:
     name: Test cmake FetchContent (static lib)

--- a/.github/workflows/reusable_packaging_and_deployment.yml
+++ b/.github/workflows/reusable_packaging_and_deployment.yml
@@ -59,13 +59,8 @@ jobs:
           CXX: ${{ steps.install_cc.outputs.cxx }}
         run: |
           # build and test package
-          #debub begin
-          cmake --system-information
-          conan_name=$(cmake --system-information | awk -F= '$1~/CMAKE_PROJECT_NAME:STATIC/{print$2}')
-          conan_version=$(cmake --system-information | awk -F= '$1~/CMAKE_PROJECT_VERSION:STATIC/{print$2}')
-          echo "$conan_name {conan_name}"
-          echo "conan_version {conan_version}"
-          #debub end
+          conan_name=$(conan inspect -f json . | jq -r '.name')
+          conan_version=$(conan inspect -f json . | jq -r '.version')
           conan_user=ci
           conan_channel=testing
           

--- a/.github/workflows/reusable_run_test_and_examples_by_linking_type.yml
+++ b/.github/workflows/reusable_run_test_and_examples_by_linking_type.yml
@@ -51,17 +51,15 @@ jobs:
           CC: ${{ steps.install_cc.outputs.cc }}
           CXX: ${{ steps.install_cc.outputs.cxx }}
         run: |
-          pip3 install conan ${{ fromJSON('["", "gcovr"]')[inputs.with-coverage] }}
-          conan user
-          conan profile new --detect default
-          conan profile update settings.compiler.libcxx=libstdc++11 default
+          pip3 install "conan>=2.0" ${{ fromJSON('["", "gcovr"]')[inputs.with-coverage] }}
+          conan profile detect
 
       - name: Cache conan data
         id: cache-conan
         uses: actions/cache@v3
         with:
-          path: ~/.conan/data
-          key: ${{ inputs.os }}-${{ inputs.compiler }}-conan
+          path: ~/.conan2/data
+          key: ${{ inputs.os }}-${{ inputs.compiler }}-conan2
 
       - name: Check out sources
         uses: actions/checkout@v3

--- a/.github/workflows/reusable_run_test_and_examples_by_linking_type.yml
+++ b/.github/workflows/reusable_run_test_and_examples_by_linking_type.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Build Tests & Examples
         run: |
-          conan install . -s build_type=Release -of build_dir
+          conan install . -s build_type=Release -of build_dir --build missing
           cmake -DDCMAKE_TOOLCHAIN_FILE=build_dir/build/Release/generators/conan_toolchain.cmake \
           -G Ninja -B build_dir -DBUILD_TESTING=ON -DBUILD_EXAMPLES=ON \
           ${{ fromJSON('["", "-DBUILD_SHARED_LIBS=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON"]')[inputs.build-shared-libs] }}

--- a/.github/workflows/reusable_run_test_and_examples_by_linking_type.yml
+++ b/.github/workflows/reusable_run_test_and_examples_by_linking_type.yml
@@ -66,7 +66,9 @@ jobs:
 
       - name: Build Tests & Examples
         run: |
-          cmake -G Ninja -B build_dir -DBUILD_TESTING=ON -DBUILD_EXAMPLES=ON \
+          conan install . -s build_type=Release -of build_dir
+          cmake -DDCMAKE_TOOLCHAIN_FILE=build_dir/build/Release/generators/conan_toolchain.cmake \
+          -G Ninja -B build_dir -DBUILD_TESTING=ON -DBUILD_EXAMPLES=ON \
           ${{ fromJSON('["", "-DBUILD_SHARED_LIBS=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON"]')[inputs.build-shared-libs] }}
           cmake --build build_dir
         env:

--- a/.github/workflows/reusable_run_test_and_examples_by_linking_type.yml
+++ b/.github/workflows/reusable_run_test_and_examples_by_linking_type.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Build Tests & Examples
         run: |
           conan install . -s build_type=Release -of build_dir --build missing
-          cmake -DDCMAKE_TOOLCHAIN_FILE=build_dir/build/Release/generators/conan_toolchain.cmake \
+          cmake -DCMAKE_TOOLCHAIN_FILE=build_dir/build/Release/generators/conan_toolchain.cmake -DCMAKE_POLICY_DEFAULT_CMP0091=NEW \
           -G Ninja -B build_dir -DBUILD_TESTING=ON -DBUILD_EXAMPLES=ON \
           ${{ fromJSON('["", "-DBUILD_SHARED_LIBS=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON"]')[inputs.build-shared-libs] }}
           cmake --build build_dir

--- a/.github/workflows/run_test_and_examples.yml
+++ b/.github/workflows/run_test_and_examples.yml
@@ -28,7 +28,7 @@ jobs:
     with:
       os: ${{ matrix.cppenv.os }}
       compiler: ${{ matrix.cppenv.compiler }}
-      cmake-version: 3.22.6
+      cmake-version: 3.23.5
       with-coverage: ${{ matrix.cppenv.compiler == 'gcc-12' }}
       with-sanitizer: ${{ matrix.cppenv.compiler == 'clang-14' }}
     secrets:

--- a/.github/workflows/test_packaging_and_deployment.yml
+++ b/.github/workflows/test_packaging_and_deployment.yml
@@ -9,7 +9,7 @@ jobs:
     with:
       os: ubuntu-22.04
       compiler: clang-14
-      cmake-version: 3.22.6
+      cmake-version: 3.23.5
 
   packaging-and-deployment-tests-gcc:
     name: Packaging and deployment tests gcc-12
@@ -17,4 +17,4 @@ jobs:
     with:
       os: ubuntu-22.04
       compiler: gcc-12
-      cmake-version: 3.22.6
+      cmake-version: 3.23.5

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.23)
 project(rdf4cpp VERSION 0.0.11)
 
 include(cmake/boilerplate_init.cmake)

--- a/cmake/conan_cmake.cmake
+++ b/cmake/conan_cmake.cmake
@@ -13,7 +13,7 @@ macro(install_packages_via_conan conanfile conan_options)
     include(${CMAKE_BINARY_DIR}/conan.cmake)
 
     conan_cmake_autodetect(settings)
-    conan_check(VERSION 1 DETECT_QUIET)
+    conan_check(VERSION 2 DETECT_QUIET)
     if (CONAN_CMD)
         conan_cmake_install(PATH_OR_REFERENCE ${conanfile}
                 BUILD missing

--- a/cmake/conan_cmake.cmake
+++ b/cmake/conan_cmake.cmake
@@ -1,25 +1,64 @@
 macro(install_packages_via_conan conanfile conan_options)
+    if (FALSE) # TODO: we must wait until there is a cmake integration for conan again
+        list(APPEND CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR})
+        list(APPEND CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR})
 
-    list(APPEND CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR})
-    list(APPEND CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR})
 
+        #    if (NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
+        #        message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
+        #        file(DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/0.18.1/conan.cmake"
+        #                "${CMAKE_BINARY_DIR}/conan.cmake"
+        #                TLS_VERIFY ON)
+        #    endif ()
+        #    include(${CMAKE_BINARY_DIR}/conan.cmake)
 
-    if (NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
-        message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
-        file(DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/0.18.1/conan.cmake"
-                "${CMAKE_BINARY_DIR}/conan.cmake"
-                TLS_VERIFY ON)
-    endif ()
-    include(${CMAKE_BINARY_DIR}/conan.cmake)
+        if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+            SET(CONAN_COMPILER clang)
+        elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+            SET(CONAN_COMPILER gcc)
+        elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+            SET(CONAN_COMPILER intel-cc)
+        elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+            SET(CONAN_COMPILER msvc)
+        endif ()
 
-    conan_cmake_autodetect(settings)
-    conan_check(VERSION 2 DETECT_QUIET)
-    if (CONAN_CMD)
-        conan_cmake_install(PATH_OR_REFERENCE ${conanfile}
-                BUILD missing
-                SETTINGS ${settings}
-                OPTIONS "${conan_options}")
-    else ()
-        message(WARNING "No conan executable was found. Dependency retrieval via conan is disabled. System dependencies will be used if available.")
+        # next 3 lines extract the major compiler version
+        SET(CONAN_COMPILER_VERSION "${CMAKE_CXX_COMPILER_VERSION}")
+        string(REPLACE "." ";" CONAN_COMPILER_VERSION "${CONAN_COMPILER_VERSION}")
+        list(GET CONAN_COMPILER_VERSION 0 CONAN_COMPILER_VERSION)
+
+        SET(CONAN_CPPSTD gnu23)
+
+        if (BUILD_SHARED_LIBS)
+            SET(CONAN_RUNTIME static)
+        else ()
+            SET(CONAN_RUNTIME dynamic)
+        endif ()
+
+        SET(CONAN_BUILD_TYPE "${CMAKE_BUILD_TYPE}")
+
+        # there seems to be no way anymore to pass environment variables to conan install. Documentation is still Work in progress, see https://docs.conan.io/1/migrating_to_2.0/general.html#environment-variables
+        set(ENV{CXX} "${CMAKE_CXX_COMPILER}")
+        set(ENV{CC} "${CMAKE_C_COMPILER}")
+        SET(BUILD_CMD conan install . -of ${CMAKE_BINARY_DIR} -s:h build_type=${CONAN_BUILD_TYPE} -s:b build_type=${CONAN_BUILD_TYPE} -s:h compiler=${CONAN_COMPILER} -s:b compiler=${CONAN_COMPILER} -s:h compiler.cppstd=${CONAN_CPPSTD} -s:b compiler.cppstd=${CONAN_CPPSTD} -s:h compiler.libcxx=libstdc++11 -s:b compiler.libcxx=libstdc++11 -s:h compiler.version=${CONAN_COMPILER_VERSION} -s:b compiler.version=${CONAN_COMPILER_VERSION} --build missing)
+        message("${BUILD_CMD}")
+        #    SET(BUILD_CMD "echo '${CXX} ${CC}'")
+        execute_process(COMMAND ${BUILD_CMD}
+                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                RESULT_VARIABLE CONAN_INSTALL_RESULT)
+        if (NOT CONAN_INSTALL_RESULT EQUAL "0")
+            message(FATAL_ERROR "${BUILD_CMD}\n${CONAN_INSTALL_RESULT}")
+        endif ()
+
+        #    conan_cmake_autodetect(settings)
+        #    conan_check(VERSION 2 DETECT_QUIET)
+        #    if (CONAN_CMD)
+        #        conan_cmake_install(PATH_OR_REFERENCE ${conanfile} -s:b
+        #                BUILD missing
+        #                SETTINGS ${settings}
+        #                OPTIONS "${conan_options}")
+        #    else ()
+        #        message(WARNING "No conan executable was found. Dependency retrieval via conan is disabled. System dependencies will be used if available.")
+        #    endif ()
     endif ()
 endmacro()

--- a/conanfile.py
+++ b/conanfile.py
@@ -8,15 +8,9 @@ from conan import ConanFile
 from conan.tools.files import load, rmdir, copy
 
 
-def retrieve_version_from_cmake():
-    from pathlib import Path
-    cmake_file = Path("CMakeLists.txt").read_text()
-    return re.search(r"project\([^)]*VERSION\s+(\d+\.\d+.\d+)[^)]*\)", cmake_file).group(1)
-
-
 class Recipe(ConanFile):
     name = "rdf4cpp"
-    version = retrieve_version_from_cmake()
+    version = "0.0.11"
 
     author = "https://github.com/rdf4cpp"
     url = "https://github.com/rdf4cpp/rdf4cpp"
@@ -43,11 +37,6 @@ class Recipe(ConanFile):
 
         self.requires("fmt/9.1.0", **header_only_non_transitive)
         self.requires("utfcpp/3.2.3", **header_only_non_transitive)
-
-    def set_version(self):
-        if not hasattr(self, 'version') or self.version is None:
-            cmake_file = load(self, os.path.join(self.recipe_folder, "CMakeLists.txt"))
-            self.version = re.search(r"project\([^)]*VERSION\s+(\d+\.\d+.\d+)[^)]*\)", cmake_file).group(1)
 
     def config_options(self):
         if self.settings.os == "Windows":

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,11 +1,11 @@
 import os
 import re
 
-from conan.tools.cmake import CMake
+from conan.tools.cmake import CMake, cmake_layout, CMakeToolchain, CMakeDeps
 
 from conan import ConanFile
 
-from conan.tools.files import load, copy, rmdir
+from conan.tools.files import load, rmdir, copy
 
 
 class Recipe(ConanFile):
@@ -23,13 +23,15 @@ class Recipe(ConanFile):
     default_options = {"shared": False, "fPIC": True}
     exports = "LICENSE",
     exports_sources = "src/*", "private/*", "CMakeLists.txt", "cmake/*"
-    requires = (("fmt/9.0.0", "private"),  # format must only be used within cpp files
-                "expected-lite/0.6.2",
-                "boost/1.79.0",
-                "re2/20221201",
-                ("utfcpp/3.2.3", "private"))
 
-    generators = ("CMakeDeps", "CMakeToolchain")
+    def requirements(self):
+        self.requires("expected-lite/0.6.2", transitive_headers=True)
+        self.requires("boost/1.79.0", transitive_headers=True, transitive_libs=True)
+        self.requires("re2/20221201", transitive_headers=True, transitive_libs=True)
+        header_only_non_transitive = {"headers": True, "libs": False, "build": False, "run": False,
+                                      "transitive_libs": False, "transitive_headers": False}
+        self.requires("fmt/9.0.0", **header_only_non_transitive)
+        self.requires("utfcpp/3.2.3", **header_only_non_transitive)
 
     def set_version(self):
         if not hasattr(self, 'version') or self.version is None:
@@ -38,25 +40,33 @@ class Recipe(ConanFile):
 
     def config_options(self):
         if self.settings.os == "Windows":
-            del self.options.fPIC
+            self.options.rm_safe("fPIC")
         self.options["fmt"].header_only = True
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+        tc = CMakeToolchain(self)
+        tc.generate()
 
     _cmake = None
 
     def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.configure(variables={"USE_CONAN": False})
-
+        if not self._cmake:
+            self._cmake = CMake(self)
+            self._cmake.configure(variables={"USE_CONAN": False, "BUILD_TESTING": False})
         return self._cmake
 
     def build(self):
-        self._configure_cmake().build()
+        cmake = self._configure_cmake()
+        cmake.build()
 
     def package(self):
-        self._configure_cmake().install()
-        rmdir(self, os.path.join(self.package_folder, "cmake"))
+        cmake = self._configure_cmake()
+        cmake.install()
         rmdir(self, os.path.join(self.package_folder, "share"))
         copy(self, "LICENSE", src=self.recipe_folder, dst="licenses")
         copy(self, os.path.join("serd", "COPYING"), src=self.build_folder, dst="licenses")

--- a/conanfile.py
+++ b/conanfile.py
@@ -8,9 +8,15 @@ from conan import ConanFile
 from conan.tools.files import load, rmdir, copy
 
 
+def retrieve_version_from_cmake():
+    from pathlib import Path
+    cmake_file = Path("CMakeLists.txt").read_text()
+    return re.search(r"project\([^)]*VERSION\s+(\d+\.\d+.\d+)[^)]*\)", cmake_file).group(1)
+
+
 class Recipe(ConanFile):
     name = "rdf4cpp"
-    version = None
+    version = retrieve_version_from_cmake()
 
     author = "https://github.com/rdf4cpp"
     url = "https://github.com/rdf4cpp/rdf4cpp"
@@ -37,11 +43,6 @@ class Recipe(ConanFile):
 
         self.requires("fmt/9.1.0", **header_only_non_transitive)
         self.requires("utfcpp/3.2.3", **header_only_non_transitive)
-
-    def set_version(self):
-        if not hasattr(self, 'version') or self.version is None:
-            cmake_file = load(self, os.path.join(self.recipe_folder, "CMakeLists.txt"))
-            self.version = re.search(r"project\([^)]*VERSION\s+(\d+\.\d+.\d+)[^)]*\)", cmake_file).group(1)
 
     def config_options(self):
         if self.settings.os == "Windows":

--- a/conanfile.py
+++ b/conanfile.py
@@ -18,6 +18,7 @@ class Recipe(ConanFile):
     topics = ("rdf", "semantic-web", "sparql", "knowledge-graphs", "C++20")
 
     # Binary configuration
+    package_type = "library"
     settings = "os", "compiler", "build_type", "arch"
     options = {"shared": [True, False], "fPIC": [True, False]}
     default_options = {"shared": False, "fPIC": True}
@@ -25,12 +26,16 @@ class Recipe(ConanFile):
     exports_sources = "src/*", "private/*", "CMakeLists.txt", "cmake/*"
 
     def requirements(self):
-        self.requires("expected-lite/0.6.2", transitive_headers=True)
-        self.requires("boost/1.79.0", transitive_headers=True, transitive_libs=True)
-        self.requires("re2/20221201", transitive_headers=True, transitive_libs=True)
+        transitive = {"headers": True, "libs": True, "transitive_headers": True, "transitive_libs": True}
+        transitive_header_only = {"headers": True, "transitive_headers": True}
         header_only_non_transitive = {"headers": True, "libs": False, "build": False, "run": False,
                                       "transitive_libs": False, "transitive_headers": False}
-        self.requires("fmt/9.0.0", **header_only_non_transitive)
+
+        self.requires("expected-lite/0.6.2", **transitive_header_only)
+        self.requires("boost/1.81.0", **transitive)
+        self.requires("re2/20230201", **transitive)
+
+        self.requires("fmt/9.1.0", **header_only_non_transitive)
         self.requires("utfcpp/3.2.3", **header_only_non_transitive)
 
     def set_version(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -44,6 +44,11 @@ class Recipe(ConanFile):
         self.requires("fmt/9.1.0", **header_only_non_transitive)
         self.requires("utfcpp/3.2.3", **header_only_non_transitive)
 
+    def set_version(self):
+        if not hasattr(self, 'version') or self.version is None:
+            cmake_file = load(self, os.path.join(self.recipe_folder, "CMakeLists.txt"))
+            self.version = re.search(r"project\([^)]*VERSION\s+(\d+\.\d+.\d+)[^)]*\)", cmake_file).group(1)
+
     def config_options(self):
         if self.settings.os == "Windows":
             self.options.rm_safe("fPIC")

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 project(PackageTest CXX)
 
-find_package(rdf4cpp REQUIRED)
+find_package(rdf4cpp CONFIG REQUIRED)
 
 add_executable(example example.cpp)
 

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,25 +1,28 @@
 import os
-from conans import ConanFile
-from conan.tools.cmake import CMake, CMakeToolchain
-from conan.tools.layout import cmake_layout
 
-required_conan_version = ">=1.43.0"
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
+
+required_conan_version = ">=2.0"
+
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "CMakeDeps"
+    generators = "CMakeToolchain", "CMakeDeps"
 
-    def generate(self):
-        tc = CMakeToolchain(self)
-        tc.generate()
-
-    def layout(self):
-        cmake_layout(self)
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
 
+    def layout(self):
+        cmake_layout(self)
+
     def test(self):
-        self.run(os.path.join(self.cpp.build.bindirs[0], "example"), run_environment=True)
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindir, "example")
+            self.run(cmd, env="conanrun")


### PR DESCRIPTION
I see right now no way how one could easily use conan 2.0 within CLion. As I see it, either CLion would need better support for CMakePreset creating processes (like conan 2.0) or we would need an updated cmake integration for conan. 

I'll keep this one draft and open for when conan evolved. 