### PR TITLE
add github actions to publish release package

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   publish-conan-branch-package:
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-    uses: dice-group/cpp-conan-release-reusable-workflow/.github/workflows/publish-release.yml@feature/toggle-to-allow-release-updates
+    uses: dice-group/cpp-conan-release-reusable-workflow/.github/workflows/publish-release.yml@main
     with:
       public_artifactory: true
       os: ubuntu-22.04

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -9,13 +9,14 @@ concurrency:
 jobs:
   publish-conan-branch-package:
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-    uses: dice-group/cpp-conan-release-reusable-workflow/.github/workflows/publish-release.yml@main
+    uses: dice-group/cpp-conan-release-reusable-workflow/.github/workflows/publish-release.yml@feature/toggle-to-allow-release-updates
     with:
       public_artifactory: true
       os: ubuntu-22.04
       compiler: clang-14
       cmake-version: 3.22.6
       conan-version: 1.58
+      allow-update: true
     secrets:
       CONAN_USER: ${{ secrets.CONAN_USER }}
       CONAN_PW: ${{ secrets.CONAN_PW }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,21 @@
+name: Publish Release
+
+on:
+  create:
+
+concurrency:
+  group: publish-release-${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  publish-conan-branch-package:
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    uses: dice-group/cpp-conan-release-reusable-workflow/.github/workflows/publish-release.yml@main
+    with:
+      public_artifactory: true
+      os: ubuntu-22.04
+      compiler: clang-14
+      cmake-version: 3.22.6
+      conan-version: 1.58
+    secrets:
+      CONAN_USER: ${{ secrets.CONAN_USER }}
+      CONAN_PW: ${{ secrets.CONAN_PW }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -16,7 +16,7 @@ jobs:
       compiler: clang-14
       cmake-version: 3.22.6
       conan-version: 1.58
-      allow-update: true
+      use-tag: true
     secrets:
       CONAN_USER: ${{ secrets.CONAN_USER }}
       CONAN_PW: ${{ secrets.CONAN_PW }}


### PR DESCRIPTION
Allows to automatically create releases on develop. 
The workflow is the following:
- make sure the code on develop uses the version you want to tag in the CMake/conan file. 
- create a new release via the gui or push a tag on the develop branch with tag v{version}, e.g. v0.11.3
- If the version from the tag and the CMake/conan match, the GitHub Release will be overwritten and a conan package `rdf4cpp/{version}@` will be published.