### PR TITLE
Fix: nonstd/expected include and CI

### DIFF
--- a/.github/workflows/publish-conan-branch-package.yml
+++ b/.github/workflows/publish-conan-branch-package.yml
@@ -7,7 +7,7 @@ concurrency:
 
 jobs:
   publish-release:
-    uses: dice-group/cpp-conan-release-reusable-workflow/.github/workflows/publish-conan-branch-package.yml@feature/clang-17
+    uses: dice-group/cpp-conan-release-reusable-workflow/.github/workflows/publish-conan-branch-package.yml@main
     with:
       public_artifactory: true
       os: ubuntu-22.04

--- a/.github/workflows/publish-conan-branch-package.yml
+++ b/.github/workflows/publish-conan-branch-package.yml
@@ -7,11 +7,11 @@ concurrency:
 
 jobs:
   publish-release:
-    uses: dice-group/cpp-conan-release-reusable-workflow/.github/workflows/publish-conan-branch-package.yml@main
+    uses: dice-group/cpp-conan-release-reusable-workflow/.github/workflows/publish-conan-branch-package.yml@feature/clang-17
     with:
       public_artifactory: true
       os: ubuntu-22.04
-      compiler: clang-16
+      compiler: clang-17
       cmake-version: 3.22.6
       conan-version: 2.0.13
       conan-options: -o boost/*:header_only=True

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,11 +8,11 @@ concurrency:
 jobs:
   publish-conan-branch-package:
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-    uses: dice-group/cpp-conan-release-reusable-workflow/.github/workflows/publish-release.yml@main
+    uses: dice-group/cpp-conan-release-reusable-workflow/.github/workflows/publish-release.yml@feature/clang-17
     with:
       public_artifactory: true
       os: ubuntu-22.04
-      compiler: clang-16
+      compiler: clang-17
       cmake-version: 3.22.6
       conan-version: 2.0.13
       use-tag: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,7 +8,7 @@ concurrency:
 jobs:
   publish-conan-branch-package:
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-    uses: dice-group/cpp-conan-release-reusable-workflow/.github/workflows/publish-release.yml@feature/clang-17
+    uses: dice-group/cpp-conan-release-reusable-workflow/.github/workflows/publish-release.yml@main
     with:
       public_artifactory: true
       os: ubuntu-22.04

--- a/.github/workflows/reusable_fetch_content.yml
+++ b/.github/workflows/reusable_fetch_content.yml
@@ -28,12 +28,15 @@ jobs:
           # gcc-13
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 
-          # clang-16
           source /etc/os-release
-          echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-16 main" | sudo tee /etc/apt/sources.list.d/llvm-16.list
-          curl https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/llvm-16.gpg > /dev/null
 
-          sudo apt-get update -y
+          # clang-16
+          echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-16 main" | sudo tee /etc/apt/sources.list.d/llvm-16.list
+
+          # clang-17
+          echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-17 main" | sudo tee /etc/apt/sources.list.d/llvm-17.list
+
+          curl https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/llvm.gpg > /dev/null
 
       - name: Get minimum cmake version
         uses: lukka/get-cmake@v3.24.3

--- a/.github/workflows/reusable_fetch_content.yml
+++ b/.github/workflows/reusable_fetch_content.yml
@@ -23,14 +23,19 @@ jobs:
         shell: bash
 
     steps:
-      - name: Add Repos for for gcc-13 and clang-17
+      - name: Add Repos for for gcc-13 and clang-16,17
         run: |
           # gcc-13
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+          
+          source /etc/os-release
+
+          # clang-16
+          echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-16 main" | sudo tee /etc/apt/sources.list.d/llvm-16.list
 
           # clang-17
-          source /etc/os-release
           echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-17 main" | sudo tee /etc/apt/sources.list.d/llvm-17.list
+          
           curl https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/llvm.gpg > /dev/null
 
       - name: Get minimum cmake version

--- a/.github/workflows/reusable_fetch_content.yml
+++ b/.github/workflows/reusable_fetch_content.yml
@@ -23,19 +23,14 @@ jobs:
         shell: bash
 
     steps:
-      - name: Add Repos for for gcc-13 and clang-16
+      - name: Add Repos for for gcc-13 and clang-17
         run: |
           # gcc-13
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 
-          source /etc/os-release
-
-          # clang-16
-          echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-16 main" | sudo tee /etc/apt/sources.list.d/llvm-16.list
-
           # clang-17
+          source /etc/os-release
           echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-17 main" | sudo tee /etc/apt/sources.list.d/llvm-17.list
-
           curl https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/llvm.gpg > /dev/null
 
       - name: Get minimum cmake version

--- a/.github/workflows/reusable_packaging_and_deployment.yml
+++ b/.github/workflows/reusable_packaging_and_deployment.yml
@@ -21,14 +21,19 @@ jobs:
         shell: bash
 
     steps:
-      - name: Add Repos for for gcc-13 and clang-17
+      - name: Add Repos for for gcc-13 and clang-16,17
         run: |
           # gcc-13
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 
-          # clang-17
           source /etc/os-release
+
+          # clang-16
+          echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-16 main" | sudo tee /etc/apt/sources.list.d/llvm-16.list
+
+          # clang-17
           echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-17 main" | sudo tee /etc/apt/sources.list.d/llvm-17.list
+          
           curl https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/llvm.gpg > /dev/null
 
       - name: Ensure stdlib version

--- a/.github/workflows/reusable_packaging_and_deployment.yml
+++ b/.github/workflows/reusable_packaging_and_deployment.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Configure conan
         run: |
-          pip3 install "conan==1.60.1"
+          pip3 install conan==1.62.0
           conan user
           conan profile new --detect default
           conan profile update settings.compiler.libcxx=libstdc++11 default

--- a/.github/workflows/reusable_packaging_and_deployment.yml
+++ b/.github/workflows/reusable_packaging_and_deployment.yml
@@ -21,19 +21,14 @@ jobs:
         shell: bash
 
     steps:
-      - name: Add Repos for for gcc-13 and clang-16,17
+      - name: Add Repos for for gcc-13 and clang-17
         run: |
           # gcc-13
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 
-          source /etc/os-release
-
-          # clang-16
-          echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-16 main" | sudo tee /etc/apt/sources.list.d/llvm-16.list
-
           # clang-17
+          source /etc/os-release
           echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-17 main" | sudo tee /etc/apt/sources.list.d/llvm-17.list
-          
           curl https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/llvm.gpg > /dev/null
 
       - name: Ensure stdlib version

--- a/.github/workflows/reusable_packaging_and_deployment.yml
+++ b/.github/workflows/reusable_packaging_and_deployment.yml
@@ -21,17 +21,20 @@ jobs:
         shell: bash
 
     steps:
-      - name: Add Repos for for gcc-13 and clang-16
+      - name: Add Repos for for gcc-13 and clang-16,17
         run: |
           # gcc-13
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 
-          # clang-16
           source /etc/os-release
-          echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-16 main" | sudo tee /etc/apt/sources.list.d/llvm-16.list
-          curl https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/llvm-16.gpg > /dev/null
 
-          sudo apt-get update -y
+          # clang-16
+          echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-16 main" | sudo tee /etc/apt/sources.list.d/llvm-16.list
+
+          # clang-17
+          echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-17 main" | sudo tee /etc/apt/sources.list.d/llvm-17.list
+          
+          curl https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/llvm.gpg > /dev/null
 
       - name: Ensure stdlib version
         run: |

--- a/.github/workflows/reusable_run_test_and_examples_by_linking_type.yml
+++ b/.github/workflows/reusable_run_test_and_examples_by_linking_type.yml
@@ -35,19 +35,14 @@ jobs:
         shell: bash
 
     steps:
-      - name: Add Repos for for gcc-13 and clang-16,17
+      - name: Add Repos for for gcc-13 and clang-17
         run: |
           # gcc-13
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
           
-          source /etc/os-release
-          
-          # clang-16
-          echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-16 main" | sudo tee /etc/apt/sources.list.d/llvm-16.list
-          
           # clang-17
+          source /etc/os-release
           echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-17 main" | sudo tee /etc/apt/sources.list.d/llvm-17.list
-          
           curl https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/llvm.gpg > /dev/null
 
       - name: Ensure stdlib version

--- a/.github/workflows/reusable_run_test_and_examples_by_linking_type.yml
+++ b/.github/workflows/reusable_run_test_and_examples_by_linking_type.yml
@@ -40,9 +40,14 @@ jobs:
           # gcc-13
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
           
-          # clang-17
           source /etc/os-release
+
+          # clang-16
+          echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-16 main" | sudo tee /etc/apt/sources.list.d/llvm-16.list
+
+          # clang-17
           echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-17 main" | sudo tee /etc/apt/sources.list.d/llvm-17.list
+          
           curl https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/llvm.gpg > /dev/null
 
       - name: Ensure stdlib version
@@ -94,7 +99,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.conan/data
-          key: ${{ inputs.os }}-${{ inputs.compiler }}-conan
+          key: ${{ inputs.os }}-${{ inputs.compiler }}-conan${{ fromJSON('["", "-coverage"]')[inputs.with-coverage] }}${{ fromJSON('["", "-sanitizer"]')[inputs.with-sanitizer] }}${{ fromJSON('["", "-avx"]')[inputs.with-avx] }}
 
       - name: Check out sources
         uses: actions/checkout@v3

--- a/.github/workflows/reusable_run_test_and_examples_by_linking_type.yml
+++ b/.github/workflows/reusable_run_test_and_examples_by_linking_type.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Configure conan
         run: |
-          pip3 install "conan==1.60.1" ${{ fromJSON('["", "gcovr"]')[inputs.with-coverage] }}
+          pip3 install conan==1.62.0 ${{ fromJSON('["", "gcovr"]')[inputs.with-coverage] }}
           conan profile new --detect default
           conan profile update settings.compiler.libcxx=libstdc++11 default
           conan remote add -f dice-group https://conan.dice-research.org/artifactory/api/conan/tentris

--- a/.github/workflows/reusable_run_test_and_examples_by_linking_type.yml
+++ b/.github/workflows/reusable_run_test_and_examples_by_linking_type.yml
@@ -35,17 +35,20 @@ jobs:
         shell: bash
 
     steps:
-      - name: Add Repos for for gcc-13 and clang-16
+      - name: Add Repos for for gcc-13 and clang-16,17
         run: |
           # gcc-13
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
           
-          # clang-16
           source /etc/os-release
-          echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-16 main" | sudo tee /etc/apt/sources.list.d/llvm-16.list
-          curl https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/llvm-16.gpg > /dev/null
           
-          sudo apt-get update -y
+          # clang-16
+          echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-16 main" | sudo tee /etc/apt/sources.list.d/llvm-16.list
+          
+          # clang-17
+          echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-17 main" | sudo tee /etc/apt/sources.list.d/llvm-17.list
+          
+          curl https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/llvm.gpg > /dev/null
 
       - name: Ensure stdlib version
         run: |

--- a/.github/workflows/run_test_and_examples.yml
+++ b/.github/workflows/run_test_and_examples.yml
@@ -9,9 +9,9 @@ jobs:
             compiler: gcc-13
 
           - os: ubuntu-22.04
-            compiler: clang-15
-          - os: ubuntu-22.04
             compiler: clang-16
+          - os: ubuntu-22.04
+            compiler: clang-17
 
       fail-fast: false
     name: ${{ matrix.cppenv.compiler }}, ${{ matrix.cppenv.os }}
@@ -21,6 +21,6 @@ jobs:
       compiler: ${{ matrix.cppenv.compiler }}
       cmake-version: 3.22.6
       with-coverage: false
-      with-sanitizer: ${{ matrix.cppenv.compiler == 'clang-16' }}
-      with-Werror: ${{ matrix.cppenv.compiler == 'clang-16' || matrix.cppenv.compiler == 'gcc-13' }}
-      with-AVX: ${{ matrix.cppenv.compiler == 'clang-16' }}
+      with-sanitizer: ${{ matrix.cppenv.compiler == 'clang-17' }}
+      with-Werror: ${{ matrix.cppenv.compiler == 'clang-17' || matrix.cppenv.compiler == 'gcc-13' }}
+      with-AVX: ${{ matrix.cppenv.compiler == 'clang-17' }}

--- a/.github/workflows/run_test_and_examples.yml
+++ b/.github/workflows/run_test_and_examples.yml
@@ -9,6 +9,10 @@ jobs:
             compiler: gcc-13
 
           - os: ubuntu-22.04
+            compiler: clang-15
+          - os: ubuntu-22.04
+            compiler: clang-16
+          - os: ubuntu-22.04
             compiler: clang-17
 
       fail-fast: false

--- a/.github/workflows/run_test_and_examples.yml
+++ b/.github/workflows/run_test_and_examples.yml
@@ -9,8 +9,6 @@ jobs:
             compiler: gcc-13
 
           - os: ubuntu-22.04
-            compiler: clang-16
-          - os: ubuntu-22.04
             compiler: clang-17
 
       fail-fast: false

--- a/.github/workflows/run_test_for_coverage.yml
+++ b/.github/workflows/run_test_for_coverage.yml
@@ -1,5 +1,5 @@
 name: Run unit tests and examples
-on: [ 'push' ]
+on: [ 'pull_request' ]
 
 
 jobs:

--- a/.github/workflows/run_test_for_coverage.yml
+++ b/.github/workflows/run_test_for_coverage.yml
@@ -6,10 +6,9 @@ jobs:
   tests_and_example_matrix:
     strategy:
       matrix:
-        cppenv: [ {
-          os: ubuntu-22.04,
-          compiler: "gcc-13",
-        } ]
+        cppenv:
+          - os: ubuntu-22.04,
+            compiler: gcc-13,
       fail-fast: false
     name: ${{ matrix.cppenv.compiler }}, ${{ matrix.cppenv.os }}
     uses: ./.github/workflows/reusable_run_test_and_examples_by_linking_type.yml

--- a/.github/workflows/run_test_for_coverage.yml
+++ b/.github/workflows/run_test_for_coverage.yml
@@ -7,8 +7,8 @@ jobs:
     strategy:
       matrix:
         cppenv:
-          - os: ubuntu-22.04,
-            compiler: gcc-13,
+          - os: ubuntu-22.04
+            compiler: gcc-13
       fail-fast: false
     name: ${{ matrix.cppenv.compiler }}, ${{ matrix.cppenv.os }}
     uses: ./.github/workflows/reusable_run_test_and_examples_by_linking_type.yml

--- a/.github/workflows/test_packaging_and_deployment.yml
+++ b/.github/workflows/test_packaging_and_deployment.yml
@@ -2,11 +2,11 @@ name: Packaging and deployment tests
 on: [ 'pull_request' ]
 jobs:
   packaging-and-deployment-tests-clang:
-    name: Packaging and deployment tests clang-16
+    name: Packaging and deployment tests clang-17
     uses: ./.github/workflows/reusable_packaging_and_deployment.yml
     with:
       os: ubuntu-22.04
-      compiler: clang-16
+      compiler: clang-17
       cmake-version: 3.22.6
 
   packaging-and-deployment-tests-gcc:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,7 +241,7 @@ target_link_libraries(rdf4cpp
 set_target_properties(rdf4cpp PROPERTIES
         VERSION ${PROJECT_VERSION}
         SOVERSION ${PROJECT_VERSION_MAJOR}
-        CXX_STANDARD 23
+        CXX_STANDARD 20
         CXX_EXTENSIONS OFF
         CXX_STANDARD_REQUIRED ON
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,13 @@
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.22)
 project(rdf4cpp VERSION 0.0.19)
 
 include(cmake/boilerplate_init.cmake)
 boilerplate_init()
 
 OPTION(USE_CONAN "If available, use conan to retrieve dependencies." ON)
-if (IS_TOP_LEVEL AND USE_CONAN)
+if (PROJECT_IS_TOP_LEVEL AND USE_CONAN)
     include(cmake/conan_cmake.cmake)
-    if (PROJECT_IS_TOP_LEVEL AND BUILD_TESTING)
+    if (BUILD_TESTING)
         set(CONAN_HYPERTRIE_WITH_TEST_DEPS "True")
     else()
         set(CONAN_HYPERTRIE_WITH_TEST_DEPS "False")
@@ -246,12 +246,12 @@ set_target_properties(rdf4cpp PROPERTIES
         CXX_STANDARD_REQUIRED ON
 )
 
-if (IS_TOP_LEVEL)
+if (PROJECT_IS_TOP_LEVEL)
     include(cmake/install_library.cmake)
     install_cpp_library(rdf4cpp src)
 endif ()
 
-if (BUILD_TESTING AND IS_TOP_LEVEL)
+if (PROJECT_IS_TOP_LEVEL AND BUILD_TESTING)
     message("Tests are configured to be build.")
     include(CTest)
     enable_testing()
@@ -259,7 +259,7 @@ if (BUILD_TESTING AND IS_TOP_LEVEL)
 endif ()
 
 OPTION(BUILD_EXAMPLES "Build the examples for rdf4cpp." OFF)
-if (BUILD_EXAMPLES AND IS_TOP_LEVEL)
+if (PROJECT_IS_TOP_LEVEL AND BUILD_EXAMPLES)
     message("Examples are configured to be build.")
     add_subdirectory(examples)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,7 +241,7 @@ target_link_libraries(rdf4cpp
 set_target_properties(rdf4cpp PROPERTIES
         VERSION ${PROJECT_VERSION}
         SOVERSION ${PROJECT_VERSION_MAJOR}
-        CXX_STANDARD 20
+        CXX_STANDARD 23
         CXX_EXTENSIONS OFF
         CXX_STANDARD_REQUIRED ON
 )

--- a/cmake/boilerplate_init.cmake
+++ b/cmake/boilerplate_init.cmake
@@ -30,6 +30,4 @@ macro(boilerplate_init)
             set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
         endif ()
     endif ()
-
-    string(COMPARE EQUAL "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}" IS_TOP_LEVEL)
 endmacro()

--- a/conanfile.py
+++ b/conanfile.py
@@ -30,7 +30,7 @@ class Recipe(ConanFile):
 
     def requirements(self):
         self.requires("boost/1.83.0", transitive_headers=True)
-        self.requires("expected-lite/0.6.2", transitive_headers=True)
+        self.requires("expected-lite/0.6.3", transitive_headers=True)
         self.requires("re2/20221201")
         self.requires("openssl/3.0.8")
         self.requires("uni-algo/0.7.1")

--- a/src/rdf4cpp/rdf/datatypes/LiteralDatatype.hpp
+++ b/src/rdf4cpp/rdf/datatypes/LiteralDatatype.hpp
@@ -7,8 +7,7 @@
 #include <rdf4cpp/rdf/datatypes/registry/util/ConstexprString.hpp>
 #include <rdf4cpp/rdf/storage/node/identifier/LiteralID.hpp>
 #include <rdf4cpp/rdf/storage/node/identifier/LiteralType.hpp>
-
-#include <nonstd/expected.hpp>
+#include <rdf4cpp/rdf/util/Expected.hpp>
 
 namespace rdf4cpp::rdf::datatypes {
 

--- a/src/rdf4cpp/rdf/datatypes/registry/DatatypeConversion.hpp
+++ b/src/rdf4cpp/rdf/datatypes/registry/DatatypeConversion.hpp
@@ -6,7 +6,7 @@
 #include <type_traits>
 #include <utility>
 
-#include <nonstd/expected.hpp>
+#include <rdf4cpp/rdf/util/Expected.hpp>
 
 #include <rdf4cpp/rdf/datatypes/LiteralDatatype.hpp>
 #include <rdf4cpp/rdf/datatypes/registry/DatatypeConversionTyping.hpp>

--- a/src/rdf4cpp/rdf/parser/IStreamQuadIterator.hpp
+++ b/src/rdf4cpp/rdf/parser/IStreamQuadIterator.hpp
@@ -4,7 +4,7 @@
 #include <iterator>
 #include <memory>
 
-#include <nonstd/expected.hpp>
+#include <rdf4cpp/rdf/util/Expected.hpp>
 
 #include <rdf4cpp/rdf/Quad.hpp>
 

--- a/src/rdf4cpp/rdf/util/BigDecimal.hpp
+++ b/src/rdf4cpp/rdf/util/BigDecimal.hpp
@@ -7,8 +7,9 @@
 #include <string_view>
 
 #include <boost/multiprecision/cpp_int.hpp>
-#include <nonstd/expected.hpp>
 #include <dice/hash.hpp>
+
+#include <rdf4cpp/rdf/util/Expected.hpp>
 
 namespace rdf4cpp::rdf::util {
 enum class RoundingMode {

--- a/src/rdf4cpp/rdf/util/Expected.hpp
+++ b/src/rdf4cpp/rdf/util/Expected.hpp
@@ -2,7 +2,7 @@
 #define RDF4CPP_EXPECTED_HPP
 
 /**
- * Workaround for buggy detection std::expected detection logic in <nonstd/expected.hpp>
+ * Workaround for buggy std::expected detection logic in <nonstd/expected.hpp>
  * (std::expected does not work on clang yet, nonstd/expected.hpp does not honor feature test macro)
  *
  * Additionally the API of std::expected is different from nonstd::expected so it is not a drop in replacement.

--- a/src/rdf4cpp/rdf/util/Expected.hpp
+++ b/src/rdf4cpp/rdf/util/Expected.hpp
@@ -1,17 +1,14 @@
+#ifndef RDF4CPP_EXPECTED_HPP
+#define RDF4CPP_EXPECTED_HPP
+
 /**
- * Workaround for buggy detection logic for std::expected in <nonstd/expected.hpp>
+ * Workaround for buggy detection std::expected detection logic in <nonstd/expected.hpp>
+ * (std::expected does not work on clang yet, nonstd/expected.hpp does not honor feature test macro)
+ *
+ * Additionally the API of std::expected is different from nonstd::expected so it is not a drop in replacement.
  */
