### PR TITLE
Fix: prevent default node storage instance overwrite

### DIFF
--- a/src/rdf4cpp/rdf/storage/node/NodeStorage.cpp
+++ b/src/rdf4cpp/rdf/storage/node/NodeStorage.cpp
@@ -55,6 +55,7 @@ NodeStorage &NodeStorage::default_instance() {
 }
 
 void NodeStorage::set_default_instance(NodeStorage const &node_context) {
+    std::call_once(default_init_once_flag, []() {});
     default_instance_ = node_context;
 }
 

--- a/tests/nodes/tests_NodeStorage_lifetime.cpp
+++ b/tests/nodes/tests_NodeStorage_lifetime.cpp
@@ -279,4 +279,10 @@ TEST_SUITE("NodeStorage lifetime and ref counting") {
             run.store(true, std::memory_order_release);
         }
     }
+
+    TEST_CASE("no default instance overwrite") {
+        auto inst = NodeStorage::new_instance();
+        NodeStorage::set_default_instance(inst);
+        CHECK(NodeStorage::default_instance().id() == inst.id());
+    }
 }


### PR DESCRIPTION
Previously a sequence of
```c++
NodeStorage::set_default_instance(...some-instance);
auto &dinst = NodeStorage::default_instance();
```
would overwrite the original node storage the user had set because the internal init-once-flag was never set by `set_default_instance()`, and therefore `default_instance()` would itself initialize the default instance to an instance of the default backend.

This PR does not synchronize multiple calls to `set_default_instance()` or `default_instance()` in general cases, so multiple threads trying to initialize the `default node storage` will not work reliably. But that is probably either something for later or never since at least to me it is not entirely clear why multiple threads would try to compete around setting the default instance.