### PR TITLE
Fix: CI Debug build and flag optimization

### DIFF
--- a/.github/workflows/reusable_run_test_and_examples_by_linking_type.yml
+++ b/.github/workflows/reusable_run_test_and_examples_by_linking_type.yml
@@ -70,14 +70,10 @@ jobs:
         env:
           CC: ${{ steps.install_cc.outputs.cc }}
           CXX: ${{ steps.install_cc.outputs.cxx }}
-          CXXFLAGS: |
-            -Wno-unused-command-line-argument -fuse-ld=mold \
-            ${{ fromJSON('["", "-fsanitize=undefined -fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls"]')[inputs.with-sanitizer] }} \
-            ${{ fromJSON('["", "--coverage"]')[inputs.with-coverage] }}
-        run: |
-          cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DBUILD_EXAMPLES=ON \
-          ${{ fromJSON('["", "-DBUILD_SHARED_LIBS=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON"]')[inputs.build-shared-libs] }} \
-          -G Ninja -B build_dir
+          CXXFLAGS: -Wno-unused-command-line-argument -fuse-ld=mold ${{ fromJSON('["", "-fsanitize=undefined -fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls"]')[inputs.with-sanitizer] }} ${{ fromJSON('["", "--coverage"]')[inputs.with-coverage] }}
+        run: >
+          cmake -G Ninja -B build_dir -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DBUILD_EXAMPLES=ON
+          ${{ fromJSON('["", "-DBUILD_SHARED_LIBS=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON"]')[inputs.build-shared-libs] }}
 
       - name: Build Tests & Examples
         working-directory: build_dir
@@ -85,8 +81,7 @@ jobs:
 
       - name: Run tests
         working-directory: build_dir
-        run: |
-          ctest --parallel 2 --verbose
+        run: ctest --parallel 2 --verbose
 
       - name: Report coverage
         env:

--- a/.github/workflows/reusable_run_test_and_examples_by_linking_type.yml
+++ b/.github/workflows/reusable_run_test_and_examples_by_linking_type.yml
@@ -67,14 +67,17 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build Tests & Examples
-        run: |
-          cmake -G Ninja -B build_dir -DBUILD_TESTING=ON -DBUILD_EXAMPLES=ON \
-          ${{ fromJSON('["", "-DBUILD_SHARED_LIBS=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON"]')[inputs.build-shared-libs] }}
-          cmake --build build_dir
         env:
           CC: ${{ steps.install_cc.outputs.cc }}
           CXX: ${{ steps.install_cc.outputs.cxx }}
-          CXXFLAGS: ${{ fromJSON('["", "-fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer -Wno-unused-command-line-argument -fuse-ld=lld"]')[inputs.with-sanitizer] }} ${{ fromJSON('["", "--coverage"]')[inputs.with-coverage] }}
+          CXXFLAGS: >
+            -Wno-unused-command-line-argument -fuse-ld=mold
+            ${{ fromJSON('["", "-fsanitize=undefined -fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls"]')[inputs.with-sanitizer] }}
+            ${{ fromJSON('["", "--coverage"]')[inputs.with-coverage] }}
+        run: |
+          cmake -G Ninja -B build_dir -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DBUILD_EXAMPLES=ON \
+          ${{ fromJSON('["", "-DBUILD_SHARED_LIBS=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON"]')[inputs.build-shared-libs] }}
+          cmake --build build_dir --parallel 2
 
       - name: Run tests
         working-directory: build_dir

--- a/.github/workflows/reusable_run_test_and_examples_by_linking_type.yml
+++ b/.github/workflows/reusable_run_test_and_examples_by_linking_type.yml
@@ -70,13 +70,13 @@ jobs:
         env:
           CC: ${{ steps.install_cc.outputs.cc }}
           CXX: ${{ steps.install_cc.outputs.cxx }}
-          CXXFLAGS: >
-            -Wno-unused-command-line-argument -fuse-ld=mold
-            ${{ fromJSON('["", "-fsanitize=undefined -fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls"]')[inputs.with-sanitizer] }}
+          CXXFLAGS: |
+            -Wno-unused-command-line-argument -fuse-ld=mold \
+            ${{ fromJSON('["", "-fsanitize=undefined -fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls"]')[inputs.with-sanitizer] }} \
             ${{ fromJSON('["", "--coverage"]')[inputs.with-coverage] }}
-        run: >
-          cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DBUILD_EXAMPLES=ON
-          ${{ fromJSON('["", "-DBUILD_SHARED_LIBS=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON"]')[inputs.build-shared-libs] }}
+        run: |
+          cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DBUILD_EXAMPLES=ON \
+          ${{ fromJSON('["", "-DBUILD_SHARED_LIBS=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON"]')[inputs.build-shared-libs] }} \
           -G Ninja -B build_dir
 
       - name: Build Tests & Examples

--- a/.github/workflows/reusable_run_test_and_examples_by_linking_type.yml
+++ b/.github/workflows/reusable_run_test_and_examples_by_linking_type.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Check out sources
         uses: actions/checkout@v3
 
-      - name: Build Tests & Examples
+      - name: Configure CMake
         env:
           CC: ${{ steps.install_cc.outputs.cc }}
           CXX: ${{ steps.install_cc.outputs.cxx }}
@@ -74,10 +74,14 @@ jobs:
             -Wno-unused-command-line-argument -fuse-ld=mold
             ${{ fromJSON('["", "-fsanitize=undefined -fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls"]')[inputs.with-sanitizer] }}
             ${{ fromJSON('["", "--coverage"]')[inputs.with-coverage] }}
-        run: |
-          cmake -G Ninja -B build_dir -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DBUILD_EXAMPLES=ON \
+        run: >
+          cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DBUILD_EXAMPLES=ON
           ${{ fromJSON('["", "-DBUILD_SHARED_LIBS=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON"]')[inputs.build-shared-libs] }}
-          cmake --build build_dir --parallel 2
+          -G Ninja -B build_dir
+
+      - name: Build Tests & Examples
+        working-directory: build_dir
+        run: cmake --build . --parallel 2
 
       - name: Run tests
         working-directory: build_dir

--- a/examples/literal_datatypes.cpp
+++ b/examples/literal_datatypes.cpp
@@ -21,10 +21,10 @@ void lexical_access() {
 
     Literal lang_string = Literal::make_lang_tagged("Hello", "en-US");
     assert(lang_string.lexical_form() == "Hello");
-    assert(lang_string.language_tag() == "en-US");
+    assert(lang_string.language_tag() == "en-us");
     assert(lang_string.language_tag_matches_range("*"));
     assert(lang_string.language_tag_matches_range("en"));
-    assert(std::string{lang_string} == R"#("Hello"@en-US)#");
+    assert(std::string{lang_string} == R"#("Hello"@en-us)#");
 }
 
 void direct_value_access() {


### PR DESCRIPTION
The CI was not building the tests in ReleaseWithDebugInfo instead of Debug which will disable all `assert`s. This is not very useful for testing purposes. Also added an option that makes `ASan` output more readable, and enabled parallel build.

For some unknown-to-me reason I am not allowed to use yamls `>` to put the `CXXFLAGS` into a multiline block, cmake just can't cope for some reason. (Even though the `>` should simply replace all newlines in the block with single spaces.)