-
-#if __cpp_lib_expected >= 202202L
-
-#include <expected>
-namespace nonstd {
-    using std::expected;
-} // namepace nonstd
-
-#else
 
 #define nsel_CONFIG_SELECT_EXPECTED 1 // do not attempt to use std::expected
 #include <nonstd/expected.hpp>
 
-#endif
+#endif // RDF4CPP_EXPECTED_HPP

--- a/src/rdf4cpp/rdf/util/Expected.hpp
+++ b/src/rdf4cpp/rdf/util/Expected.hpp
@@ -1,0 +1,17 @@
+/**
+ * Workaround for buggy detection logic for std::expected in <nonstd/expected.hpp>
+ */
+
+#if __cpp_lib_expected >= 202202L
+
+#include <expected>
+namespace nonstd {
+    using std::expected;
+} // namepace nonstd
+
+#else
+
+#define nsel_CONFIG_SELECT_EXPECTED 1 // do not attempt to use std::expected
+#include <nonstd/expected.hpp>
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD 20)
 
 find_package(doctest REQUIRED)
 find_package(nanobench REQUIRED)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 
 find_package(doctest REQUIRED)
 find_package(nanobench REQUIRED)
@@ -9,7 +9,6 @@ target_link_libraries(tests_Variable
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_Variable PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_Variable COMMAND tests_Variable)
 
 
@@ -18,7 +17,6 @@ target_link_libraries(tests_TriplePattern
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_TriplePattern PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_TriplePattern COMMAND tests_TriplePattern)
 
 
@@ -27,7 +25,6 @@ target_link_libraries(tests_QuadPattern
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_QuadPattern PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_QuadPattern COMMAND tests_QuadPattern)
 
 
@@ -36,7 +33,6 @@ target_link_libraries(tests_Literal
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_Literal PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_Literal COMMAND tests_Literal)
 
 add_executable(tests_Literal_ops nodes/tests_Literal_ops.cpp)
