### PR TITLE
Feature: RAND with user provided random number generator

### DIFF
--- a/src/rdf4cpp/rdf/Literal.cpp
+++ b/src/rdf4cpp/rdf/Literal.cpp
@@ -260,13 +260,8 @@ Literal Literal::make_string_uuid(Node::NodeStorage &node_storage) {
 }
 
 Literal Literal::generate_random_double(Node::NodeStorage &node_storage) {
-    struct RngState {
-        std::default_random_engine rng{std::random_device{}()};
-        std::uniform_real_distribution<datatypes::xsd::Double::cpp_type> dist{0.0, 1.0};
-    };
-
-    static thread_local RngState state;
-    return Literal::make_typed_from_value<datatypes::xsd::Double>(state.dist(state.rng), node_storage);
+    static thread_local std::default_random_engine rng{std::random_device{}()};
+    return Literal::generate_random_double(rng, node_storage);
 }
 
 Literal Literal::to_node_storage(NodeStorage &node_storage) const noexcept {

--- a/src/rdf4cpp/rdf/Literal.hpp
+++ b/src/rdf4cpp/rdf/Literal.hpp
@@ -5,6 +5,7 @@
 #include <any>
 #include <optional>
 #include <ostream>
+#include <random>
 #include <rdf4cpp/rdf/Node.hpp>
 #include <rdf4cpp/rdf/datatypes/LiteralDatatype.hpp>
 #include <rdf4cpp/rdf/datatypes/owl.hpp>
@@ -329,9 +330,27 @@ public:
      * Generates a random double in the range [0.0, 1.0).
      * The values are generated in a thread-safe manner using a lazily initialized thread_local random generator.
      *
+     * @return random double in [0.0, 1.0]
+     *
      * @see https://www.w3.org/TR/sparql11-query/#idp2130040
      */
     [[nodiscard]] static Literal generate_random_double(NodeStorage &node_storage = NodeStorage::default_instance());
+
+    /**
+     * Generates a random double in the range [0.0, 1.0).
+     * The values are generated using the given random number generator
+     *
+     * @param rng random number generator
+     * @return random double in [0.0, 1.0]
+     *
+     * @see https://www.w3.org/TR/sparql11-query/#idp2130040
+     */
+    template<typename Rng>
+    [[nodiscard]] static Literal generate_random_double(Rng &rng, NodeStorage &node_storage = NodeStorage::default_instance()) {
+        // uniform_real_distribution does not have any state, therefore we can construct a new one for each call
+        std::uniform_real_distribution<typename datatypes::xsd::Double::cpp_type> dist{0.0, 1.0};
+        return Literal::make_typed_from_value<datatypes::xsd::Double>(dist(rng), node_storage);
+    }
 
     Literal to_node_storage(NodeStorage &node_storage) const noexcept;
     [[nodiscard]] Literal try_get_in_node_storage(NodeStorage const &node_storage) const noexcept;

--- a/src/rdf4cpp/rdf/Literal.hpp
+++ b/src/rdf4cpp/rdf/Literal.hpp
@@ -330,7 +330,7 @@ public:
      * Generates a random double in the range [0.0, 1.0).
      * The values are generated in a thread-safe manner using a lazily initialized thread_local random generator.
      *
-     * @return random double in [0.0, 1.0]
+     * @return random double in [0.0, 1.0)
      *
      * @see https://www.w3.org/TR/sparql11-query/#idp2130040
      */
@@ -341,7 +341,7 @@ public:
      * The values are generated using the given random number generator
      *
      * @param rng random number generator
-     * @return random double in [0.0, 1.0]
+     * @return random double in [0.0, 1.0)
      *
      * @see https://www.w3.org/TR/sparql11-query/#idp2130040
      */

--- a/tests/nodes/tests_Literal.cpp
+++ b/tests/nodes/tests_Literal.cpp
@@ -500,6 +500,19 @@ TEST_CASE("Literal - misc functions") {
 
             CHECK_NE(l1, l2);  // note: non-deterministic but should basically never fail
         }
+
+        SUBCASE("provided rng determinism") {
+            std::vector<Literal> lits;
+            for (size_t ix = 0; ix < 100; ++ix) {
+                std::default_random_engine rng{};
+                lits.push_back(Literal::generate_random_double(rng));
+            }
+
+            auto first = lits[0];
+            for (size_t ix = 1; ix < lits.size(); ++ix) {
+                CHECK_EQ(first, lits[ix]);
+            }
+        }
     }
 
     SUBCASE("abs") {


### PR DESCRIPTION
Adds the following additional overload to `Literal::generate_random_double`:
```c++
template<typename Rng>
[[nodiscard]] static Literal Literal::generate_random_double(Rng &rng, NodeStorage &node_storage = NodeStorage::default_instance());
```