### PR TITLE
Fix: namespace ambiguity

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -29,6 +29,7 @@ class Recipe(ConanFile):
                 "re2/20221201",
                 ("utfcpp/3.2.3", "private"),
                 "openssl/3.0.8",
+                "zlib/1.2.12",
                 "uni-algo/0.7.1@rdf4cpp/temporary")
 
     generators = ("CMakeDeps", "CMakeToolchain")

--- a/conanfile.py
+++ b/conanfile.py
@@ -29,7 +29,7 @@ class Recipe(ConanFile):
                 "re2/20221201",
                 ("utfcpp/3.2.3", "private"),
                 "openssl/3.0.8",
-                "zlib/1.2.12",
+                "zlib/1.2.12", # force override version from openssl and boost
                 "uni-algo/0.7.1@rdf4cpp/temporary")
 
     generators = ("CMakeDeps", "CMakeToolchain")

--- a/src/rdf4cpp/rdf/datatypes/rdf/LangString.hpp
+++ b/src/rdf4cpp/rdf/datatypes/rdf/LangString.hpp
@@ -51,12 +51,10 @@ struct LangString : registry::LiteralDatatypeImpl<registry::rdf_lang_string,
 template<>
 struct std::hash<rdf4cpp::rdf::datatypes::registry::LangStringRepr> {
     size_t operator()(rdf4cpp::rdf::datatypes::registry::LangStringRepr const &x) const noexcept {
-        using namespace rdf4cpp::rdf::storage::util;
-
-        return robin_hood::hash<std::array<size_t, 2>>{}(
+        return rdf4cpp::rdf::storage::util::robin_hood::hash<std::array<size_t, 2>>{}(
                 std::array<size_t, 2>{
-                        robin_hood::hash<std::string_view>{}(x.lexical_form),
-                        robin_hood::hash<std::string_view>{}(x.language_tag)});
+                        rdf4cpp::rdf::storage::util::robin_hood::hash<std::string_view>{}(x.lexical_form),
+                        rdf4cpp::rdf::storage::util::robin_hood::hash<std::string_view>{}(x.language_tag)});
     }
 };
 


### PR DESCRIPTION
Currently if you include rdf4cpp in a project that also uses robin hood the library will not compile as the namespace `robin_hood` will be ambiguous in the changed function.

Also needed to force `zlib` to a specific version as rdf4cpp would not compile on my machine otherwise, no idea why.