@@ -44,7 +40,6 @@ target_link_libraries(tests_Literal_ops
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_Literal_ops PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_Literal_ops COMMAND tests_Literal_ops)
 
 add_executable(tests_Node nodes/tests_Node.cpp)
@@ -52,7 +47,6 @@ target_link_libraries(tests_Node
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_Node PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_Node COMMAND tests_Node)
 
 add_executable(tests_NodeStorage_lifetime nodes/tests_NodeStorage_lifetime.cpp)
@@ -60,7 +54,6 @@ target_link_libraries(tests_NodeStorage_lifetime
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_NodeStorage_lifetime PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_NodeStorage_lifetime COMMAND tests_Node)
 
 # RDF Core Types
@@ -69,7 +62,6 @@ target_link_libraries(tests_String
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_String PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_String COMMAND tests_String)
 
 add_executable(tests_Boolean datatype/tests_Boolean.cpp)
@@ -77,7 +69,6 @@ target_link_libraries(tests_Boolean
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_Boolean PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_Boolean COMMAND tests_Boolean)
 
 
@@ -86,7 +77,6 @@ target_link_libraries(tests_Decimal
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_Decimal PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_Decimal COMMAND tests_Decimal)
 
 add_executable(tests_Float datatype/tests_Float.cpp)
@@ -94,7 +84,6 @@ target_link_libraries(tests_Float
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_Float PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_Float COMMAND tests_Float)
 
 add_executable(tests_HexBinary datatype/tests_HexBinary.cpp)
