### PR TITLE
Fix: namespace in version header

### DIFF
--- a/cmake/version.hpp.in
+++ b/cmake/version.hpp.in
@@ -3,10 +3,10 @@
 
 #include <array>
 
-namespace dice::rdf4cpp {
+namespace rdf4cpp {
 inline constexpr const char name[] = "rdf4cpp";
 inline constexpr const char version[] = "@PROJECT_VERSION@";
 inline constexpr std::array<int, 3> version_tuple = {@PROJECT_VERSION_MAJOR@, @PROJECT_VERSION_MINOR@, @PROJECT_VERSION_PATCH@};
-}// namespace dice::rdf4cpp
+}// namespace rdf4cpp
 
 #endif//RDF4CPP_VERSION_H


### PR DESCRIPTION
Remember that thing in in the tentris PR where I needed to always write `::rdf4cpp` (absolute namspace), that was caused by this namespace being wrong.