### PR TITLE
Fix: use conan 1.x for now

### DIFF
--- a/.github/workflows/reusable_packaging_and_deployment.yml
+++ b/.github/workflows/reusable_packaging_and_deployment.yml
@@ -40,7 +40,7 @@ jobs:
           CC: ${{ steps.install_cc.outputs.cc }}
           CXX: ${{ steps.install_cc.outputs.cxx }}
         run: |
-          pip3 install "conan>=1.59,<2.0" ${{ fromJSON('["", "gcovr"]')[inputs.with-coverage] }}
+          pip3 install "conan==1.59" ${{ fromJSON('["", "gcovr"]')[inputs.with-coverage] }}
           conan user
           conan profile new --detect default
           conan profile update settings.compiler.libcxx=libstdc++11 default

--- a/.github/workflows/reusable_packaging_and_deployment.yml
+++ b/.github/workflows/reusable_packaging_and_deployment.yml
@@ -40,7 +40,7 @@ jobs:
           CC: ${{ steps.install_cc.outputs.cc }}
           CXX: ${{ steps.install_cc.outputs.cxx }}
         run: |
-          pip3 install conan ${{ fromJSON('["", "gcovr"]')[inputs.with-coverage] }}
+          pip3 install "conan>=1.59,<2.0" ${{ fromJSON('["", "gcovr"]')[inputs.with-coverage] }}
           conan user
           conan profile new --detect default
           conan profile update settings.compiler.libcxx=libstdc++11 default

--- a/.github/workflows/reusable_run_test_and_examples_by_linking_type.yml
+++ b/.github/workflows/reusable_run_test_and_examples_by_linking_type.yml
@@ -51,7 +51,7 @@ jobs:
           CC: ${{ steps.install_cc.outputs.cc }}
           CXX: ${{ steps.install_cc.outputs.cxx }}
         run: |
-          pip3 install conan ${{ fromJSON('["", "gcovr"]')[inputs.with-coverage] }}
+          pip3 install "conan>=1.59,<2.0" ${{ fromJSON('["", "gcovr"]')[inputs.with-coverage] }}
           conan user
           conan profile new --detect default
           conan profile update settings.compiler.libcxx=libstdc++11 default

--- a/.github/workflows/reusable_run_test_and_examples_by_linking_type.yml
+++ b/.github/workflows/reusable_run_test_and_examples_by_linking_type.yml
@@ -51,7 +51,7 @@ jobs:
           CC: ${{ steps.install_cc.outputs.cc }}
           CXX: ${{ steps.install_cc.outputs.cxx }}
         run: |
-          pip3 install "conan>=1.59,<2.0" ${{ fromJSON('["", "gcovr"]')[inputs.with-coverage] }}
+          pip3 install "conan==1.59" ${{ fromJSON('["", "gcovr"]')[inputs.with-coverage] }}
           conan user
           conan profile new --detect default
           conan profile update settings.compiler.libcxx=libstdc++11 default


### PR DESCRIPTION
I found several draw-backs that make it very hard for us to use Conan 2.0 at the moment. Overall, it looks really promising because it supports very fine-grained dependency management between packages. 
I made the CI work with Conan 2.0 packages in #154. Still, I think that Conan 2.0 is missing a CMake or CLion integration is a blocker for migration. 

This PR basically fixes the Conan version to 1.x