@@ -102,7 +91,6 @@ target_link_libraries(tests_HexBinary
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_HexBinary PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_HexBinary COMMAND tests_HexBinary)
 
 add_executable(tests_Base64Binary datatype/tests_Base64Binary.cpp)
@@ -110,7 +98,6 @@ target_link_libraries(tests_Base64Binary
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_Base64Binary PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_Base64Binary COMMAND tests_Base64Binary)
 
 add_executable(tests_Double datatype/tests_Double.cpp)
@@ -118,7 +105,6 @@ target_link_libraries(tests_Double
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_Double PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_Double COMMAND tests_Double)
 
 add_executable(tests_Integer datatype/tests_Integer.cpp)
@@ -126,7 +112,6 @@ target_link_libraries(tests_Integer
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_Integer PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_Integer COMMAND tests_Integer)
 
 add_executable(tests_owl_Rational datatype/tests_owl_Rational.cpp)
@@ -134,7 +119,6 @@ target_link_libraries(tests_owl_Rational
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_owl_Rational PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_owl_Rational COMMAND tests_owl_Rational)
 
 add_executable(tests_Byte datatype/tests_Byte.cpp)
@@ -142,7 +126,6 @@ target_link_libraries(tests_Byte
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_Byte PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_Byte COMMAND tests_Byte)
 
 add_executable(tests_Short datatype/tests_Short.cpp)
