### PR TITLE
Fix: boost dep in conan package

### DIFF
--- a/.github/workflows/publish-conan-branch-package.yml
+++ b/.github/workflows/publish-conan-branch-package.yml
@@ -13,6 +13,7 @@ jobs:
       os: ubuntu-22.04
       compiler: clang-14
       cmake-version: 3.22.6
+      conan-options: -o boost:header_only=True
     secrets:
       CONAN_USER: ${{ secrets.CONAN_USER }}
       CONAN_PW: ${{ secrets.CONAN_PW }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -16,6 +16,7 @@ jobs:
       cmake-version: 3.22.6
       conan-version: 1.58
       use-tag: true
+      conan-options: -o boost:header_only=True
     secrets:
       CONAN_USER: ${{ secrets.CONAN_USER }}
       CONAN_PW: ${{ secrets.CONAN_PW }}

--- a/.github/workflows/reusable_packaging_and_deployment.yml
+++ b/.github/workflows/reusable_packaging_and_deployment.yml
@@ -71,7 +71,7 @@ jobs:
           CXX: ${{ steps.install_cc.outputs.cxx }}
         run: |
           # build and test package
-          conan create . $(conan inspect . --raw name)/$(conan inspect . --raw version)@ci/testing -pr:b=default --build missing
+          conan create . $(conan inspect . --raw name)/$(conan inspect . --raw version)@ci/testing -pr:b=default --build missing -o boost:header_only=True
           conan remove -f $(conan inspect . --raw name)/$(conan inspect . --raw version)@ci/testing
 
   test-fetch-content-static:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if (IS_TOP_LEVEL AND USE_CONAN)
         set(CONAN_HYPERTRIE_WITH_TEST_DEPS "False")
     endif()
     set(CONAN_OPTIONS "with_test_deps=${CONAN_HYPERTRIE_WITH_TEST_DEPS}")
-    install_packages_via_conan("${CMAKE_SOURCE_DIR}/conanfile.py" "${CONAN_OPTIONS}")
+    install_packages_via_conan("${CMAKE_SOURCE_DIR}/conanfile.py" "${CONAN_OPTIONS};boost:header_only=True")
 endif ()
 
 # find packages

--- a/conanfile.py
+++ b/conanfile.py
@@ -28,7 +28,6 @@ class Recipe(ConanFile):
 
     def requirements(self):
         self.requires("boost/1.81.0")
-        self.options["boost"].header_only = True
         self.requires("expected-lite/0.6.2")
         self.requires("re2/20221201")
         self.requires("openssl/3.0.8")


### PR DESCRIPTION
rdf4cpp specified `boost:header_only=True` explicitly which prevents packages using rdf4cpp and boost from building