### PR TITLE
Add special case for xsd:string in serialization

### DIFF
--- a/src/rdf4cpp/rdf/Literal.cpp
+++ b/src/rdf4cpp/rdf/Literal.cpp
@@ -650,7 +650,19 @@ Literal::operator std::string() const noexcept {
 
     std::string buf;
 
-    if (this->datatype_eq<datatypes::rdf::LangString>()) {
+    if (this->datatype_eq<datatypes::xsd::String>()) {
+        auto const value = this->backend_handle().literal_backend().get_lexical();
+
+        if (value.needs_escape) [[unlikely]] {
+            buf.reserve(estimated_escaped_size(value.lexical_form.size()) + 2);
+            append_quoted_lexical(buf, value.lexical_form);
+        } else {
+            buf.reserve(value.lexical_form.size() + 2);
+            buf.push_back('"');
+            buf.append(value.lexical_form);
+            buf.push_back('"');
+        }
+    } else if (this->datatype_eq<datatypes::rdf::LangString>()) {
         auto const value = this->lang_tagged_get_de_inlined().backend_handle().literal_backend().get_lexical();
 
         if (value.needs_escape) [[unlikely]] {

--- a/tests/nodes/tests_Literal.cpp
+++ b/tests/nodes/tests_Literal.cpp
@@ -19,7 +19,7 @@ TEST_CASE("Literal - Check for only lexical form") {
     CHECK_EQ(lit1.lexical_form(), "Bunny");
     CHECK_EQ(lit1.datatype(), iri);
     CHECK_EQ(lit1.language_tag(), "");
-    CHECK_EQ(std::string(lit1), "\"Bunny\"^^<http://www.w3.org/2001/XMLSchema#string>");
+    CHECK_EQ(std::string(lit1), "\"Bunny\"");
 }
 
 TEST_CASE("Literal - Check for lexical form with IRI") {
@@ -35,7 +35,7 @@ TEST_CASE("Literal - Check for lexical form with IRI") {
         CHECK_EQ(lit1.lexical_form(), "Bunny");
         CHECK_EQ(lit1.datatype(), iri);
         CHECK_EQ(lit1.language_tag(), "");
-        CHECK_EQ(std::string(lit1), "\"Bunny\"^^<http://www.w3.org/2001/XMLSchema#string>");
+        CHECK_EQ(std::string(lit1), "\"Bunny\"");
 
         [[maybe_unused]] Literal no_discard_dummy;
         CHECK_THROWS_AS(no_discard_dummy = Literal::make_simple("\xc3\x28"), std::runtime_error);


### PR DESCRIPTION
Serialize `xsd:string` without datatype