@@ -150,7 +133,6 @@ target_link_libraries(tests_Short
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_Short PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_Short COMMAND tests_Short)
 
 add_executable(tests_Int datatype/tests_Int.cpp)
@@ -158,7 +140,6 @@ target_link_libraries(tests_Int
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_Int PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_Int COMMAND tests_Int)
 
 add_executable(tests_Long datatype/tests_Long.cpp)
@@ -166,7 +147,6 @@ target_link_libraries(tests_Long
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_Long PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_Long COMMAND tests_Long)
 
 add_executable(tests_UnsignedByte datatype/tests_UnsignedByte.cpp)
@@ -174,7 +154,6 @@ target_link_libraries(tests_UnsignedByte
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_UnsignedByte PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_UnsignedByte COMMAND tests_UnsignedByte)
 
 add_executable(tests_UnsignedShort datatype/tests_UnsignedShort.cpp)
@@ -182,7 +161,6 @@ target_link_libraries(tests_UnsignedShort
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_UnsignedShort PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_UnsignedShort COMMAND tests_UnsignedShort)
 
 add_executable(tests_UnsignedInt datatype/tests_UnsignedInt.cpp)
@@ -190,7 +168,6 @@ target_link_libraries(tests_UnsignedInt
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_UnsignedInt PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_UnsignedInt COMMAND tests_UnsignedInt)
 
 add_executable(tests_UnsignedLong datatype/tests_UnsignedLong.cpp)
