### PR TITLE
Fix: Parser malformed input rejection

### DIFF
--- a/examples/graphs_and_datasets.cpp
+++ b/examples/graphs_and_datasets.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[]) {
             return 1;
         }
 
-        for (parser::IStreamQuadIterator qit{ifs}; qit != parser::IStreamQuadIterator{}; ++qit) {
+        for (parser::IStreamQuadIterator qit{ifs}; qit != std::default_sentinel; ++qit) {
             if (qit->has_value()) {
                 ds2.add(qit->value());
             } else {

--- a/private/rdf4cpp/rdf/parser/IStreamQuadIteratorSerdImpl.cpp
+++ b/private/rdf4cpp/rdf/parser/IStreamQuadIteratorSerdImpl.cpp
@@ -33,11 +33,10 @@ nonstd::expected<Node, SerdStatus> IStreamQuadIterator::Impl::get_bnode(std::str
         } catch (std::runtime_error const &e) {
             // TODO: check when actual blank node validation implemented
             // NOTE: line, col not entirely accurate as this function is called after a triple was parsed
-            this->last_error = ParsingError{
-                    .error_type = ParsingError::Type::BadBlankNode,
-                    .line = serd_reader_get_current_line(this->reader),
-                    .col = serd_reader_get_current_col(this->reader),
-                    .message = std::string{e.what()} + ". note: position may not be accurate and instead point to the end of the triple."};
+            this->last_error = ParsingError{.error_type = ParsingError::Type::BadBlankNode,
+                                            .line = serd_reader_get_current_line(this->reader),
+                                            .col = serd_reader_get_current_col(this->reader),
+                                            .message = std::string{e.what()} + ". note: position may not be accurate and instead point to the end of the triple."};
 
             return nonstd::make_unexpected(SERD_ERR_BAD_SYNTAX);
         }
@@ -53,11 +52,10 @@ nonstd::expected<Node, SerdStatus> IStreamQuadIterator::Impl::get_bnode(std::str
     } catch (std::runtime_error const &e) {
         // TODO: check when actual blank node validation implemented
         // NOTE: line, col not entirely accurate as this function is called after a triple was parsed
-        this->last_error = ParsingError{
-                .error_type = ParsingError::Type::BadBlankNode,
-                .line = serd_reader_get_current_line(this->reader),
-                .col = serd_reader_get_current_col(this->reader),
-                .message = std::string{e.what()} + ". note: position may not be accurate and instead point to the end of the triple."};
+        this->last_error = ParsingError{.error_type = ParsingError::Type::BadBlankNode,
+                                        .line = serd_reader_get_current_line(this->reader),
+                                        .col = serd_reader_get_current_col(this->reader),
+                                        .message = std::string{e.what()} + ". note: position may not be accurate and instead point to the end of the triple."};
 
         return nonstd::make_unexpected(SERD_ERR_BAD_SYNTAX);
     }
@@ -68,11 +66,10 @@ nonstd::expected<IRI, SerdStatus> IStreamQuadIterator::Impl::get_iri(SerdNode co
     auto iri = state->iri_factory.from_relative(node_into_string_view(node), this->state->node_storage);
     if (!iri.has_value()) {
         IRIFactoryError err = iri.error();
-        this->last_error = ParsingError{
-                .error_type = ParsingError::Type::BadIri,
-                .line = serd_reader_get_current_line(this->reader),
-                .col = serd_reader_get_current_col(this->reader),
-                .message = std::format("invalid iri. {}. note: position may not be accurate and instead point to the end of the triple.", err)};
+        this->last_error = ParsingError{.error_type = ParsingError::Type::BadIri,
+                                        .line = serd_reader_get_current_line(this->reader),
+                                        .col = serd_reader_get_current_col(this->reader),
+                                        .message = std::format("invalid iri. {}. note: position may not be accurate and instead point to the end of the triple.", err)};
 
         return nonstd::make_unexpected(SERD_ERR_BAD_SYNTAX);
     }
@@ -96,19 +93,17 @@ nonstd::expected<IRI, SerdStatus> IStreamQuadIterator::Impl::get_prefixed_iri(Se
         IRIFactoryError err = iri.error();
         if (err == IRIFactoryError::UnknownPrefix) {
             // NOTE: line, col not entirely accurate as this function is called after a triple was parsed
-            this->last_error = ParsingError{
-                    .error_type = ParsingError::Type::BadCurie,
-                    .line = serd_reader_get_current_line(this->reader),
-                    .col = serd_reader_get_current_col(this->reader),
-                    .message = "unknown prefix. note: position may not be accurate and instead point to the end of the triple."};
+            this->last_error = ParsingError{.error_type = ParsingError::Type::BadCurie,
+                                            .line = serd_reader_get_current_line(this->reader),
+                                            .col = serd_reader_get_current_col(this->reader),
+                                            .message = "unknown prefix. note: position may not be accurate and instead point to the end of the triple."};
 
             return nonstd::make_unexpected(SERD_ERR_BAD_CURIE);
         } else {
-            this->last_error = ParsingError{
-                    .error_type = ParsingError::Type::BadIri,
-                    .line = serd_reader_get_current_line(this->reader),
-                    .col = serd_reader_get_current_col(this->reader),
-                    .message = std::format("unable to expand curie into valid iri. {}. note: position may not be accurate and instead point to the end of the triple.", err)};
+            this->last_error = ParsingError{.error_type = ParsingError::Type::BadIri,
+                                            .line = serd_reader_get_current_line(this->reader),
+                                            .col = serd_reader_get_current_col(this->reader),
+                                            .message = std::format("unable to expand curie into valid iri. {}. note: position may not be accurate and instead point to the end of the triple.", err)};
 
             return nonstd::make_unexpected(SERD_ERR_BAD_SYNTAX);
         }
@@ -150,18 +145,17 @@ nonstd::expected<Literal, SerdStatus> IStreamQuadIterator::Impl::get_literal(Ser
         }
     } catch (std::runtime_error const &e) {
         // NOTE: line, col not entirely accurate as this function is called after a triple was parsed
-        this->last_error = ParsingError{
-                .error_type = ParsingError::Type::BadLiteral,
-                .line = serd_reader_get_current_line(this->reader),
-                .col = serd_reader_get_current_col(this->reader),
-                .message = std::string{e.what()} + ". note: position may not be accurate and instead point to the end of the triple."};
+        this->last_error = ParsingError{.error_type = ParsingError::Type::BadLiteral,
+                                        .line = serd_reader_get_current_line(this->reader),
+                                        .col = serd_reader_get_current_col(this->reader),
+                                        .message = std::string{e.what()} + ". note: position may not be accurate and instead point to the end of the triple."};
 
         return nonstd::make_unexpected(SERD_ERR_BAD_SYNTAX);
     }
 }
 
 SerdStatus IStreamQuadIterator::Impl::on_error(void *voided_self, SerdError const *error) noexcept {
-    auto *self = reinterpret_cast<Impl *>(voided_self);
+    auto *self = static_cast<Impl *>(voided_self);
 
     auto const buf_sz = vsnprintf(nullptr, 0, error->fmt, *error->args);
     std::string message;
@@ -170,55 +164,45 @@ SerdStatus IStreamQuadIterator::Impl::on_error(void *voided_self, SerdError cons
     vsnprintf(message.data(), message.size(), error->fmt, *error->args);
     message.resize(buf_sz - 1);  // drop null-terminator from vsnprintf and newline from serd
 
-    self->last_error = ParsingError{
-            .error_type = parsing_error_type_from_serd(error->status),
-            .line = error->line,
-            .col = error->col,
-            .message = message};
+    self->last_error = ParsingError{.error_type = parsing_error_type_from_serd(error->status),
+                                    .line = error->line,
+                                    .col = error->col,
+                                    .message = message};
     self->last_error_requires_skip = true;
 
     return SERD_SUCCESS;
 }
 
 SerdStatus IStreamQuadIterator::Impl::on_base(void *voided_self, const SerdNode *uri) noexcept {
-    auto *self = reinterpret_cast<Impl *>(voided_self);
+    auto *self = static_cast<Impl *>(voided_self);
 
     if (self->no_parse_prefixes) {
-        self->last_error = ParsingError{
-                .error_type = ParsingError::Type::BadSyntax,
-                .line = serd_reader_get_current_line(self->reader),
-                .col = serd_reader_get_current_col(self->reader),
-                .message = "Encountered base while parsing. hint: prefix parsing is currently deactivated. note: position may not be accurate and instead point to the end of the line."};
-
-        return SERD_SUCCESS;
-    }
-
-    auto e = self->state->iri_factory.set_base(node_into_string_view(uri));
-    if (e != IRIFactoryError::Ok) {
-        self->last_error = ParsingError{
-            .error_type = ParsingError::Type::BadSyntax,
-            .line = serd_reader_get_current_line(self->reader),
-            .col = serd_reader_get_current_col(self->reader),
-            .message = std::format("Error setting base: {}. note: position may not be accurate and instead point to the end of the line.", e)};
-        return SERD_SUCCESS;
+        self->last_error = ParsingError{.error_type = ParsingError::Type::BadSyntax,
+                                        .line = serd_reader_get_current_line(self->reader),
+                                        .col = serd_reader_get_current_col(self->reader),
+                                        .message = "Encountered base while parsing. hint: prefix parsing is currently deactivated. note: position may not be accurate and instead point to the end of the line."};
+    } else if (auto e = self->state->iri_factory.set_base(node_into_string_view(uri)); e != IRIFactoryError::Ok) {
+        self->last_error = ParsingError{.error_type = ParsingError::Type::BadSyntax,
+                                        .line = serd_reader_get_current_line(self->reader),
+                                        .col = serd_reader_get_current_col(self->reader),
+                                        .message = std::format("Error setting base: {}. note: position may not be accurate and instead point to the end of the line.", e)};
     }
 
     return SERD_SUCCESS;
 }
 
 SerdStatus IStreamQuadIterator::Impl::on_prefix(void *voided_self, SerdNode const *name, SerdNode const *uri) noexcept {
-    auto *self = reinterpret_cast<Impl *>(voided_self);
+    auto *self = static_cast<Impl *>(voided_self);
 
     if (self->no_parse_prefixes) {
-        self->last_error = ParsingError{
-                .error_type = ParsingError::Type::BadSyntax,
-                .line = serd_reader_get_current_line(self->reader),
-                .col = serd_reader_get_current_col(self->reader),
-                .message = "Encountered prefix while parsing. hint: prefix parsing is currently deactivated. note: position may not be accurate and instead point to the end of the line."};
-        return SERD_SUCCESS;
+        self->last_error = ParsingError{.error_type = ParsingError::Type::BadSyntax,
+                                        .line = serd_reader_get_current_line(self->reader),
+                                        .col = serd_reader_get_current_col(self->reader),
+                                        .message = "Encountered prefix while parsing. hint: prefix parsing is currently deactivated. note: position may not be accurate and instead point to the end of the line."};
+    } else {
+        self->state->iri_factory.assign_prefix(node_into_string_view(name), node_into_string_view(uri));
     }
 
-    self->state->iri_factory.assign_prefix(node_into_string_view(name), node_into_string_view(uri));
     return SERD_SUCCESS;
 }
 
@@ -231,7 +215,7 @@ SerdStatus IStreamQuadIterator::Impl::on_stmt(void *voided_self,
                                               SerdNode const *obj_datatype,
                                               SerdNode const *obj_lang) noexcept {
 
-    auto *self = reinterpret_cast<Impl *>(voided_self);
+    auto *self = static_cast<Impl *>(voided_self);
 
     auto const graph_node = [&]() -> nonstd::expected<Node, SerdStatus> {
         if (graph != nullptr) {

--- a/private/rdf4cpp/rdf/parser/IStreamQuadIteratorSerdImpl.cpp
+++ b/private/rdf4cpp/rdf/parser/IStreamQuadIteratorSerdImpl.cpp
@@ -11,13 +11,13 @@ std::string_view IStreamQuadIterator::Impl::node_into_string_view(SerdNode const
 
 ParsingError::Type IStreamQuadIterator::Impl::parsing_error_type_from_serd(SerdStatus const st) noexcept {
     switch (st) {
-        case SerdStatus::SERD_ERR_BAD_SYNTAX:
+        case SERD_ERR_BAD_SYNTAX:
             return ParsingError::Type::BadSyntax;
-        case SerdStatus::SERD_ERR_BAD_CURIE:
+        case SERD_ERR_BAD_CURIE:
             return ParsingError::Type::BadCurie;
-        case SerdStatus::SERD_FAILURE:
+        case SERD_FAILURE:
             return ParsingError::Type::EofReached;
-        case SerdStatus::SERD_ERR_ID_CLASH:
+        case SERD_ERR_ID_CLASH:
             return ParsingError::Type::BadBlankNode;
         default:
             return ParsingError::Type::Internal;
@@ -35,11 +35,11 @@ nonstd::expected<Node, SerdStatus> IStreamQuadIterator::Impl::get_bnode(std::str
             // NOTE: line, col not entirely accurate as this function is called after a triple was parsed
             this->last_error = ParsingError{
                     .error_type = ParsingError::Type::BadBlankNode,
-                    .line = serd_reader_get_current_line(this->reader.get()),
-                    .col = serd_reader_get_current_col(this->reader.get()),
+                    .line = serd_reader_get_current_line(this->reader),
+                    .col = serd_reader_get_current_col(this->reader),
                     .message = std::string{e.what()} + ". note: position may not be accurate and instead point to the end of the triple."};
 
-            return nonstd::make_unexpected(SerdStatus::SERD_ERR_BAD_SYNTAX);
+            return nonstd::make_unexpected(SERD_ERR_BAD_SYNTAX);
         }
     }
 
@@ -55,11 +55,11 @@ nonstd::expected<Node, SerdStatus> IStreamQuadIterator::Impl::get_bnode(std::str
         // NOTE: line, col not entirely accurate as this function is called after a triple was parsed
         this->last_error = ParsingError{
                 .error_type = ParsingError::Type::BadBlankNode,
-                .line = serd_reader_get_current_line(this->reader.get()),
-                .col = serd_reader_get_current_col(this->reader.get()),
+                .line = serd_reader_get_current_line(this->reader),
+                .col = serd_reader_get_current_col(this->reader),
                 .message = std::string{e.what()} + ". note: position may not be accurate and instead point to the end of the triple."};
 
-        return nonstd::make_unexpected(SerdStatus::SERD_ERR_BAD_SYNTAX);
+        return nonstd::make_unexpected(SERD_ERR_BAD_SYNTAX);
     }
 }
 
@@ -70,11 +70,11 @@ nonstd::expected<IRI, SerdStatus> IStreamQuadIterator::Impl::get_iri(SerdNode co
         IRIFactoryError err = iri.error();
         this->last_error = ParsingError{
                 .error_type = ParsingError::Type::BadIri,
-                .line = serd_reader_get_current_line(this->reader.get()),
-                .col = serd_reader_get_current_col(this->reader.get()),
+                .line = serd_reader_get_current_line(this->reader),
+                .col = serd_reader_get_current_col(this->reader),
                 .message = std::format("invalid iri. {}. note: position may not be accurate and instead point to the end of the triple.", err)};
 
-        return nonstd::make_unexpected(SerdStatus::SERD_ERR_BAD_SYNTAX);
+        return nonstd::make_unexpected(SERD_ERR_BAD_SYNTAX);
     }
 
     return *iri;
@@ -85,7 +85,7 @@ nonstd::expected<IRI, SerdStatus> IStreamQuadIterator::Impl::get_prefixed_iri(Se
 
     auto const sep_pos = uri_node_view.find(':');
     if (sep_pos == std::string_view::npos) {
-        return nonstd::make_unexpected(SerdStatus::SERD_ERR_BAD_CURIE);
+        return nonstd::make_unexpected(SERD_ERR_BAD_CURIE);
     }
 
     auto const prefix = uri_node_view.substr(0, sep_pos);
@@ -98,19 +98,19 @@ nonstd::expected<IRI, SerdStatus> IStreamQuadIterator::Impl::get_prefixed_iri(Se
             // NOTE: line, col not entirely accurate as this function is called after a triple was parsed
             this->last_error = ParsingError{
                     .error_type = ParsingError::Type::BadCurie,
-                    .line = serd_reader_get_current_line(this->reader.get()),
-                    .col = serd_reader_get_current_col(this->reader.get()),
+                    .line = serd_reader_get_current_line(this->reader),
+                    .col = serd_reader_get_current_col(this->reader),
                     .message = "unknown prefix. note: position may not be accurate and instead point to the end of the triple."};
 
-            return nonstd::make_unexpected(SerdStatus::SERD_ERR_BAD_CURIE);
+            return nonstd::make_unexpected(SERD_ERR_BAD_CURIE);
         } else {
             this->last_error = ParsingError{
                     .error_type = ParsingError::Type::BadIri,
-                    .line = serd_reader_get_current_line(this->reader.get()),
-                .col = serd_reader_get_current_col(this->reader.get()),
+                    .line = serd_reader_get_current_line(this->reader),
+                    .col = serd_reader_get_current_col(this->reader),
                     .message = std::format("unable to expand curie into valid iri. {}. note: position may not be accurate and instead point to the end of the triple.", err)};
 
-            return nonstd::make_unexpected(SerdStatus::SERD_ERR_BAD_SYNTAX);
+            return nonstd::make_unexpected(SERD_ERR_BAD_SYNTAX);
         }
     }
 
@@ -152,11 +152,11 @@ nonstd::expected<Literal, SerdStatus> IStreamQuadIterator::Impl::get_literal(Ser
         // NOTE: line, col not entirely accurate as this function is called after a triple was parsed
         this->last_error = ParsingError{
                 .error_type = ParsingError::Type::BadLiteral,
-                .line = serd_reader_get_current_line(this->reader.get()),
-                .col = serd_reader_get_current_col(this->reader.get()),
+                .line = serd_reader_get_current_line(this->reader),
+                .col = serd_reader_get_current_col(this->reader),
                 .message = std::string{e.what()} + ". note: position may not be accurate and instead point to the end of the triple."};
 
-        return nonstd::make_unexpected(SerdStatus::SERD_ERR_BAD_SYNTAX);
+        return nonstd::make_unexpected(SERD_ERR_BAD_SYNTAX);
     }
 }
 
@@ -175,8 +175,9 @@ SerdStatus IStreamQuadIterator::Impl::on_error(void *voided_self, SerdError cons
             .line = error->line,
             .col = error->col,
             .message = message};
+    self->last_error_requires_skip = true;
 
-    return SerdStatus::SERD_SUCCESS;
+    return SERD_SUCCESS;
 }
 
 SerdStatus IStreamQuadIterator::Impl::on_base(void *voided_self, const SerdNode *uri) noexcept {
@@ -185,19 +186,21 @@ SerdStatus IStreamQuadIterator::Impl::on_base(void *voided_self, const SerdNode 
     if (self->no_parse_prefixes) {
         self->last_error = ParsingError{
                 .error_type = ParsingError::Type::BadSyntax,
-                .line = serd_reader_get_current_line(self->reader.get()),
-                .col = serd_reader_get_current_col(self->reader.get()),
+                .line = serd_reader_get_current_line(self->reader),
+                .col = serd_reader_get_current_col(self->reader),
                 .message = "Encountered base while parsing. hint: prefix parsing is currently deactivated. note: position may not be accurate and instead point to the end of the line."};
-    } else {
-        auto e = self->state->iri_factory.set_base(node_into_string_view(uri));
-        if (e != IRIFactoryError::Ok) {
-            self->last_error = ParsingError{
-                    .error_type = ParsingError::Type::BadSyntax,
-                    .line = serd_reader_get_current_line(self->reader.get()),
-                    .col = serd_reader_get_current_col(self->reader.get()),
-                    .message = std::format("Error setting base: {}. hint: prefix parsing is currently deactivated. note: position may not be accurate and instead point to the end of the line.", e)};
-            return SERD_ERR_BAD_SYNTAX;
-        }
+
+        return SERD_SUCCESS;
+    }
+
+    auto e = self->state->iri_factory.set_base(node_into_string_view(uri));
+    if (e != IRIFactoryError::Ok) {
+        self->last_error = ParsingError{
+            .error_type = ParsingError::Type::BadSyntax,
+            .line = serd_reader_get_current_line(self->reader),
+            .col = serd_reader_get_current_col(self->reader),
+            .message = std::format("Error setting base: {}. note: position may not be accurate and instead point to the end of the line.", e)};
+        return SERD_SUCCESS;
     }
 
     return SERD_SUCCESS;
@@ -209,13 +212,13 @@ SerdStatus IStreamQuadIterator::Impl::on_prefix(void *voided_self, SerdNode cons
     if (self->no_parse_prefixes) {
         self->last_error = ParsingError{
                 .error_type = ParsingError::Type::BadSyntax,
-                .line = serd_reader_get_current_line(self->reader.get()),
-                .col = serd_reader_get_current_col(self->reader.get()),
+                .line = serd_reader_get_current_line(self->reader),
+                .col = serd_reader_get_current_col(self->reader),
                 .message = "Encountered prefix while parsing. hint: prefix parsing is currently deactivated. note: position may not be accurate and instead point to the end of the line."};
-    } else {
-        self->state->iri_factory.assign_prefix(node_into_string_view(name), node_into_string_view(uri));
+        return SERD_SUCCESS;
     }
 
+    self->state->iri_factory.assign_prefix(node_into_string_view(name), node_into_string_view(uri));
     return SERD_SUCCESS;
 }
 
@@ -248,7 +251,7 @@ SerdStatus IStreamQuadIterator::Impl::on_stmt(void *voided_self,
     }();
 
     if (!graph_node.has_value()) {
-        return graph_node.error();
+        return SERD_SUCCESS;
     }
 
     auto const subj_node = [&]() -> nonstd::expected<Node, SerdStatus> {
@@ -265,7 +268,7 @@ SerdStatus IStreamQuadIterator::Impl::on_stmt(void *voided_self,
     }();
 
     if (!subj_node.has_value()) {
-        return subj_node.error();
+        return SERD_SUCCESS;
     }
 
     auto const pred_node = [&]() -> nonstd::expected<Node, SerdStatus> {
@@ -280,7 +283,7 @@ SerdStatus IStreamQuadIterator::Impl::on_stmt(void *voided_self,
     }();
 
     if (!pred_node.has_value()) {
-        return pred_node.error();
+        return SERD_SUCCESS;
     }
 
     auto const obj_node = [&]() -> nonstd::expected<Node, SerdStatus> {
@@ -299,7 +302,7 @@ SerdStatus IStreamQuadIterator::Impl::on_stmt(void *voided_self,
     }();
 
     if (!obj_node.has_value()) {
-        return obj_node.error();
+        return SERD_SUCCESS;
     }
     self->quad_buffer.emplace_back(*graph_node, *subj_node, *pred_node, *obj_node);
     return SERD_SUCCESS;
@@ -321,41 +324,53 @@ IStreamQuadIterator::Impl::Impl(void *stream,
         this->state_is_owned = true;
     }
 
-    serd_reader_set_strict(this->reader.get(), flags.contains(ParsingFlag::Strict));
-    serd_reader_set_error_sink(this->reader.get(), &Impl::on_error, this);
-    serd_reader_start_source_stream(this->reader.get(), read, error, stream, nullptr, 4096);
+    serd_reader_set_strict(this->reader, flags.contains(ParsingFlag::Strict));
+    serd_reader_set_error_sink(this->reader, &Impl::on_error, this);
+    serd_reader_start_source_stream(this->reader, read, error, stream, nullptr, 4096);
 }
 
 IStreamQuadIterator::Impl::~Impl() noexcept {
+    serd_reader_end_stream(this->reader);
+    serd_reader_free(this->reader);
+
     if (this->state_is_owned) {
         delete this->state;
     }
 }
 
 std::optional<nonstd::expected<IStreamQuadIterator::ok_type, IStreamQuadIterator::error_type>> IStreamQuadIterator::Impl::next() noexcept {
-    if (this->is_at_end()) [[unlikely]] {
-        return std::nullopt;
-    }
-
     while (this->quad_buffer.empty()) {
-        this->last_error = std::nullopt;
-        SerdStatus const st = serd_reader_read_chunk(this->reader.get());
+        if (this->last_error.has_value()) {
+            // handle error from last time
+            if (this->last_error_requires_skip) {
+                this->last_error_requires_skip = false;
+                serd_reader_skip_until_byte(this->reader, '\n');
+            }
+            return nonstd::make_unexpected(*std::exchange(this->last_error, std::nullopt));
+        } else if (this->end_flag) {
+            return std::nullopt;
+        }
 
-        if (quad_buffer.empty()) {
-            if (st != SerdStatus::SERD_SUCCESS) {
-                // was not able to read stmt, prefix or base
+        SerdStatus const st = serd_reader_read_chunk(this->reader);
 
-                if (!this->last_error.has_value()) {
-                    // did not receive error either => must be eof
-                    this->end_flag = true;
-                    return std::nullopt;  // eof reached
-                }
+        if (st == SERD_SUCCESS) {
+            // was able to parse something
+            // not sure if triple or something else, continue loop
+            continue;
+        }
 
-                serd_reader_skip_until_byte(this->reader.get(), '\n');
-                return nonstd::make_unexpected(*this->last_error);
-            } else if (this->last_error.has_value()) {
-                // non-fatal, artificially inserted error
-                return nonstd::make_unexpected(*this->last_error);
+        if (!this->last_error.has_value()) {
+            if (st == SERD_FAILURE) {
+                // no error and SERD_FAILURE means EOF
+                this->end_flag = true;
+            } else {
+                // got some other specific error => not eof
+                // but we don't really know what because the error handler was not called
+                this->last_error = ParsingError{.error_type = parsing_error_type_from_serd(st),
+                                                .line = serd_reader_get_current_line(this->reader),
+                                                .col = serd_reader_get_current_col(this->reader),
+                                                .message = "Unknown error"};
+                this->last_error_requires_skip = true;
             }
         }
     }

--- a/src/rdf4cpp/rdf/parser/IStreamQuadIterator.cpp
+++ b/src/rdf4cpp/rdf/parser/IStreamQuadIterator.cpp
@@ -31,10 +31,11 @@ static size_t istream_read(void *buf, [[maybe_unused]] size_t elem_size, size_t 
  * Matches the interface of SerdStreamErrorFunc
  *
  * @param voided_self pointer to std::istream cast to void *
+ * @return whether the given istream encountered an error (cast to int)
  */
 static int istream_error(void *voided_self) noexcept {
     auto *self = static_cast<std::istream *>(voided_self);
-    return *self ? 0 : 1;
+    return static_cast<int>(self->fail() && !self->eof());
 }
 
 IStreamQuadIterator::IStreamQuadIterator(void *stream,

--- a/src/rdf4cpp/rdf/parser/IStreamQuadIterator.hpp
+++ b/src/rdf4cpp/rdf/parser/IStreamQuadIterator.hpp
@@ -73,27 +73,9 @@ private:
     struct Impl;
 
     std::unique_ptr<Impl> impl;
-    nonstd::expected<ok_type, error_type> cur = nonstd::make_unexpected(ParsingError{.error_type = ParsingError::Type::EofReached, .line = 0, .col = 0, .message = "eof reached"});
-
-    [[nodiscard]] bool is_at_end() const noexcept;
+    std::optional<nonstd::expected<ok_type, error_type>> cur;
 
 public:
-    /**
-     * Constructs the end-of-stream iterator
-     */
-    IStreamQuadIterator() noexcept;
-
-    /**
-     * Constructs the end-of-stream iterator
-     */
-    explicit IStreamQuadIterator(std::default_sentinel_t) noexcept;
-
-    IStreamQuadIterator(IStreamQuadIterator const &) = delete;
-    IStreamQuadIterator(IStreamQuadIterator &&) noexcept;
-
-    IStreamQuadIterator &operator=(IStreamQuadIterator const &) = delete;
-    IStreamQuadIterator &operator=(IStreamQuadIterator &&) noexcept;
-
     /**
      * Constructs a IStreamQuadIterator from a C-like io api. That is something similar to
      * the triple (FILE *, fread, ferror) (parameters are called (stream, read, error) here).
@@ -126,14 +108,17 @@ public:
                                  flags_type flags = ParsingFlags::none(),
                                  state_type *initial_state = nullptr) noexcept;
 
+    IStreamQuadIterator(IStreamQuadIterator const &) = delete;
+    IStreamQuadIterator(IStreamQuadIterator &&) noexcept;
+
+    IStreamQuadIterator &operator=(IStreamQuadIterator const &) = delete;
+    IStreamQuadIterator &operator=(IStreamQuadIterator &&) noexcept;
+
     ~IStreamQuadIterator() noexcept;
 
     reference operator*() const noexcept;
     pointer operator->() const noexcept;
     IStreamQuadIterator &operator++();
-
-    bool operator==(IStreamQuadIterator const &) const noexcept;
-    bool operator!=(IStreamQuadIterator const &) const noexcept;
 
     bool operator==(std::default_sentinel_t) const noexcept;
     bool operator!=(std::default_sentinel_t) const noexcept;

--- a/tests/parser/tests_IStreamQuadIterator.cpp
+++ b/tests/parser/tests_IStreamQuadIterator.cpp
@@ -342,254 +342,282 @@ TEST_SUITE("IStreamQuadIterator") {
         ++qit;
         CHECK(qit == std::default_sentinel);
     }
-}
 
-TEST_CASE("N-Triple") {
-    SUBCASE("simple") {
-        std::stringstream str{"<http://example/s> <http://example/p> \"string\" ."};
+    TEST_CASE("garbage input") {
+        std::istringstream iss{"}; SELECT * WHERE { ?s ?p ?o "};
 
-        IStreamQuadIterator it{str, ParsingFlag::NTriples};
+        size_t count = 0;
+        for (IStreamQuadIterator qit{iss, ParsingFlag::NoParsePrefix | ParsingFlag::KeepBlankNodeIds}; qit != std::default_sentinel; ++qit) {
+            CHECK_FALSE(qit->has_value());
+            ++count;
+        }
 
-        CHECK_NE(it, std::default_sentinel);
-        CHECK(it->has_value());
-        CHECK(it->value() == Quad{IRI{"http://example/s"},
-                                  IRI{"http://example/p"},
-                                  Literal::make_simple("string")});
-
-        ++it;
-        CHECK_EQ(it, std::default_sentinel);
-    }
-    SUBCASE("Turtle") {
-        constexpr char const *triples = "@base <http://invalid-url.org> .\n"
-                                        "@prefix xsd: <http://some-random-url.de#> .\n"
-                                        "<http://data.semanticweb.org/workshop/admire/2012/paper/12> <http://purl.org/dc/elements/1.1/subject> \"search\" .\n"
-                                        "xsd:subject xsd:predicate \"aaaaa\" .\n";
-
-        std::istringstream iss{triples};
-        IStreamQuadIterator qit{iss, ParsingFlag::NTriples};
-
-        CHECK_NE(qit, std::default_sentinel);
-        CHECK(!qit->has_value());
-        std::cout << qit->error() << std::endl;
-
-        ++qit;
-        CHECK_NE(qit, std::default_sentinel);
-        CHECK(!qit->has_value());
-        std::cout << qit->error() << std::endl;
-
-        ++qit;
-        CHECK_NE(qit, std::default_sentinel);
-        CHECK(qit->has_value());
-        CHECK(qit->value() == Quad{IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/12"},
-                                   IRI{"http://purl.org/dc/elements/1.1/subject"},
-                                   Literal::make_simple("search")});
-
-        ++qit;
-        CHECK_NE(qit, std::default_sentinel);
-        CHECK(!qit->has_value());
-        std::cout << qit->error() << std::endl;
-
-        ++qit;
-        CHECK_EQ(qit, std::default_sentinel);
-    }
-}
-
-TEST_CASE("N-Quads") {
-    SUBCASE("simple") {
-        std::stringstream str{"<http://example/s> <http://example/p> <http://example/o> <http://example/g> .\n"
-                              "<http://example/s> <http://example/p> <http://example/o>."};
-
-        IStreamQuadIterator it{str, ParsingFlag::NQuads};
-
-        CHECK_NE(it, std::default_sentinel);
-        CHECK(it->has_value());
-        CHECK(it->value() == Quad{IRI{"http://example/g"},
-                                  IRI{"http://example/s"},
-                                  IRI{"http://example/p"},
-                                  IRI{"http://example/o"}});
-
-        ++it;
-        CHECK_NE(it, std::default_sentinel);
-        CHECK(it->has_value());
-        CHECK(it->value() == Quad{IRI{"http://example/s"},
-                                  IRI{"http://example/p"},
-                                  IRI{"http://example/o"}});
-
-        ++it;
-        CHECK_EQ(it, std::default_sentinel);
-    }
-    SUBCASE("Turtle") {
-        constexpr char const *triples = "@base <http://invalid-url.org> .\n"
-                                        "@prefix xsd: <http://some-random-url.de#> .\n"
-                                        "<http://data.semanticweb.org/workshop/admire/2012/paper/12> <http://purl.org/dc/elements/1.1/subject> \"search\" .\n"
-                                        "xsd:subject xsd:predicate \"aaaaa\" .\n";
-
-        std::istringstream iss{triples};
-        IStreamQuadIterator qit{iss, ParsingFlag::NTriples};
-
-        CHECK_NE(qit, std::default_sentinel);
-        CHECK(!qit->has_value());
-        std::cout << qit->error() << std::endl;
-
-        ++qit;
-        CHECK_NE(qit, std::default_sentinel);
-        CHECK(!qit->has_value());
-        std::cout << qit->error() << std::endl;
-
-        ++qit;
-        CHECK_NE(qit, std::default_sentinel);
-        CHECK(qit->has_value());
-        CHECK(qit->value() == Quad{IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/12"},
-                                   IRI{"http://purl.org/dc/elements/1.1/subject"},
-                                   Literal::make_simple("search")});
-
-        ++qit;
-        CHECK_NE(qit, std::default_sentinel);
-        CHECK(!qit->has_value());
-        std::cout << qit->error() << std::endl;
-
-        ++qit;
-        CHECK_EQ(qit, std::default_sentinel);
-    }
-}
-
-TEST_CASE("TriG") {
-    SUBCASE("simple") {
-        std::stringstream str{"<http://example/g> {<http://example/s> <http://example/p> <http://example/o> .}"};
-
-        IStreamQuadIterator it{str, ParsingFlag::TriG};
-
-        CHECK_NE(it, std::default_sentinel);
-        CHECK(it->has_value());
-        CHECK_EQ(it->value(), Quad{IRI{"http://example/g"},
-                                   IRI{"http://example/s"},
-                                   IRI{"http://example/p"},
-                                   IRI{"http://example/o"}});
-
-        ++it;
-        CHECK_EQ(it, std::default_sentinel);
-    }
-    SUBCASE("mixed") {
-        std::stringstream str{"@prefix p: <http://a.example/>.\n"
-                              "{p:s <http://a.example/p> p:o .}\n"
-                              "<http://example/graph> {<http://a.example/s> <http://a.example/p> <http://a.example/o> .}"};
-
-        IStreamQuadIterator it{str, ParsingFlag::TriG};
-
-        CHECK_NE(it, std::default_sentinel);
-        CHECK(it->has_value());
-        CHECK_EQ(it->value(), Quad{IRI{"http://a.example/s"},
-                                   IRI{"http://a.example/p"},
-                                   IRI{"http://a.example/o"}});
-        ++it;
-        CHECK_NE(it, std::default_sentinel);
-        CHECK(it->has_value());
-        CHECK_EQ(it->value(), Quad{IRI{"http://example/graph"},
-                                   IRI{"http://a.example/s"},
-                                   IRI{"http://a.example/p"},
-                                   IRI{"http://a.example/o"}});
-
-        ++it;
-        CHECK_EQ(it, std::default_sentinel);
-    }
-}
-
-TEST_CASE("bnode management") {
-    constexpr char const *triples = "<http://data.semanticweb.org/workshop/admire/2012/paper/12> <http://purl.org/dc/elements/1.1/subject> _:b1 .\n"
-                                    "<http://data.semanticweb.org/workshop/admire/2012/paper/13> <http://purl.org/dc/elements/1.1/subject> _:b1 .\n"
-                                    "_:b2 <http://purl.org/dc/elements/1.1/subject> \"Some Subject\" .\n";
-
-    SUBCASE("bnodes") {
-        IStreamQuadIterator::state_type state{
-                .blank_node_generator = &bnode_mngt::NodeGenerator::default_instance(),
-                .blank_node_scope_manager = &bnode_mngt::ReferenceNodeScopeManager::default_instance()};
-
-        std::istringstream iss{triples};
-        IStreamQuadIterator qit{iss, ParsingFlags::none(), &state};
-
-        CHECK(qit != std::default_sentinel);
-        CHECK(qit->has_value());
-        CHECK(qit->value().subject() == IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/12"});
-        CHECK(qit->value().predicate() == IRI{"http://purl.org/dc/elements/1.1/subject"});
-
-        auto b1_1 = qit->value().object();
-        CHECK(b1_1.is_blank_node());
-        std::cout << qit->value().object() << std::endl;
-
-        ++qit;
-        CHECK(qit != std::default_sentinel);
-        CHECK(qit->value().subject() == IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/13"});
-        CHECK(qit->value().predicate() == IRI{"http://purl.org/dc/elements/1.1/subject"});
-
-        auto b1_2 = qit->value().object();
-        CHECK(b1_1.is_blank_node());
-        std::cout << qit->value().object() << std::endl;
-        CHECK(b1_1 == b1_2);
-
-        ++qit;
-        CHECK(qit != std::default_sentinel);
-        auto b2_1 = qit->value().subject();
-        CHECK(b2_1.is_blank_node());
-        CHECK(b2_1 != b1_1);
-        std::cout << b2_1 << std::endl;
-        CHECK(qit->value().predicate() == IRI{"http://purl.org/dc/elements/1.1/subject"});
-        CHECK(qit->value().object() == Literal::make_simple("Some Subject"));
-
-        ++qit;
-        CHECK(qit == std::default_sentinel);
+        CHECK_EQ(count, 1);
     }
 
-    SUBCASE("skolem iris") {
-        auto scope_mng = bnode_mngt::ReferenceNodeScopeManager{};
-        auto generator = bnode_mngt::NodeGenerator::new_instance_with_factory<bnode_mngt::SkolemIRIFactory>("http://skolem-iris.org#");
+    TEST_CASE("empty input") {
+        SUBCASE("istream") {
+            std::istringstream iss{""};
 
-        IStreamQuadIterator::state_type state{.blank_node_generator = &generator,
-                                              .blank_node_scope_manager = &scope_mng};
+            for (IStreamQuadIterator qit{iss}; qit != std::default_sentinel; ++qit) {
+                FAIL("not empty");
+            }
+        }
 
-        std::istringstream iss{triples};
-        IStreamQuadIterator qit{iss, ParsingFlags::none(), &state};
+        SUBCASE("fopen") {
+            static constexpr char const *path = "/tmp/rdf4cpp-istreamquad-iter-empty";
 
-        CHECK(qit != std::default_sentinel);
-        CHECK(qit->has_value());
-        CHECK(qit->value().subject() == IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/12"});
-        CHECK(qit->value().predicate() == IRI{"http://purl.org/dc/elements/1.1/subject"});
+            {
+                auto *f = fopen(path, "w");
+                fclose(f);
+            }
 
-        auto b1_1 = qit->value().object();
-        CHECK(b1_1.is_iri());
-        std::cout << qit->value().object() << std::endl;
+            auto *f = fopen(path, "r");
+            for (IStreamQuadIterator qit{f, reinterpret_cast<ReadFunc>(fread), reinterpret_cast<ErrorFunc>(ferror)}; qit != std::default_sentinel; ++qit) {
+                FAIL("not empty");
+            }
 
-        ++qit;
-        CHECK(qit != std::default_sentinel);
-        CHECK(qit->value().subject() == IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/13"});
-        CHECK(qit->value().predicate() == IRI{"http://purl.org/dc/elements/1.1/subject"});
-
-        auto b1_2 = qit->value().object();
-        CHECK(b1_1.is_iri());
-        std::cout << qit->value().object() << std::endl;
-        CHECK(b1_1 == b1_2);
-
-        ++qit;
-        CHECK(qit != std::default_sentinel);
-        auto b2_1 = qit->value().subject();
-        CHECK(b2_1.is_iri());
-        CHECK(b2_1 != b1_1);
-        std::cout << b2_1 << std::endl;
-        CHECK(qit->value().predicate() == IRI{"http://purl.org/dc/elements/1.1/subject"});
-        CHECK(qit->value().object() == Literal::make_simple("Some Subject"));
-
-        ++qit;
-        CHECK(qit == std::default_sentinel);
-    }
-}
-
-TEST_CASE("garbage input") {
-    std::istringstream iss{"}; SELECT * WHERE { ?s ?p ?o "};
-
-    size_t count = 0;
-    for (IStreamQuadIterator qit{iss, ParsingFlag::NoParsePrefix | ParsingFlag::KeepBlankNodeIds}; qit != std::default_sentinel; ++qit) {
-        CHECK_FALSE(qit->has_value());
-        ++count;
+            fclose(f);
+            remove(path);
+        }
     }
 
-    CHECK_EQ(count, 1);
+    TEST_CASE("N-Triple") {
+        SUBCASE("simple") {
+            std::stringstream str{"<http://example/s> <http://example/p> \"string\" ."};
+
+            IStreamQuadIterator it{str, ParsingFlag::NTriples};
+
+            CHECK_NE(it, std::default_sentinel);
+            CHECK(it->has_value());
+            CHECK(it->value() == Quad{IRI{"http://example/s"},
+                                      IRI{"http://example/p"},
+                                      Literal::make_simple("string")});
+
+            ++it;
+            CHECK_EQ(it, std::default_sentinel);
+        }
+        SUBCASE("Turtle") {
+            constexpr char const *triples = "@base <http://invalid-url.org> .\n"
+                                            "@prefix xsd: <http://some-random-url.de#> .\n"
+                                            "<http://data.semanticweb.org/workshop/admire/2012/paper/12> <http://purl.org/dc/elements/1.1/subject> \"search\" .\n"
+                                            "xsd:subject xsd:predicate \"aaaaa\" .\n";
+
+            std::istringstream iss{triples};
+            IStreamQuadIterator qit{iss, ParsingFlag::NTriples};
+
+            CHECK_NE(qit, std::default_sentinel);
+            CHECK(!qit->has_value());
+            std::cout << qit->error() << std::endl;
+
+            ++qit;
+            CHECK_NE(qit, std::default_sentinel);
+            CHECK(!qit->has_value());
+            std::cout << qit->error() << std::endl;
+
+            ++qit;
+            CHECK_NE(qit, std::default_sentinel);
+            CHECK(qit->has_value());
+            CHECK(qit->value() == Quad{IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/12"},
+                                       IRI{"http://purl.org/dc/elements/1.1/subject"},
+                                       Literal::make_simple("search")});
+
+            ++qit;
+            CHECK_NE(qit, std::default_sentinel);
+            CHECK(!qit->has_value());
+            std::cout << qit->error() << std::endl;
+
+            ++qit;
+            CHECK_EQ(qit, std::default_sentinel);
+        }
+    }
+
+    TEST_CASE("N-Quads") {
+        SUBCASE("simple") {
+            std::stringstream str{"<http://example/s> <http://example/p> <http://example/o> <http://example/g> .\n"
+                                  "<http://example/s> <http://example/p> <http://example/o>."};
+
+            IStreamQuadIterator it{str, ParsingFlag::NQuads};
+
+            CHECK_NE(it, std::default_sentinel);
+            CHECK(it->has_value());
+            CHECK(it->value() == Quad{IRI{"http://example/g"},
+                                      IRI{"http://example/s"},
+                                      IRI{"http://example/p"},
+                                      IRI{"http://example/o"}});
+
+            ++it;
+            CHECK_NE(it, std::default_sentinel);
+            CHECK(it->has_value());
+            CHECK(it->value() == Quad{IRI{"http://example/s"},
+                                      IRI{"http://example/p"},
+                                      IRI{"http://example/o"}});
+
+            ++it;
+            CHECK_EQ(it, std::default_sentinel);
+        }
+        SUBCASE("Turtle") {
+            constexpr char const *triples = "@base <http://invalid-url.org> .\n"
+                                            "@prefix xsd: <http://some-random-url.de#> .\n"
+                                            "<http://data.semanticweb.org/workshop/admire/2012/paper/12> <http://purl.org/dc/elements/1.1/subject> \"search\" .\n"
+                                            "xsd:subject xsd:predicate \"aaaaa\" .\n";
+
+            std::istringstream iss{triples};
+            IStreamQuadIterator qit{iss, ParsingFlag::NTriples};
+
+            CHECK_NE(qit, std::default_sentinel);
+            CHECK(!qit->has_value());
+            std::cout << qit->error() << std::endl;
+
+            ++qit;
+            CHECK_NE(qit, std::default_sentinel);
+            CHECK(!qit->has_value());
+            std::cout << qit->error() << std::endl;
+
+            ++qit;
+            CHECK_NE(qit, std::default_sentinel);
+            CHECK(qit->has_value());
+            CHECK(qit->value() == Quad{IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/12"},
+                                       IRI{"http://purl.org/dc/elements/1.1/subject"},
+                                       Literal::make_simple("search")});
+
+            ++qit;
+            CHECK_NE(qit, std::default_sentinel);
+            CHECK(!qit->has_value());
+            std::cout << qit->error() << std::endl;
+
+            ++qit;
+            CHECK_EQ(qit, std::default_sentinel);
+        }
+    }
+
+    TEST_CASE("TriG") {
+        SUBCASE("simple") {
+            std::stringstream str{"<http://example/g> {<http://example/s> <http://example/p> <http://example/o> .}"};
+
+            IStreamQuadIterator it{str, ParsingFlag::TriG};
+
+            CHECK_NE(it, std::default_sentinel);
+            CHECK(it->has_value());
+            CHECK_EQ(it->value(), Quad{IRI{"http://example/g"},
+                                       IRI{"http://example/s"},
+                                       IRI{"http://example/p"},
+                                       IRI{"http://example/o"}});
+
+            ++it;
+            CHECK_EQ(it, std::default_sentinel);
+        }
+        SUBCASE("mixed") {
+            std::stringstream str{"@prefix p: <http://a.example/>.\n"
+                                  "{p:s <http://a.example/p> p:o .}\n"
+                                  "<http://example/graph> {<http://a.example/s> <http://a.example/p> <http://a.example/o> .}"};
+
+            IStreamQuadIterator it{str, ParsingFlag::TriG};
+
+            CHECK_NE(it, std::default_sentinel);
+            CHECK(it->has_value());
+            CHECK_EQ(it->value(), Quad{IRI{"http://a.example/s"},
+                                       IRI{"http://a.example/p"},
+                                       IRI{"http://a.example/o"}});
+            ++it;
+            CHECK_NE(it, std::default_sentinel);
+            CHECK(it->has_value());
+            CHECK_EQ(it->value(), Quad{IRI{"http://example/graph"},
+                                       IRI{"http://a.example/s"},
+                                       IRI{"http://a.example/p"},
+                                       IRI{"http://a.example/o"}});
+
+            ++it;
+            CHECK_EQ(it, std::default_sentinel);
+        }
+    }
+
+    TEST_CASE("bnode management") {
+        constexpr char const *triples = "<http://data.semanticweb.org/workshop/admire/2012/paper/12> <http://purl.org/dc/elements/1.1/subject> _:b1 .\n"
+                                        "<http://data.semanticweb.org/workshop/admire/2012/paper/13> <http://purl.org/dc/elements/1.1/subject> _:b1 .\n"
+                                        "_:b2 <http://purl.org/dc/elements/1.1/subject> \"Some Subject\" .\n";
+
+        SUBCASE("bnodes") {
+            IStreamQuadIterator::state_type state{
+                    .blank_node_generator = &bnode_mngt::NodeGenerator::default_instance(),
+                    .blank_node_scope_manager = &bnode_mngt::ReferenceNodeScopeManager::default_instance()};
+
+            std::istringstream iss{triples};
+            IStreamQuadIterator qit{iss, ParsingFlags::none(), &state};
+
+            CHECK(qit != std::default_sentinel);
+            CHECK(qit->has_value());
+            CHECK(qit->value().subject() == IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/12"});
+            CHECK(qit->value().predicate() == IRI{"http://purl.org/dc/elements/1.1/subject"});
+
+            auto b1_1 = qit->value().object();
+            CHECK(b1_1.is_blank_node());
+            std::cout << qit->value().object() << std::endl;
+
+            ++qit;
+            CHECK(qit != std::default_sentinel);
+            CHECK(qit->value().subject() == IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/13"});
+            CHECK(qit->value().predicate() == IRI{"http://purl.org/dc/elements/1.1/subject"});
+
+            auto b1_2 = qit->value().object();
+            CHECK(b1_1.is_blank_node());
+            std::cout << qit->value().object() << std::endl;
+            CHECK(b1_1 == b1_2);
+
+            ++qit;
+            CHECK(qit != std::default_sentinel);
+            auto b2_1 = qit->value().subject();
+            CHECK(b2_1.is_blank_node());
+            CHECK(b2_1 != b1_1);
+            std::cout << b2_1 << std::endl;
+            CHECK(qit->value().predicate() == IRI{"http://purl.org/dc/elements/1.1/subject"});
+            CHECK(qit->value().object() == Literal::make_simple("Some Subject"));
+
+            ++qit;
+            CHECK(qit == std::default_sentinel);
+        }
+
+        SUBCASE("skolem iris") {
+            auto scope_mng = bnode_mngt::ReferenceNodeScopeManager{};
+            auto generator = bnode_mngt::NodeGenerator::new_instance_with_factory<bnode_mngt::SkolemIRIFactory>("http://skolem-iris.org#");
+
+            IStreamQuadIterator::state_type state{.blank_node_generator = &generator,
+                                                  .blank_node_scope_manager = &scope_mng};
+
+            std::istringstream iss{triples};
+            IStreamQuadIterator qit{iss, ParsingFlags::none(), &state};
+
+            CHECK(qit != std::default_sentinel);
+            CHECK(qit->has_value());
+            CHECK(qit->value().subject() == IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/12"});
+            CHECK(qit->value().predicate() == IRI{"http://purl.org/dc/elements/1.1/subject"});
+
+            auto b1_1 = qit->value().object();
+            CHECK(b1_1.is_iri());
+            std::cout << qit->value().object() << std::endl;
+
+            ++qit;
+            CHECK(qit != std::default_sentinel);
+            CHECK(qit->value().subject() == IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/13"});
+            CHECK(qit->value().predicate() == IRI{"http://purl.org/dc/elements/1.1/subject"});
+
+            auto b1_2 = qit->value().object();
+            CHECK(b1_1.is_iri());
+            std::cout << qit->value().object() << std::endl;
+            CHECK(b1_1 == b1_2);
+
+            ++qit;
+            CHECK(qit != std::default_sentinel);
+            auto b2_1 = qit->value().subject();
+            CHECK(b2_1.is_iri());
+            CHECK(b2_1 != b1_1);
+            std::cout << b2_1 << std::endl;
+            CHECK(qit->value().predicate() == IRI{"http://purl.org/dc/elements/1.1/subject"});
+            CHECK(qit->value().object() == Literal::make_simple("Some Subject"));
+
+            ++qit;
+            CHECK(qit == std::default_sentinel);
+        }
+    }
+
 }

--- a/tests/parser/tests_IStreamQuadIterator.cpp
+++ b/tests/parser/tests_IStreamQuadIterator.cpp
@@ -19,7 +19,7 @@ TEST_SUITE("IStreamQuadIterator") {
         std::istringstream iss{triples};
 
         size_t n = 0;
-        for (auto qit = IStreamQuadIterator{iss}; qit != IStreamQuadIterator{}; ++qit) {
+        for (auto qit = IStreamQuadIterator{iss}; qit != std::default_sentinel; ++qit) {
             CHECK(qit->has_value());
             n += 1;
         }
@@ -39,7 +39,7 @@ TEST_SUITE("IStreamQuadIterator") {
 
         storage::node::NodeStorage ns = storage::node::NodeStorage::new_instance();
         IStreamQuadIterator::state_type state{.node_storage = ns};
-        for (auto qit = IStreamQuadIterator{iss, ParsingFlags::none(), &state}; qit != IStreamQuadIterator{}; ++qit) {
+        for (auto qit = IStreamQuadIterator{iss, ParsingFlags::none(), &state}; qit != std::default_sentinel; ++qit) {
             CHECK(qit->has_value());
 
             for (auto const term : **qit) {
@@ -60,25 +60,25 @@ TEST_SUITE("IStreamQuadIterator") {
 
         std::istringstream iss{triples};
         IStreamQuadIterator qit{iss};
-        CHECK_NE(qit, IStreamQuadIterator{});
+        CHECK_NE(qit, std::default_sentinel);
         CHECK_EQ(qit->value().subject(), IRI{"http://www.example.org/s1"});
         CHECK_EQ(qit->value().predicate(), IRI{"http://www.example.org/p1"});
         CHECK_EQ(qit->value().object(), IRI{"http://www.example.org/o1"});
 
         ++qit;
-        CHECK_NE(qit, IStreamQuadIterator{});
+        CHECK_NE(qit, std::default_sentinel);
         CHECK_EQ(qit->value().subject(), IRI{"http://www.example.org/s1"});
         CHECK_EQ(qit->value().predicate(), IRI{"http://www.example.org/p2"});
         CHECK_EQ(qit->value().object(), IRI{"http://www.example.org/o2"});
 
         ++qit;
-        CHECK_NE(qit, IStreamQuadIterator{});
+        CHECK_NE(qit, std::default_sentinel);
         CHECK_EQ(qit->value().subject(), IRI{"http://www.example.org/s2"});
         CHECK_EQ(qit->value().predicate(), IRI{"http://www.example.org/p3"});
         CHECK_EQ(qit->value().object(), Literal::make_simple("test"));
 
         ++qit;
-        CHECK_EQ(qit, IStreamQuadIterator{});
+        CHECK_EQ(qit, std::default_sentinel);
     }
 
     TEST_CASE("continue after error") {
@@ -91,60 +91,60 @@ TEST_SUITE("IStreamQuadIterator") {
             std::istringstream iss{triples};
             IStreamQuadIterator qit{iss, ParsingFlag::Strict};
 
-            CHECK_NE(qit, IStreamQuadIterator{});
+            CHECK_NE(qit, std::default_sentinel);
             CHECK_EQ(qit->value().subject(), IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/12"});
             CHECK_EQ(qit->value().predicate(), IRI{"http://purl.org/dc/elements/1.1/subject"});
             CHECK_EQ(qit->value().object(), Literal::make_simple("search"));
 
             ++qit;
-            CHECK_NE(qit, IStreamQuadIterator{});
+            CHECK_NE(qit, std::default_sentinel);
             CHECK_EQ(qit->value().subject(), IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/12"});
             CHECK_EQ(qit->value().predicate(), IRI{"http://purl.org/ontology/bibo/authorList"});
             CHECK_EQ(qit->value().object(), IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/12/authorlist"});
 
             ++qit;
-            CHECK_NE(qit, IStreamQuadIterator{});
+            CHECK_NE(qit, std::default_sentinel);
             CHECK(!qit->has_value());
             std::cerr << qit->error() << std::endl;
 
             ++qit;
-            CHECK_NE(qit, IStreamQuadIterator{});
+            CHECK_NE(qit, std::default_sentinel);
             CHECK_EQ(qit->value().subject(), IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/12"});
             CHECK_EQ(qit->value().predicate(), IRI{"http://xmlns.com/foaf/0.1/maker"});
             CHECK_EQ(qit->value().object(), IRI{"http://data.semanticweb.org/person/ichiro-fujinaga"});
 
             ++qit;
-            CHECK_EQ(qit, IStreamQuadIterator{});
+            CHECK_EQ(qit, std::default_sentinel);
         }
 
         SUBCASE("non-strict") {
             std::istringstream iss{triples};
             IStreamQuadIterator qit{iss};
 
-            CHECK_NE(qit, IStreamQuadIterator{});
+            CHECK_NE(qit, std::default_sentinel);
             CHECK_EQ(qit->value().subject(), IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/12"});
             CHECK_EQ(qit->value().predicate(), IRI{"http://purl.org/dc/elements/1.1/subject"});
             CHECK_EQ(qit->value().object(), Literal::make_simple("search"));
 
             ++qit;
-            CHECK_NE(qit, IStreamQuadIterator{});
+            CHECK_NE(qit, std::default_sentinel);
             CHECK_EQ(qit->value().subject(), IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/12"});
             CHECK_EQ(qit->value().predicate(), IRI{"http://purl.org/ontology/bibo/authorList"});
             CHECK_EQ(qit->value().object(), IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/12/authorlist"});
 
             ++qit;
-            CHECK_NE(qit, IStreamQuadIterator{});
+            CHECK_NE(qit, std::default_sentinel);
             CHECK(!qit->has_value());
             std::cerr << qit->error() << std::endl;
 
             ++qit;
-            CHECK_NE(qit, IStreamQuadIterator{});
+            CHECK_NE(qit, std::default_sentinel);
             CHECK_EQ(qit->value().subject(), IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/12"});
             CHECK_EQ(qit->value().predicate(), IRI{"http://xmlns.com/foaf/0.1/maker"});
             CHECK_EQ(qit->value().object(), IRI{"http://data.semanticweb.org/person/ichiro-fujinaga"});
 
             ++qit;
-            CHECK_EQ(qit, IStreamQuadIterator{});
+            CHECK_EQ(qit, std::default_sentinel);
         }
     }
 
@@ -169,14 +169,14 @@ TEST_SUITE("IStreamQuadIterator") {
         std::istringstream iss{triples};
         IStreamQuadIterator qit{iss, ParsingFlag::KeepBlankNodeIds};
 
-        CHECK_NE(qit, IStreamQuadIterator{});
+        CHECK_NE(qit, std::default_sentinel);
         CHECK(qit->value() == Quad{IRI{"http://www.w3.org/TR/rdf-syntax-grammar"},
                                    IRI{"http://purl.org/dc/elements/1.1/title"},
                                    Literal::make_typed_from_value<datatypes::xsd::String>("RDF/XML Syntax Specification (Revised)")});
 
 
         ++qit;
-        CHECK_NE(qit, IStreamQuadIterator{});
+        CHECK_NE(qit, std::default_sentinel);
         CHECK(qit->value() == Quad{IRI{"http://www.w3.org/TR/rdf-syntax-grammar"},
                                    IRI{"http://example.org/stuff/1.0/editor"},
                                    BlankNode{"b1"}});
@@ -191,25 +191,25 @@ TEST_SUITE("IStreamQuadIterator") {
 
         // start of new spec
         ++qit;
-        CHECK_NE(qit, IStreamQuadIterator{});
+        CHECK_NE(qit, std::default_sentinel);
         CHECK(qit->value() == Quad{IRI{"http://www.w3.org/TR/rdf-syntax-grammar"},
                                    IRI{"http://purl.org/dc/elements/1.1/title"},
                                    Literal::make_typed_from_value<datatypes::xsd::String>("RDF/XML Syntax Specification (Revised)")});
 
         ++qit;
-        CHECK_NE(qit, IStreamQuadIterator{});
+        CHECK_NE(qit, std::default_sentinel);
         CHECK(qit->value() == Quad{IRI{"http://www.w3.org/TR/rdf-syntax-grammar"},
                                    IRI{"http://example.org/stuff/1.0/editor"},
                                    BlankNode{"b2"}});
 
         ++qit;
-        CHECK_NE(qit, IStreamQuadIterator{});
+        CHECK_NE(qit, std::default_sentinel);
         CHECK(qit->value() == Quad{BlankNode{"b2"},
                                    IRI{"http://example.org/stuff/1.0/fullname"},
                                    Literal::make_typed_from_value<datatypes::xsd::String>("Dave Beckett")});
 
         ++qit;
-        CHECK_EQ(qit, IStreamQuadIterator{});
+        CHECK_EQ(qit, std::default_sentinel);
     }
 
     TEST_CASE("invalid literal") {
@@ -218,12 +218,12 @@ TEST_SUITE("IStreamQuadIterator") {
         std::istringstream iss{triples};
         IStreamQuadIterator qit{iss};
 
-        CHECK_NE(qit, IStreamQuadIterator{});
+        CHECK_NE(qit, std::default_sentinel);
         CHECK(!qit->has_value());
         std::cerr << qit->error() << std::endl;
 
         ++qit;
-        CHECK_EQ(qit, IStreamQuadIterator{});
+        CHECK_EQ(qit, std::default_sentinel);
     }
 
     TEST_CASE("unknown prefix") {
@@ -232,12 +232,12 @@ TEST_SUITE("IStreamQuadIterator") {
         std::istringstream iss{triples};
         IStreamQuadIterator qit{iss};
 
-        CHECK_NE(qit, IStreamQuadIterator{});
+        CHECK_NE(qit, std::default_sentinel);
         CHECK(!qit->has_value());
         std::cerr << qit->error() << std::endl;
 
         ++qit;
-        CHECK_EQ(qit, IStreamQuadIterator{});
+        CHECK_EQ(qit, std::default_sentinel);
     }
 
     TEST_CASE("curie as literal type") {
@@ -247,12 +247,12 @@ TEST_SUITE("IStreamQuadIterator") {
         std::istringstream iss{triples};
         IStreamQuadIterator qit{iss};
 
-        CHECK_NE(qit, IStreamQuadIterator{});
+        CHECK_NE(qit, std::default_sentinel);
         CHECK(qit->has_value());
         std::cerr << qit->value() << std::endl;
 
         ++qit;
-        CHECK_EQ(qit, IStreamQuadIterator{});
+        CHECK_EQ(qit, std::default_sentinel);
     }
 
     TEST_CASE("manually added prefix") {
@@ -264,14 +264,14 @@ TEST_SUITE("IStreamQuadIterator") {
 
         IStreamQuadIterator qit{iss, ParsingFlags::none(), &state};
 
-        CHECK_NE(qit, IStreamQuadIterator{});
+        CHECK_NE(qit, std::default_sentinel);
         CHECK(qit->has_value());
         CHECK(qit->value() == Quad{IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/12"},
                                    IRI{"https://hello.com#predicate"},
                                    Literal::make_simple("search")});
 
         ++qit;
-        CHECK_EQ(qit, IStreamQuadIterator{});
+        CHECK_EQ(qit, std::default_sentinel);
     }
 
     TEST_CASE("no prefix parsing") {
@@ -283,29 +283,29 @@ TEST_SUITE("IStreamQuadIterator") {
         std::istringstream iss{triples};
         IStreamQuadIterator qit{iss, ParsingFlag::NoParsePrefix};
 
-        CHECK_NE(qit, IStreamQuadIterator{});
+        CHECK_NE(qit, std::default_sentinel);
         CHECK(!qit->has_value());
         std::cout << qit->error() << std::endl;
 
         ++qit;
-        CHECK_NE(qit, IStreamQuadIterator{});
+        CHECK_NE(qit, std::default_sentinel);
         CHECK(!qit->has_value());
         std::cout << qit->error() << std::endl;
 
         ++qit;
-        CHECK_NE(qit, IStreamQuadIterator{});
+        CHECK_NE(qit, std::default_sentinel);
         CHECK(qit->has_value());
         CHECK(qit->value() == Quad{IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/12"},
                                    IRI{"http://purl.org/dc/elements/1.1/subject"},
                                    Literal::make_simple("search")});
 
         ++qit;
-        CHECK_NE(qit, IStreamQuadIterator{});
+        CHECK_NE(qit, std::default_sentinel);
         CHECK(!qit->has_value());
         std::cout << qit->error() << std::endl;
 
         ++qit;
-        CHECK_EQ(qit, IStreamQuadIterator{});
+        CHECK_EQ(qit, std::default_sentinel);
     }
 
     TEST_CASE("relative IRIs") {
@@ -319,7 +319,7 @@ TEST_SUITE("IStreamQuadIterator") {
         std::istringstream iss{triples};
         IStreamQuadIterator qit{iss};
 
-        CHECK(qit != IStreamQuadIterator());
+        CHECK(qit != std::default_sentinel);
         CHECK(qit->has_value());
         CHECK(qit->value() == Quad{IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/12"},
                                    IRI{"http://purl.org/dc/elements/1.1/subject"},
@@ -327,7 +327,7 @@ TEST_SUITE("IStreamQuadIterator") {
 
         ++qit;
 
-        CHECK(qit != IStreamQuadIterator());
+        CHECK(qit != std::default_sentinel);
         CHECK(qit->has_value());
         CHECK(qit->value() == Quad{IRI{"http://invalid-url.org/foo/subject"},
                                    IRI{"http://invalid-url.org/foo/predicate"},
@@ -335,12 +335,12 @@ TEST_SUITE("IStreamQuadIterator") {
 
         ++qit;
 
-        CHECK(qit != IStreamQuadIterator());
+        CHECK(qit != std::default_sentinel);
         CHECK(!qit->has_value());
         std::cout << qit->error() << std::endl;
 
         ++qit;
-        CHECK(qit == IStreamQuadIterator());
+        CHECK(qit == std::default_sentinel);
     }
 }
 
@@ -350,14 +350,14 @@ TEST_CASE("N-Triple") {
 
         IStreamQuadIterator it{str, ParsingFlag::NTriples};
 
-        CHECK_NE(it, IStreamQuadIterator{});
+        CHECK_NE(it, std::default_sentinel);
         CHECK(it->has_value());
         CHECK(it->value() == Quad{IRI{"http://example/s"},
                                   IRI{"http://example/p"},
                                   Literal::make_simple("string")});
 
         ++it;
-        CHECK_EQ(it, IStreamQuadIterator{});
+        CHECK_EQ(it, std::default_sentinel);
     }
     SUBCASE("Turtle") {
         constexpr char const *triples = "@base <http://invalid-url.org> .\n"
@@ -368,29 +368,29 @@ TEST_CASE("N-Triple") {
         std::istringstream iss{triples};
         IStreamQuadIterator qit{iss, ParsingFlag::NTriples};
 
-        CHECK_NE(qit, IStreamQuadIterator{});
+        CHECK_NE(qit, std::default_sentinel);
         CHECK(!qit->has_value());
         std::cout << qit->error() << std::endl;
 
         ++qit;
-        CHECK_NE(qit, IStreamQuadIterator{});
+        CHECK_NE(qit, std::default_sentinel);
         CHECK(!qit->has_value());
         std::cout << qit->error() << std::endl;
 
         ++qit;
-        CHECK_NE(qit, IStreamQuadIterator{});
+        CHECK_NE(qit, std::default_sentinel);
         CHECK(qit->has_value());
         CHECK(qit->value() == Quad{IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/12"},
                                    IRI{"http://purl.org/dc/elements/1.1/subject"},
                                    Literal::make_simple("search")});
 
         ++qit;
-        CHECK_NE(qit, IStreamQuadIterator{});
+        CHECK_NE(qit, std::default_sentinel);
         CHECK(!qit->has_value());
         std::cout << qit->error() << std::endl;
 
         ++qit;
-        CHECK_EQ(qit, IStreamQuadIterator{});
+        CHECK_EQ(qit, std::default_sentinel);
     }
 }
 
@@ -401,7 +401,7 @@ TEST_CASE("N-Quads") {
 
         IStreamQuadIterator it{str, ParsingFlag::NQuads};
 
-        CHECK_NE(it, IStreamQuadIterator{});
+        CHECK_NE(it, std::default_sentinel);
         CHECK(it->has_value());
         CHECK(it->value() == Quad{IRI{"http://example/g"},
                                   IRI{"http://example/s"},
@@ -409,14 +409,14 @@ TEST_CASE("N-Quads") {
                                   IRI{"http://example/o"}});
 
         ++it;
-        CHECK_NE(it, IStreamQuadIterator{});
+        CHECK_NE(it, std::default_sentinel);
         CHECK(it->has_value());
         CHECK(it->value() == Quad{IRI{"http://example/s"},
                                   IRI{"http://example/p"},
                                   IRI{"http://example/o"}});
 
         ++it;
-        CHECK_EQ(it, IStreamQuadIterator{});
+        CHECK_EQ(it, std::default_sentinel);
     }
     SUBCASE("Turtle") {
         constexpr char const *triples = "@base <http://invalid-url.org> .\n"
@@ -427,29 +427,29 @@ TEST_CASE("N-Quads") {
         std::istringstream iss{triples};
         IStreamQuadIterator qit{iss, ParsingFlag::NTriples};
 
-        CHECK_NE(qit, IStreamQuadIterator{});
+        CHECK_NE(qit, std::default_sentinel);
         CHECK(!qit->has_value());
         std::cout << qit->error() << std::endl;
 
         ++qit;
-        CHECK_NE(qit, IStreamQuadIterator{});
+        CHECK_NE(qit, std::default_sentinel);
         CHECK(!qit->has_value());
         std::cout << qit->error() << std::endl;
 
         ++qit;
-        CHECK_NE(qit, IStreamQuadIterator{});
+        CHECK_NE(qit, std::default_sentinel);
         CHECK(qit->has_value());
         CHECK(qit->value() == Quad{IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/12"},
                                    IRI{"http://purl.org/dc/elements/1.1/subject"},
                                    Literal::make_simple("search")});
 
         ++qit;
-        CHECK_NE(qit, IStreamQuadIterator{});
+        CHECK_NE(qit, std::default_sentinel);
         CHECK(!qit->has_value());
         std::cout << qit->error() << std::endl;
 
         ++qit;
-        CHECK_EQ(qit, IStreamQuadIterator{});
+        CHECK_EQ(qit, std::default_sentinel);
     }
 }
 
@@ -459,7 +459,7 @@ TEST_CASE("TriG") {
 
         IStreamQuadIterator it{str, ParsingFlag::TriG};
 
-        CHECK_NE(it, IStreamQuadIterator{});
+        CHECK_NE(it, std::default_sentinel);
         CHECK(it->has_value());
         CHECK_EQ(it->value(), Quad{IRI{"http://example/g"},
                                    IRI{"http://example/s"},
@@ -467,7 +467,7 @@ TEST_CASE("TriG") {
                                    IRI{"http://example/o"}});
 
         ++it;
-        CHECK_EQ(it, IStreamQuadIterator{});
+        CHECK_EQ(it, std::default_sentinel);
     }
     SUBCASE("mixed") {
         std::stringstream str{"@prefix p: <http://a.example/>.\n"
@@ -476,13 +476,13 @@ TEST_CASE("TriG") {
 
         IStreamQuadIterator it{str, ParsingFlag::TriG};
 
-        CHECK_NE(it, IStreamQuadIterator{});
+        CHECK_NE(it, std::default_sentinel);
         CHECK(it->has_value());
         CHECK_EQ(it->value(), Quad{IRI{"http://a.example/s"},
                                    IRI{"http://a.example/p"},
                                    IRI{"http://a.example/o"}});
         ++it;
-        CHECK_NE(it, IStreamQuadIterator{});
+        CHECK_NE(it, std::default_sentinel);
         CHECK(it->has_value());
         CHECK_EQ(it->value(), Quad{IRI{"http://example/graph"},
                                    IRI{"http://a.example/s"},
@@ -490,7 +490,7 @@ TEST_CASE("TriG") {
                                    IRI{"http://a.example/o"}});
 
         ++it;
-        CHECK_EQ(it, IStreamQuadIterator{});
+        CHECK_EQ(it, std::default_sentinel);
     }
 }
 
@@ -507,7 +507,7 @@ TEST_CASE("bnode management") {
         std::istringstream iss{triples};
         IStreamQuadIterator qit{iss, ParsingFlags::none(), &state};
 
-        CHECK(qit != IStreamQuadIterator{});
+        CHECK(qit != std::default_sentinel);
         CHECK(qit->has_value());
         CHECK(qit->value().subject() == IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/12"});
         CHECK(qit->value().predicate() == IRI{"http://purl.org/dc/elements/1.1/subject"});
@@ -517,7 +517,7 @@ TEST_CASE("bnode management") {
         std::cout << qit->value().object() << std::endl;
 
         ++qit;
-        CHECK(qit != IStreamQuadIterator{});
+        CHECK(qit != std::default_sentinel);
         CHECK(qit->value().subject() == IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/13"});
         CHECK(qit->value().predicate() == IRI{"http://purl.org/dc/elements/1.1/subject"});
 
@@ -527,7 +527,7 @@ TEST_CASE("bnode management") {
         CHECK(b1_1 == b1_2);
 
         ++qit;
-        CHECK(qit != IStreamQuadIterator{});
+        CHECK(qit != std::default_sentinel);
         auto b2_1 = qit->value().subject();
         CHECK(b2_1.is_blank_node());
         CHECK(b2_1 != b1_1);
@@ -536,7 +536,7 @@ TEST_CASE("bnode management") {
         CHECK(qit->value().object() == Literal::make_simple("Some Subject"));
 
         ++qit;
-        CHECK(qit == IStreamQuadIterator{});
+        CHECK(qit == std::default_sentinel);
     }
 
     SUBCASE("skolem iris") {
@@ -549,7 +549,7 @@ TEST_CASE("bnode management") {
         std::istringstream iss{triples};
         IStreamQuadIterator qit{iss, ParsingFlags::none(), &state};
 
-        CHECK(qit != IStreamQuadIterator{});
+        CHECK(qit != std::default_sentinel);
         CHECK(qit->has_value());
         CHECK(qit->value().subject() == IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/12"});
         CHECK(qit->value().predicate() == IRI{"http://purl.org/dc/elements/1.1/subject"});
@@ -559,7 +559,7 @@ TEST_CASE("bnode management") {
         std::cout << qit->value().object() << std::endl;
 
         ++qit;
-        CHECK(qit != IStreamQuadIterator{});
+        CHECK(qit != std::default_sentinel);
         CHECK(qit->value().subject() == IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/13"});
         CHECK(qit->value().predicate() == IRI{"http://purl.org/dc/elements/1.1/subject"});
 
@@ -569,7 +569,7 @@ TEST_CASE("bnode management") {
         CHECK(b1_1 == b1_2);
 
         ++qit;
-        CHECK(qit != IStreamQuadIterator{});
+        CHECK(qit != std::default_sentinel);
         auto b2_1 = qit->value().subject();
         CHECK(b2_1.is_iri());
         CHECK(b2_1 != b1_1);
@@ -578,6 +578,18 @@ TEST_CASE("bnode management") {
         CHECK(qit->value().object() == Literal::make_simple("Some Subject"));
 
         ++qit;
-        CHECK(qit == IStreamQuadIterator{});
+        CHECK(qit == std::default_sentinel);
     }
+}
+
+TEST_CASE("garbage input") {
+    std::istringstream iss{"}; SELECT * WHERE { ?s ?p ?o "};
+
+    size_t count = 0;
+    for (IStreamQuadIterator qit{iss, ParsingFlag::NoParsePrefix | ParsingFlag::KeepBlankNodeIds}; qit != std::default_sentinel; ++qit) {
+        CHECK_FALSE(qit->has_value());
+        ++count;
+    }
+
+    CHECK_EQ(count, 1);
 }


### PR DESCRIPTION
Fixes various issues that caused malformed inputs to sometimes not be rejected during parsing.
Additionally this PR simplifies the interface and implementation of the parser.

Important takeaways:
- serd does not like it if you do not return `SERD_SUCCESS` in event handlers. I couldn't make sense of what it does but it somehow messes up the parsing state sometimes
- the iterator sometimes ate errors without surfacing them