### PR TITLE
Feature+Fix: adding `Node::try_get_in_node_storage` and fixing `Node::to_node_storage`

### DIFF
--- a/src/rdf4cpp/rdf/BlankNode.cpp
+++ b/src/rdf4cpp/rdf/BlankNode.cpp
@@ -2,7 +2,7 @@
 
 namespace rdf4cpp::rdf {
 BlankNode::BlankNode() noexcept : Node{NodeBackendHandle{{}, storage::node::identifier::RDFNodeType::BNode, {}}} {}
-BlankNode::BlankNode(std::string_view identifier, Node::NodeStorage &node_storage)
+BlankNode::BlankNode(std::string_view identifier, NodeStorage &node_storage)
     : Node(NodeBackendHandle{node_storage.find_or_make_id(storage::node::view::BNodeBackendView{.identifier = identifier}),
                              storage::node::identifier::RDFNodeType::BNode,
                              node_storage.id()}) {}
@@ -12,16 +12,29 @@ BlankNode BlankNode::make_null() noexcept {
     return BlankNode{};
 }
 
-BlankNode BlankNode::make(std::string_view identifier, Node::NodeStorage &node_storage) {
+BlankNode BlankNode::make(std::string_view identifier, NodeStorage &node_storage) {
     return BlankNode{identifier, node_storage};
 }
 
-BlankNode BlankNode::to_node_storage(Node::NodeStorage &node_storage) const noexcept {
+BlankNode BlankNode::to_node_storage(NodeStorage &node_storage) const noexcept {
     if (handle_.node_storage_id() == node_storage.id()) {
         return *this;
     }
 
     auto const node_id = node_storage.find_or_make_id(NodeStorage::find_bnode_backend_view(handle_));
+    return BlankNode{NodeBackendHandle{node_id, storage::node::identifier::RDFNodeType::BNode, node_storage.id()}};
+}
+
+BlankNode BlankNode::try_get_in_node_storage(NodeStorage const &node_storage) const noexcept {
+    if (handle_.node_storage_id() == node_storage.id()) {
+        return *this;
+    }
+
+    auto const node_id = node_storage.find_id(NodeStorage::find_bnode_backend_view(handle_));
+    if (node_id == NodeID{}) {
+        return BlankNode{};
+    }
+
     return BlankNode{NodeBackendHandle{node_id, storage::node::identifier::RDFNodeType::BNode, node_storage.id()}};
 }
 

--- a/src/rdf4cpp/rdf/BlankNode.hpp
+++ b/src/rdf4cpp/rdf/BlankNode.hpp
@@ -33,7 +33,8 @@ public:
      */
     [[nodiscard]] static BlankNode make(std::string_view identifier, NodeStorage &node_storage = NodeStorage::default_instance());
 
-    [[nodiscard]] BlankNode to_node_storage(NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
+    BlankNode to_node_storage(NodeStorage &node_storage) const noexcept;
+    [[nodiscard]] BlankNode try_get_in_node_storage(NodeStorage const &node_storage) const noexcept;
 
     /**
      * Get the string identifier of this. For BlankNode `_:abc` the identifier is `abc`.

--- a/src/rdf4cpp/rdf/IRI.cpp
+++ b/src/rdf4cpp/rdf/IRI.cpp
@@ -44,12 +44,25 @@ IRI IRI::make_uuid(Node::NodeStorage &node_storage) {
     return IRI{stream.view(), node_storage};
 }
 
-IRI IRI::to_node_storage(Node::NodeStorage &node_storage) const noexcept {
+IRI IRI::to_node_storage(NodeStorage &node_storage) const noexcept {
     if (handle_.node_storage_id() == node_storage.id()) {
         return *this;
     }
 
     auto const node_id = node_storage.find_or_make_id(NodeStorage::find_iri_backend_view(handle_));
+    return IRI{NodeBackendHandle{node_id, storage::node::identifier::RDFNodeType::IRI, node_storage.id()}};
+}
+
+IRI IRI::try_get_in_node_storage(NodeStorage const &node_storage) const noexcept {
+    if (handle_.node_storage_id() == node_storage.id()) {
+        return *this;
+    }
+
+    auto const node_id = node_storage.find_id(NodeStorage::find_iri_backend_view(handle_));
+    if (node_id == NodeID{}) {
+        return IRI{};
+    }
+
     return IRI{NodeBackendHandle{node_id, storage::node::identifier::RDFNodeType::IRI, node_storage.id()}};
 }
 

--- a/src/rdf4cpp/rdf/IRI.hpp
+++ b/src/rdf4cpp/rdf/IRI.hpp
@@ -57,7 +57,8 @@ public:
      */
     [[nodiscard]] static IRI make_uuid(NodeStorage &node_storage = NodeStorage::default_instance());
 
-    [[nodiscard]] IRI to_node_storage(NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
+    IRI to_node_storage(NodeStorage &node_storage) const noexcept;
+    [[nodiscard]] IRI try_get_in_node_storage(NodeStorage const &node_storage) const noexcept;
 
     /**
      * Get the IRI string of this.

--- a/src/rdf4cpp/rdf/Literal.hpp
+++ b/src/rdf4cpp/rdf/Literal.hpp
@@ -112,7 +112,7 @@ private:
      * @param inlined_value a valid inlined value for the given datatype (identified via a fixed_id) packed into the lower LiteralID::width bits of the integer
      * @note inlined_values for a datatype can be obtained via Datatype::try_into_inlined(value) if the datatype is inlineable (see registry::capabilities::Inlineable)
      */
-    [[nodiscard]] static Literal make_inlined_typed_unchecked(storage::node::identifier::LiteralID inlined_value, storage::node::identifier::LiteralType fixed_id, NodeStorage &node_storage) noexcept;
+    [[nodiscard]] static Literal make_inlined_typed_unchecked(storage::node::identifier::LiteralID inlined_value, storage::node::identifier::LiteralType fixed_id, NodeStorage const &node_storage) noexcept;
 
     /**
      * Creates an inlined or non-inlined typed Literal without any safety checks
@@ -320,7 +320,8 @@ public:
      */
     [[nodiscard]] static Literal generate_random_double(NodeStorage &node_storage = NodeStorage::default_instance());
 
-    [[nodiscard]] Literal to_node_storage(NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
+    Literal to_node_storage(NodeStorage &node_storage) const noexcept;
+    [[nodiscard]] Literal try_get_in_node_storage(NodeStorage const &node_storage) const noexcept;
 
     /**
      * Checks if the datatype of this matches the provided LiteralDatatype

--- a/src/rdf4cpp/rdf/Node.cpp
+++ b/src/rdf4cpp/rdf/Node.cpp
@@ -16,29 +16,43 @@ Node Node::make_null() noexcept {
 }
 
 Node Node::to_node_storage(Node::NodeStorage &node_storage) const noexcept {
-    if (handle_.node_storage_id() == node_storage.id())
-        return *this;
-    else {
-        auto const into_node = [&](NodeID node_id) {
-            return Node{NodeBackendHandle{node_id, handle_.type(), node_storage.id()}};
-        };
+    switch (handle_.type()) {
+        case RDFNodeType::Variable: {
+            return query::Variable{handle_}.to_node_storage(node_storage);
+        }
+        case RDFNodeType::BNode: {
+            return BlankNode{handle_}.to_node_storage(node_storage);
+        }
+        case RDFNodeType::IRI: {
+            return IRI{handle_}.to_node_storage(node_storage);
+        }
+        case RDFNodeType::Literal: {
+            return Literal{handle_}.to_node_storage(node_storage);
+        }
+        default: {
+            assert(false);
+            __builtin_unreachable();
+        }
+    }
+}
 
-        switch (this->backend_handle().type()) {
-            case RDFNodeType::Variable: {
-                return into_node(node_storage.find_or_make_id(NodeStorage::find_variable_backend_view(handle_)));
-            }
-            case RDFNodeType::BNode: {
-                return into_node(node_storage.find_or_make_id(NodeStorage::find_bnode_backend_view(handle_)));
-            }
-            case RDFNodeType::IRI: {
-                return into_node(node_storage.find_or_make_id(NodeStorage::find_iri_backend_view(handle_)));
-            }
-            case RDFNodeType::Literal: {
-                return Literal{handle_}.to_node_storage(node_storage);
-            }
-            default:
-                assert(false);
-                __builtin_unreachable();
+Node Node::try_get_in_node_storage(NodeStorage const &node_storage) const noexcept {
+    switch (handle_.type()) {
+        case RDFNodeType::Variable: {
+            return query::Variable{handle_}.try_get_in_node_storage(node_storage);
+        }
+        case RDFNodeType::BNode: {
+            return BlankNode{handle_}.try_get_in_node_storage(node_storage);
+        }
+        case RDFNodeType::IRI: {
+            return IRI{handle_}.try_get_in_node_storage(node_storage);
+        }
+        case RDFNodeType::Literal: {
+            return Literal{handle_}.try_get_in_node_storage(node_storage);
+        }
+        default: {
+            assert(false);
+            __builtin_unreachable();
         }
     }
 }

--- a/src/rdf4cpp/rdf/Node.hpp
+++ b/src/rdf4cpp/rdf/Node.hpp
@@ -39,7 +39,19 @@ protected:
     explicit Node(NodeBackendHandle id) noexcept;
 
 public:
-    [[nodiscard]] Node to_node_storage(NodeStorage &node_storage) const noexcept;
+    /**
+     * Registers this node in the given node storage (if it does not already exist)
+     * @param node_storage node storage to register this node in
+     * @return this node but in node storage
+     */
+    Node to_node_storage(NodeStorage &node_storage) const noexcept;
+
+    /**
+     * Tries to retrieve this nodes equivalent node in the given node storage
+     * @param node_storage node storage to try to retrieve the node from
+     * @return this node but in node storage, or the null node if it does not exist in node_storage
+     */
+    [[nodiscard]] Node try_get_in_node_storage(NodeStorage const &node_storage) const noexcept;
 
     // TODO: revisit comparison implementation
     // TODO: support comparison between NodeStorages

--- a/src/rdf4cpp/rdf/query/Variable.cpp
+++ b/src/rdf4cpp/rdf/query/Variable.cpp
@@ -16,13 +16,26 @@ Variable Variable::make_anonymous(std::string_view name, Node::NodeStorage &node
     return Variable{name, true, node_storage};
 }
 
-query::Variable Variable::to_node_storage(Node::NodeStorage &node_storage) const noexcept {
+Variable Variable::to_node_storage(NodeStorage &node_storage) const noexcept {
     if (handle_.node_storage_id() == node_storage.id()) {
         return *this;
     }
 
     auto const node_id = node_storage.find_or_make_id(NodeStorage::find_variable_backend_view(handle_));
-    return query::Variable{NodeBackendHandle{node_id, storage::node::identifier::RDFNodeType::Variable, node_storage.id()}};
+    return Variable{NodeBackendHandle{node_id, storage::node::identifier::RDFNodeType::Variable, node_storage.id()}};
+}
+
+Variable Variable::try_get_in_node_storage(NodeStorage const &node_storage) const noexcept {
+    if (handle_.node_storage_id() == node_storage.id()) {
+        return *this;
+    }
+
+    auto const node_id = node_storage.find_id(NodeStorage::find_variable_backend_view(handle_));
+    if (node_id == NodeID{}) {
+        return Variable{};
+    }
+
+    return Variable{NodeBackendHandle{node_id, storage::node::identifier::RDFNodeType::Variable, node_storage.id()}};
 }
 
 bool Variable::is_anonymous() const {

--- a/src/rdf4cpp/rdf/query/Variable.hpp
+++ b/src/rdf4cpp/rdf/query/Variable.hpp
@@ -18,7 +18,8 @@ public:
     [[nodiscard]] static Variable make_named(std::string_view name, NodeStorage &node_storage = NodeStorage::default_instance());
     [[nodiscard]] static Variable make_anonymous(std::string_view name, NodeStorage &node_storage = NodeStorage::default_instance());
 
-    [[nodiscard]] query::Variable to_node_storage(NodeStorage &node_storage = NodeStorage::default_instance()) const noexcept;
+    Variable to_node_storage(NodeStorage &node_storage) const noexcept;
+    [[nodiscard]] Variable try_get_in_node_storage(NodeStorage const &node_storage) const noexcept;
 
     [[nodiscard]] bool is_anonymous() const;
 

--- a/src/rdf4cpp/rdf/util/BigDecimal.hpp
+++ b/src/rdf4cpp/rdf/util/BigDecimal.hpp
@@ -718,20 +718,20 @@ public:
      * conversion to a double
      * @return
      */
-    [[nodiscard]] constexpr explicit operator double() const noexcept {
-        double v = static_cast<double>(unscaled_value) * std::pow(static_cast<double>(base), -static_cast<double>(exponent));
+    [[nodiscard]] explicit operator double() const noexcept {
+        double const v = static_cast<double>(unscaled_value) * std::pow(static_cast<double>(base), -static_cast<double>(exponent));
         if (!std::isnan(v) && !std::isinf(v))
             return v;
         // even Javas BigDecimal has no better solution
-        auto s = static_cast<std::string>(*this);
-        return std::stod(s, nullptr);
+        auto const s = static_cast<std::string>(*this);
+        return std::stod(s);
     }
 
     /**
      * conversion to a float
      * @return
      */
-    [[nodiscard]] constexpr explicit operator float() const noexcept {
+    [[nodiscard]] explicit operator float() const noexcept {
         return static_cast<float>(static_cast<double>(*this));
     }
 

--- a/tests/nodes/tests_Literal.cpp
+++ b/tests/nodes/tests_Literal.cpp
@@ -873,7 +873,7 @@ TEST_CASE("to_node_storage") {
     }
 }
 
-TEST_CASE("to_node_storage") {
+TEST_CASE("try_get_in_node_storage") {
     auto ns2 = storage::node::NodeStorage::new_instance();
 
     SUBCASE("no non-inline storage available") {

--- a/tests/nodes/tests_Literal.cpp
+++ b/tests/nodes/tests_Literal.cpp
@@ -795,4 +795,182 @@ TEST_CASE("UUID") {
     CHECK(uuid.regex_matches(regex::Regex{"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"}) == util::TriBool::True);
 }
 
+TEST_CASE("to_node_storage") {
+    auto ns2 = storage::node::NodeStorage::new_instance();
+
+    SUBCASE("no non-inline storage available") {
+        auto lit = Literal::make_typed_from_value<datatypes::xsd::Int>(5);
+        assert(lit.is_inlined());
+
+        auto lit2 = lit.to_node_storage(ns2);
+        CHECK(lit2.is_inlined());
+        CHECK(lit.value<datatypes::xsd::Int>() == lit2.value<datatypes::xsd::Int>());
+        CHECK(lit.backend_handle().node_id().literal_id() == lit2.backend_handle().node_id().literal_id());
+        CHECK(lit.backend_handle().node_id().literal_type() == lit2.backend_handle().node_id().literal_type());
+        CHECK(lit.backend_handle().node_storage_id() != lit2.backend_handle().node_storage_id());
+    }
+
+    SUBCASE("specialized storage") {
+        SUBCASE("inlined") {
+            auto lit = Literal::make_typed_from_value<datatypes::xsd::Long>(10);
+            assert(lit.is_inlined());
+
+            auto lit2 = lit.to_node_storage(ns2);
+            CHECK(lit2.is_inlined());
+            CHECK(lit.value<datatypes::xsd::Long>() == lit2.value<datatypes::xsd::Long>());
+            CHECK(lit.backend_handle().node_id().literal_id() == lit2.backend_handle().node_id().literal_id());
+            CHECK(lit.backend_handle().node_id().literal_type() == lit2.backend_handle().node_id().literal_type());
+            CHECK(lit.backend_handle().node_storage_id() != lit2.backend_handle().node_storage_id());
+        }
+
+        SUBCASE("not inlined") {
+            auto lit = Literal::make_typed_from_value<datatypes::xsd::Long>(std::numeric_limits<datatypes::xsd::Long::cpp_type>::max());
+            assert(!lit.is_inlined());
+
+            auto lit2 = lit.to_node_storage(ns2);
+            CHECK(!lit2.is_inlined());
+            CHECK(lit.value<datatypes::xsd::Long>() == lit2.value<datatypes::xsd::Long>());
+            CHECK(lit.backend_handle().node_id().literal_type() == lit2.backend_handle().node_id().literal_type());
+            CHECK(lit.backend_handle().node_storage_id() != lit2.backend_handle().node_storage_id());
+        }
+    }
+
+    SUBCASE("lexical storage") {
+        SUBCASE("rdf:langString") {
+            SUBCASE("tag inlined") {
+                auto lit = Literal::make_lang_tagged("test", "en");
+                assert(lit.is_inlined());
+
+                auto lit2 = lit.to_node_storage(ns2);
+                CHECK(lit2.is_inlined());
+                CHECK(lit.value<datatypes::rdf::LangString>() == lit2.value<datatypes::rdf::LangString>());
+                CHECK(lit.backend_handle().node_id().literal_type() == lit2.backend_handle().node_id().literal_type());
+                CHECK(lit.backend_handle().node_storage_id() != lit2.backend_handle().node_storage_id());
+            }
+
+            SUBCASE("tag not inlined") {
+                auto lit = Literal::make_lang_tagged("test", "spherical");
+                assert(!lit.is_inlined());
+
+                auto lit2 = lit.to_node_storage(ns2);
+                CHECK(!lit2.is_inlined());
+                CHECK(lit.value<datatypes::rdf::LangString>() == lit2.value<datatypes::rdf::LangString>());
+                CHECK(lit.backend_handle().node_id().literal_type() == lit2.backend_handle().node_id().literal_type());
+                CHECK(lit.backend_handle().node_storage_id() != lit2.backend_handle().node_storage_id());
+            }
+        }
+
+        SUBCASE("xsd:string") {
+            auto lit = Literal::make_simple("test");
+            assert(!lit.is_inlined());
+
+            auto lit2 = lit.to_node_storage(ns2);
+            CHECK(!lit2.is_inlined());
+            CHECK(lit.value<datatypes::xsd::String>() == lit2.value<datatypes::xsd::String>());
+            CHECK(lit.backend_handle().node_id().literal_type() == lit2.backend_handle().node_id().literal_type());
+            CHECK(lit.backend_handle().node_storage_id() != lit2.backend_handle().node_storage_id());
+        }
+    }
+}
+
+TEST_CASE("to_node_storage") {
+    auto ns2 = storage::node::NodeStorage::new_instance();
+
+    SUBCASE("no non-inline storage available") {
+        auto lit = Literal::make_typed_from_value<datatypes::xsd::Int>(5);
+        assert(lit.is_inlined());
+
+        auto lit2 = lit.try_get_in_node_storage(ns2);
+        CHECK(!lit2.null());
+        CHECK(lit2.is_inlined());
+        CHECK(lit.value<datatypes::xsd::Int>() == lit2.value<datatypes::xsd::Int>());
+        CHECK(lit.backend_handle().node_id().literal_id() == lit2.backend_handle().node_id().literal_id());
+        CHECK(lit.backend_handle().node_id().literal_type() == lit2.backend_handle().node_id().literal_type());
+        CHECK(lit.backend_handle().node_storage_id() != lit2.backend_handle().node_storage_id());
+    }
+
+    SUBCASE("specialized storage") {
+        SUBCASE("inlined") {
+            auto lit = Literal::make_typed_from_value<datatypes::xsd::Long>(10);
+            assert(lit.is_inlined());
+
+            auto lit2 = lit.try_get_in_node_storage(ns2);
+            CHECK(!lit2.null());
+            CHECK(lit2.is_inlined());
+            CHECK(lit.value<datatypes::xsd::Long>() == lit2.value<datatypes::xsd::Long>());
+            CHECK(lit.backend_handle().node_id().literal_id() == lit2.backend_handle().node_id().literal_id());
+            CHECK(lit.backend_handle().node_id().literal_type() == lit2.backend_handle().node_id().literal_type());
+            CHECK(lit.backend_handle().node_storage_id() != lit2.backend_handle().node_storage_id());
+        }
+
+        SUBCASE("not inlined") {
+            auto lit = Literal::make_typed_from_value<datatypes::xsd::Long>(std::numeric_limits<datatypes::xsd::Long::cpp_type>::max());
+            assert(!lit.is_inlined());
+
+            auto lit2 = lit.try_get_in_node_storage(ns2);
+            CHECK(lit2.null());
+            lit.to_node_storage(ns2);
+
+            lit2 = lit.try_get_in_node_storage(ns2);
+            CHECK(!lit2.null());
+            CHECK(!lit2.is_inlined());
+            CHECK(lit.value<datatypes::xsd::Long>() == lit2.value<datatypes::xsd::Long>());
+            CHECK(lit.backend_handle().node_id().literal_type() == lit2.backend_handle().node_id().literal_type());
+            CHECK(lit.backend_handle().node_storage_id() != lit2.backend_handle().node_storage_id());
+        }
+    }
+
+    SUBCASE("lexical storage") {
+        SUBCASE("rdf:langString") {
+            SUBCASE("tag inlined") {
+                auto lit = Literal::make_lang_tagged("test", "en");
+                assert(lit.is_inlined());
+
+                auto lit2 = lit.try_get_in_node_storage(ns2);
+                CHECK(lit2.null());
+                lit.to_node_storage(ns2);
+
+                lit2 = lit.try_get_in_node_storage(ns2);
+                CHECK(!lit2.null());
+                CHECK(lit2.is_inlined());
+                CHECK(lit.value<datatypes::rdf::LangString>() == lit2.value<datatypes::rdf::LangString>());
+                CHECK(lit.backend_handle().node_id().literal_type() == lit2.backend_handle().node_id().literal_type());
+                CHECK(lit.backend_handle().node_storage_id() != lit2.backend_handle().node_storage_id());
+            }
+
+            SUBCASE("tag not inlined") {
+                auto lit = Literal::make_lang_tagged("test", "spherical");
+                assert(!lit.is_inlined());
+
+                auto lit2 = lit.try_get_in_node_storage(ns2);
+                CHECK(lit2.null());
+                lit.to_node_storage(ns2);
+
+                lit2 = lit.try_get_in_node_storage(ns2);
+                CHECK(!lit2.null());
+                CHECK(!lit2.is_inlined());
+                CHECK(lit.value<datatypes::rdf::LangString>() == lit2.value<datatypes::rdf::LangString>());
+                CHECK(lit.backend_handle().node_id().literal_type() == lit2.backend_handle().node_id().literal_type());
+                CHECK(lit.backend_handle().node_storage_id() != lit2.backend_handle().node_storage_id());
+            }
+        }
+
+        SUBCASE("xsd:string") {
+            auto lit = Literal::make_simple("test");
+            assert(!lit.is_inlined());
+
+            auto lit2 = lit.try_get_in_node_storage(ns2);
+            CHECK(lit2.null());
+            lit.to_node_storage(ns2);
+
+            lit2 = lit.try_get_in_node_storage(ns2);
+            CHECK(!lit2.null());
+            CHECK(!lit2.is_inlined());
+            CHECK(lit.value<datatypes::xsd::String>() == lit2.value<datatypes::xsd::String>());
+            CHECK(lit.backend_handle().node_id().literal_type() == lit2.backend_handle().node_id().literal_type());
+            CHECK(lit.backend_handle().node_storage_id() != lit2.backend_handle().node_storage_id());
+        }
+    }
+}
+
 #pragma clang diagnostic pop


### PR DESCRIPTION
This PR adds `Node::try_get_in_node_storage` a similar function `Node::to_node_storage` except that it will fail if the node does not already exist in the specified target node storage. Basically used non-mutably translating between node storages.

Additionally it fixes the implementation of `Node::to_node_storage` which did not account for all cases previously.

I will now list all cases that need to be handled here, to make the review easier:
1. normal inlined lit (doesn't matter what the target node storage is, will stay inlined)
2. inlined `rdf:langString` -> able to inline in new storage
3. inlined `rdf:langString` -> not able to inline in new storage
4. specialized storage -> specialized storage
5. specialized storage -> non-specialized storage
6. non-specialized storage -> non-specialized storage
7. non-specialized storage -> specialized storage

I've added best effort tests, but I simply cannot test the transfer between different node storage implementations without writing another implementation.

Note: yes I know the implementation of `Literal::to_node_storage` and `Literal::try_get_in_node_storage` are very similiar but I couldn't find a good way to extract the common bits.