@@ -198,7 +175,6 @@ target_link_libraries(tests_UnsignedLong
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_UnsignedLong PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_UnsignedLong COMMAND tests_UnsignedLong)
 
 add_executable(tests_PositiveInteger datatype/tests_PositiveInteger.cpp)
@@ -206,7 +182,6 @@ target_link_libraries(tests_PositiveInteger
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_PositiveInteger PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_PositiveInteger COMMAND tests_PositiveInteger)
 
 add_executable(tests_NonPositiveInteger datatype/tests_NonPositiveInteger.cpp)
@@ -214,7 +189,6 @@ target_link_libraries(tests_NonPositiveInteger
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_NonPositiveInteger PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_NonPositiveInteger COMMAND tests_NonPositiveInteger)
 
 add_executable(tests_NegativeInteger datatype/tests_NegativeInteger.cpp)
@@ -222,7 +196,6 @@ target_link_libraries(tests_NegativeInteger
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_NegativeInteger PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_NegativeInteger COMMAND tests_NegativeInteger)
 
 add_executable(tests_NonNegativeInteger datatype/tests_NonNegativeInteger.cpp)
@@ -230,7 +203,6 @@ target_link_libraries(tests_NonNegativeInteger
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_NonNegativeInteger PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_NonNegativeInteger COMMAND tests_NonNegativeInteger)
 
 add_executable(tests_CowString util/tests_CowString.cpp)
