### PR TITLE
Fix: gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,44 +43,8 @@ docu
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
-# User-specific stuff
-.idea/**/workspace.xml
-.idea/**/tasks.xml
-.idea/**/usage.statistics.xml
-.idea/**/dictionaries
-.idea/**/shelf
-
-# AWS User-specific
-.idea/**/aws.xml
-
-# Generated files
-.idea/**/contentModel.xml
-
-# Sensitive or high-churn files
-.idea/**/dataSources/
-.idea/**/dataSources.ids
-.idea/**/dataSources.local.xml
-.idea/**/sqlDataSources.xml
-.idea/**/dynamic.xml
-.idea/**/uiDesigner.xml
-.idea/**/dbnavigator.xml
-
-# Gradle
-.idea/**/gradle.xml
-.idea/**/libraries
-
-# Gradle and Maven with auto-import
-# When using Gradle or Maven with auto-import, you should exclude module files,
-# since they will be recreated, and may cause churn.  Uncomment if using
-# auto-import.
-# .idea/artifacts
-# .idea/compiler.xml
-# .idea/jarRepositories.xml
-# .idea/modules.xml
-# .idea/*.iml
-# .idea/modules
-# *.iml
-# *.ipr
+# CLion
+.idea/
 
 # CMake
 cmake-build-*/
@@ -100,32 +64,11 @@ out/
 # JIRA plugin
 atlassian-ide-plugin.xml
 
-# Cursive Clojure plugin
-.idea/replstate.xml
-
-# SonarLint plugin
-.idea/sonarlint/
-
 # Crashlytics plugin (for Android Studio and IntelliJ)
 com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 fabric.properties
-
-# Editor-based Rest Client
-.idea/httpRequests
-
-# Android studio 3.1+ serialized cache file
-.idea/caches/build_file_checksums.ser
-
-### CLion+all Patch ###
-# Ignore everything but code style settings and run configurations
-# that are supposed to be shared within teams.
-
-.idea/*
-
-!.idea/codeStyles
-!.idea/runConfigurations
 
 ### CMake ###
 CMakeLists.txt.user
@@ -150,6 +93,10 @@ conan.lock
 conanbuildinfo.*
 conaninfo.txt
 graph_info.json
+
+# Conan test_package
+test_package/CMakeUserPresets.json
+test_package/build/
 
 ## Various built-in generators
 # cmake_find_package generator https://docs.conan.io/en/latest/reference/generators/cmake_find_package.html

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,7 @@ src/rdf4cpp/rdf/version.hpp
 
 docu
 
-# Created by https://www.toptal.com/developers/gitignore/api/c++,conan,ninja,cmake,clion+all
-# Edit at https://www.toptal.com/developers/gitignore?templates=c++,conan,ninja,cmake,clion+all
+# Based on https://www.toptal.com/developers/gitignore/api/c++,conan,ninja,cmake,clion+all
 
 ### C++ ###
 # Prerequisites


### PR DESCRIPTION
Currently the gitignore is very selective about what it excludes from .idea/ which is annoying because we don't commit this directory and thus always have to manually not add it to the commit.

Additionally now correctly excludes files that get generated by `conan create`