@@ -238,7 +210,6 @@ target_link_libraries(tests_CowString
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_CowString PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_CowString COMMAND tests_CowString)
 
 add_executable(tests_BlankNodeIdManagement util/tests_BlankNodeIdManagement.cpp)
@@ -246,7 +217,6 @@ target_link_libraries(tests_BlankNodeIdManagement
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_BlankNodeIdManagement PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_BlankNodeIdManagement COMMAND tests_BlankNodeIdManagement)
 
 find_package(Metall REQUIRED)
@@ -257,7 +227,6 @@ target_link_libraries(BlankNodeIdManagement_metall_phase1
         rdf4cpp
         Metall::Metall
         )
-set_property(TARGET BlankNodeIdManagement_metall_phase1 PROPERTY CXX_STANDARD 20)
 
 add_executable(BlankNodeIdManagement_metall_phase2 util/BlankNodeIdManagement_metall_phase2.cpp)
 target_link_libraries(BlankNodeIdManagement_metall_phase2
@@ -265,7 +234,6 @@ target_link_libraries(BlankNodeIdManagement_metall_phase2
         rdf4cpp
         Metall::Metall
         )
-set_property(TARGET BlankNodeIdManagement_metall_phase2 PROPERTY CXX_STANDARD 20)
 
 add_executable(tests_BlankNodeIdManagement_metall util/tests_BlankNodeIdManagement_metall.cpp)
 add_dependencies(tests_BlankNodeIdManagement_metall BlankNodeIdManagement_metall_phase1 BlankNodeIdManagement_metall_phase2)
@@ -274,7 +242,6 @@ target_link_libraries(tests_BlankNodeIdManagement_metall
         rdf4cpp
         Metall::Metall
         )
-set_property(TARGET tests_BlankNodeIdManagement_metall PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_BlankNodeIdManagement_metall COMMAND tests_BlankNodeIdManagement_metall)
 
 add_executable(tests_TriBool util/tests_TriBool.cpp)
@@ -282,7 +249,6 @@ target_link_libraries(tests_TriBool
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_TriBool PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_TriBool COMMAND tests_TriBool)
 
 add_executable(tests_Regex util/tests_Regex.cpp)
@@ -290,7 +256,6 @@ target_link_libraries(tests_Regex
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_Regex PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_Regex COMMAND tests_Regex)
 
 add_executable(tests_Inlining util/tests_Inlining.cpp)
@@ -298,7 +263,6 @@ target_link_libraries(tests_Inlining
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_Inlining PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_Inlining COMMAND tests_Inlining)
 
 add_executable(tests_LangString datatype/tests_LangString.cpp)
@@ -306,7 +270,6 @@ target_link_libraries(tests_LangString
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_LangString PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_LangString COMMAND tests_LangString)
 
 add_executable(tests_NumOpResults datatype/tests_NumOpResults.cpp)
@@ -314,7 +277,6 @@ target_link_libraries(tests_NumOpResults
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_NumOpResults PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_NumOpResults COMMAND tests_NumOpResults)
 
 add_executable(tests_IStreamQuadIterator parser/tests_IStreamQuadIterator.cpp)
@@ -322,7 +284,6 @@ target_link_libraries(tests_IStreamQuadIterator
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_IStreamQuadIterator PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_IStreamQuadIterator COMMAND tests_IStreamQuadIterator)
 
 add_executable(bench_SerDe bench_SerDe.cpp)
@@ -330,14 +291,12 @@ target_link_libraries(bench_SerDe
         nanobench::nanobench
         rdf4cpp
 )
-set_property(TARGET bench_SerDe PROPERTY CXX_STANDARD 20)
 
 add_executable(tests_RDFFileParser parser/tests_RDFFileParser.cpp)
 target_link_libraries(tests_RDFFileParser
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_RDFFileParser PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_RDFFileParser COMMAND tests_RDFFileParser)
 
 add_executable(tests_Serialize serializer/tests_Serialize.cpp)
@@ -345,7 +304,6 @@ target_link_libraries(tests_Serialize
         doctest::doctest
         rdf4cpp
 )
-set_property(TARGET tests_Serialize PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_Serialize COMMAND tests_Serialize)
 
 add_executable(tests_Namespace_life_cycle namespaces/tests_Namespace_life_cycle.cpp)
@@ -353,7 +311,6 @@ target_link_libraries(tests_Namespace_life_cycle
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_Namespace_life_cycle PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_Namespace_life_cycle COMMAND tests_Namespace_life_cycle)
 
 add_executable(tests_NodeStorage_specialization nodes/tests_NodeStorage_specialization.cpp)
@@ -361,7 +318,6 @@ target_link_libraries(tests_NodeStorage_specialization
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_NodeStorage_specialization PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_NodeStorage_specialization COMMAND tests_NodeStorage_specialization)
 
 add_executable(tests_time_types datatype/tests_time_types.cpp)
@@ -369,7 +325,6 @@ target_link_libraries(tests_time_types
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_time_types PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_time_types COMMAND tests_time_types)
 
 add_executable(tests_BigDecimal util/tests_BigDecimal.cpp)
@@ -377,7 +332,6 @@ target_link_libraries(tests_BigDecimal
         doctest::doctest
         rdf4cpp
         )
-set_property(TARGET tests_BigDecimal PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_BigDecimal COMMAND tests_BigDecimal)
 
 add_executable(tests_dataset_backend graph/tests_dataset_backend.cpp)
@@ -385,7 +339,6 @@ target_link_libraries(tests_dataset_backend
         doctest::doctest
         rdf4cpp
 )
-set_property(TARGET tests_dataset_backend PROPERTY CXX_STANDARD 20)
 add_test(NAME tests_dataset_backend COMMAND tests_dataset_backend)
 
 # copy files for testing to the binary folder


### PR DESCRIPTION
Various fixes that prevented building (with) rdf4cpp

1. Forces the use of nonstd expected implementation instead of `std::expected` because the APIs are different
2. Fixes overcaching in the CI that would cause it to fail e.g. due to dependencies having (unresolved) coverage symbols in them even when not building with coverage (happens if the coverage workflow finishes first and populates the cache)
3. Add clang 17 to CI
