### PR TITLE
Feature: node storage optimization

### DIFF
--- a/.github/workflows/run_test_and_examples.yml
+++ b/.github/workflows/run_test_and_examples.yml
@@ -9,8 +9,6 @@ jobs:
             compiler: gcc-13
 
           - os: ubuntu-22.04
-            compiler: clang-15
-          - os: ubuntu-22.04
             compiler: clang-16
           - os: ubuntu-22.04
             compiler: clang-17

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,7 @@ add_library(rdf4cpp
         src/rdf4cpp/rdf/Statement.cpp
         src/rdf4cpp/rdf/bnode_mngt/NodeGenerator.cpp
         src/rdf4cpp/rdf/bnode_mngt/NodeScope.cpp
+        src/rdf4cpp/rdf/bnode_mngt/WeakNodeScope.cpp
         src/rdf4cpp/rdf/bnode_mngt/reference_backends/factory/SkolemIRIFactory.cpp
         src/rdf4cpp/rdf/bnode_mngt/reference_backends/factory/BNodeFactory.cpp
         src/rdf4cpp/rdf/bnode_mngt/reference_backends/generator/RandomIdGenerator.cpp

--- a/src/rdf4cpp/rdf/BlankNode.cpp
+++ b/src/rdf4cpp/rdf/BlankNode.cpp
@@ -6,7 +6,7 @@
 namespace rdf4cpp::rdf {
 BlankNode::BlankNode() noexcept : Node{NodeBackendHandle{{}, storage::node::identifier::RDFNodeType::BNode, {}}} {}
 BlankNode::BlankNode(std::string_view identifier, NodeStorage &node_storage)
-    : Node(NodeBackendHandle{node_storage.find_or_make_id(storage::node::view::BNodeBackendView{.identifier = identifier, .scope = nullptr}),
+    : Node(NodeBackendHandle{node_storage.find_or_make_id(storage::node::view::BNodeBackendView{.identifier = identifier, .scope = std::nullopt}),
                              storage::node::identifier::RDFNodeType::BNode,
                              node_storage.id()}) {}
 BlankNode::BlankNode(Node::NodeBackendHandle handle) noexcept : Node(handle) {}
@@ -42,7 +42,7 @@ BlankNode BlankNode::try_get_in_node_storage(NodeStorage const &node_storage) co
 }
 
 BlankNode BlankNode::find(std::string_view identifier, const NodeStorage& node_storage) noexcept {
-    auto nid = node_storage.find_id(storage::node::view::BNodeBackendView{identifier, nullptr});
+    auto nid = node_storage.find_id(storage::node::view::BNodeBackendView{identifier, std::nullopt});
     if (nid.null())
         return BlankNode{};
     return BlankNode{NodeBackendHandle{nid, storage::node::identifier::RDFNodeType::BNode, node_storage.id()}};
@@ -89,8 +89,8 @@ util::TriBool BlankNode::union_eq(BlankNode const &other) const noexcept {
     auto const this_backend = this->handle_.bnode_backend();
     auto const other_backend = other.handle_.bnode_backend();
 
-    if (this_backend.scope == nullptr || other_backend.scope == nullptr) {
-        return (this_backend.scope == nullptr) == (other_backend.scope == nullptr) && this_backend.identifier == other_backend.identifier;
+    if (!this_backend.scope.has_value() || !other_backend.scope.has_value()) {
+        return this_backend.scope.has_value() == other_backend.scope.has_value() && this_backend.identifier == other_backend.identifier;
     }
 
     auto this_scope = this_backend.scope->try_upgrade();

--- a/src/rdf4cpp/rdf/bnode_mngt/INodeFactory.hpp
+++ b/src/rdf4cpp/rdf/bnode_mngt/INodeFactory.hpp
@@ -4,6 +4,10 @@
 #include <rdf4cpp/rdf/bnode_mngt/IIdGenerator.hpp>
 #include <rdf4cpp/rdf/storage/node/NodeStorage.hpp>
 
+namespace rdf4cpp::rdf::storage::node {
+class NodeStorage;
+} // rdf4cpp::rdf::storage::node
+
 namespace rdf4cpp::rdf::bnode_mngt {
 
 struct NodeScope;

--- a/src/rdf4cpp/rdf/bnode_mngt/NodeScope.cpp
+++ b/src/rdf4cpp/rdf/bnode_mngt/NodeScope.cpp
@@ -195,43 +195,6 @@ bool NodeScope::operator!=(NodeScope const &other) const noexcept {
     return this->backend_index_ != other.backend_index_;
 }
 
-WeakNodeScope::WeakNodeScope(identifier::NodeScopeID backend_index, size_t generation) noexcept : backend_index_{backend_index},
-                                                                                                  generation_{generation} {
-}
-
-identifier::NodeScopeID WeakNodeScope::id() const noexcept {
-    return this->backend_index_;
-}
-
-std::optional<NodeScope> WeakNodeScope::try_upgrade() const noexcept {
-    auto &slot = NodeScope::get_slot(this->backend_index_);
-
-    if (slot.generation.load(std::memory_order_acquire) != this->generation_) {
-        return std::nullopt;
-    }
-
-    auto old_rc = slot.refcount.load(std::memory_order_relaxed);
-    while (true) {
-        if (old_rc == 0) {
-            return std::nullopt;
-        }
-
-        if (slot.refcount.compare_exchange_weak(old_rc, old_rc + 1, std::memory_order_acquire, std::memory_order_relaxed)) {
-            assert(slot.backend != nullptr);
-            assert(slot.generation == this->generation_);
-            return NodeScope{this->backend_index_};
-        }
-    }
-}
-
-NodeScope WeakNodeScope::upgrade() const {
-    if (auto ns = this->try_upgrade(); ns.has_value()) {
-        return *ns;
-    }
-
-    throw std::runtime_error{"WeakNodeScope lifetime error: referenced backend is no longer alive"};
-}
-
 }  //namespace rdf4cpp::rdf::bnode_mngt
 
 size_t std::hash<rdf4cpp::rdf::bnode_mngt::NodeScope>::operator()(rdf4cpp::rdf::bnode_mngt::NodeScope const &scope) const noexcept {

--- a/src/rdf4cpp/rdf/bnode_mngt/NodeScope.hpp
+++ b/src/rdf4cpp/rdf/bnode_mngt/NodeScope.hpp
@@ -4,33 +4,12 @@
 #include <rdf4cpp/rdf/bnode_mngt/INodeScope.hpp>
 #include <rdf4cpp/rdf/bnode_mngt/NodeGenerator.hpp>
 #include <rdf4cpp/rdf/bnode_mngt/reference_backends/scope/ReferenceNodeScope.hpp>
+#include <rdf4cpp/rdf/bnode_mngt/WeakNodeScope.hpp>
 #include <rdf4cpp/rdf/storage/node/NodeStorage.hpp>
 
 #include <string_view>
 
 namespace rdf4cpp::rdf::bnode_mngt {
-
-namespace identifier {
-
-struct NodeScopeID {
-    static constexpr size_t width = 16;
-    using underlying_type = uint16_t;
-
-private:
-    underlying_type raw_ : width;
-
-public:
-    constexpr NodeScopeID() = default;
-    explicit constexpr NodeScopeID(underlying_type raw) : raw_{raw} {}
-
-    [[nodiscard]] constexpr underlying_type to_underlying() const noexcept {
-        return raw_;
-    }
-
-    constexpr auto operator<=>(NodeScopeID const &) const noexcept = default;
-};
-
-} // namespace identifier
 
 namespace node_scope_detail {
 
@@ -212,61 +191,11 @@ public:
     bool operator!=(NodeScope const &other) const noexcept;
 };
 
-struct WeakNodeScope {
-private:
-    friend struct NodeScope;
-    friend struct std::hash<WeakNodeScope>;
-
-    identifier::NodeScopeID backend_index_;
-    size_t generation_;
-
-    WeakNodeScope(identifier::NodeScopeID backend_index, size_t generation) noexcept;
-
-public:
-    /**
-     * @return Identifier of this NodeScope
-     */
-    [[nodiscard]] identifier::NodeScopeID id() const noexcept;
-
-    /**
-     * Tries to upgrade this WeakNodeScope into a NodeScope.
-     * This will only succeed if the corresponding INodeScope backend is still alive.
-     *
-     * @return a NodeScope pointing to the same backend as this, if the backend is still alive, otherwise nullopt
-     */
-    [[nodiscard]] std::optional<NodeScope> try_upgrade() const noexcept;
-
-    /**
-     * Tries to upgrade this WeakNodeScope into a NodeScope.
-     * This will only succeed if the corresponding INodeScope is still alive.
-     * This function throws on failure to upgrade.
-     *
-     * @return a NodeScope pointing to the same backend as this, if the backend is still alive
-     * @throws std::runtime_error on upgrade failure
-     */
-    [[nodiscard]] NodeScope upgrade() const;
-
-    /**
-     * @return whether this and other are referring to the same backend
-     */
-    bool operator==(WeakNodeScope const &other) const noexcept = default;
-
-    /**
-     * @return whether this and other are _not_ referring to the same backend
-     */
-    bool operator!=(WeakNodeScope const &other) const noexcept = default;
-};
-
 }  //namespace rdf4cpp::rdf::bnode_mngt
 
 template<>
 struct std::hash<rdf4cpp::rdf::bnode_mngt::NodeScope> {
     size_t operator()(rdf4cpp::rdf::bnode_mngt::NodeScope const &scope) const noexcept;
-};
-
-template<>
-struct std::hash<rdf4cpp::rdf::bnode_mngt::WeakNodeScope> {
-    size_t operator()(rdf4cpp::rdf::bnode_mngt::WeakNodeScope const &scope) const noexcept;
 };
 
 #endif  //RDF4CPP_RDF_UTIL_BLANKNODEIDSCOPE_HPP

--- a/src/rdf4cpp/rdf/bnode_mngt/WeakNodeScope.cpp
+++ b/src/rdf4cpp/rdf/bnode_mngt/WeakNodeScope.cpp
@@ -1,0 +1,43 @@
+#include <rdf4cpp/rdf/bnode_mngt/WeakNodeScope.hpp>
+#include <rdf4cpp/rdf/bnode_mngt/NodeScope.hpp>
+
+namespace rdf4cpp::rdf::bnode_mngt {
+
+WeakNodeScope::WeakNodeScope(identifier::NodeScopeID backend_index, size_t generation) noexcept : backend_index_{backend_index},
+                                                                                                  generation_{generation} {
+}
+
+identifier::NodeScopeID WeakNodeScope::id() const noexcept {
+    return this->backend_index_;
+}
+
+std::optional<NodeScope> WeakNodeScope::try_upgrade() const noexcept {
+    auto &slot = NodeScope::get_slot(this->backend_index_);
+
+    if (slot.generation.load(std::memory_order_acquire) != this->generation_) {
+        return std::nullopt;
+    }
+
+    auto old_rc = slot.refcount.load(std::memory_order_relaxed);
+    while (true) {
+        if (old_rc == 0) {
+            return std::nullopt;
+        }
+
+        if (slot.refcount.compare_exchange_weak(old_rc, old_rc + 1, std::memory_order_acquire, std::memory_order_relaxed)) {
+            assert(slot.backend != nullptr);
+            assert(slot.generation == this->generation_);
+            return NodeScope{this->backend_index_};
+        }
+    }
+}
+
+NodeScope WeakNodeScope::upgrade() const {
+    if (auto ns = this->try_upgrade(); ns.has_value()) {
+        return *ns;
+    }
+
+    throw std::runtime_error{"WeakNodeScope lifetime error: referenced backend is no longer alive"};
+}
+
+} // namespace rdf4cpp::rdf::bnode_mngt

--- a/src/rdf4cpp/rdf/bnode_mngt/WeakNodeScope.hpp
+++ b/src/rdf4cpp/rdf/bnode_mngt/WeakNodeScope.hpp
@@ -1,0 +1,82 @@
+#ifndef RDF4CPP_RDF_UTIL_WEAKBLANKNODEIDSCOPE_HPP
+#define RDF4CPP_RDF_UTIL_WEAKBLANKNODEIDSCOPE_HPP
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <optional>
+
+namespace rdf4cpp::rdf::bnode_mngt {
+
+namespace identifier {
+
+struct NodeScopeID {
+    static constexpr size_t width = 16;
+    using underlying_type = uint16_t;
+
+private:
+    underlying_type raw_ : width;
+
+public:
+    constexpr NodeScopeID() = default;
+    explicit constexpr NodeScopeID(underlying_type raw) : raw_{raw} {}
+
+    [[nodiscard]] constexpr underlying_type to_underlying() const noexcept {
+        return raw_;
+    }
+
+    constexpr auto operator<=>(NodeScopeID const &) const noexcept = default;
+};
+
+} // namespace identifier
+
+struct NodeScope;
+
+struct WeakNodeScope {
+private:
+    friend struct NodeScope;
+    friend struct std::hash<WeakNodeScope>;
+
+    identifier::NodeScopeID backend_index_;
+    size_t generation_;
+
+    WeakNodeScope(identifier::NodeScopeID backend_index, size_t generation) noexcept;
+
+public:
+    /**
+     * @return Identifier of this NodeScope
+     */
+    [[nodiscard]] identifier::NodeScopeID id() const noexcept;
+
+    /**
+     * Tries to upgrade this WeakNodeScope into a NodeScope.
+     * This will only succeed if the corresponding INodeScope backend is still alive.
+     *
+     * @return a NodeScope pointing to the same backend as this, if the backend is still alive, otherwise nullopt
+     */
+    [[nodiscard]] std::optional<NodeScope> try_upgrade() const noexcept;
+
+    /**
+     * Tries to upgrade this WeakNodeScope into a NodeScope.
+     * This will only succeed if the corresponding INodeScope is still alive.
+     * This function throws on failure to upgrade.
+     *
+     * @return a NodeScope pointing to the same backend as this, if the backend is still alive
+     * @throws std::runtime_error on upgrade failure
+     */
+    [[nodiscard]] NodeScope upgrade() const;
+
+    /**
+     * @return whether this and other are referring to the same backend
+     */
+    auto operator<=>(WeakNodeScope const &other) const noexcept = default;
+};
+
+} // rdf4cpp::rdf::bnode_mngt
+
+template<>
+struct std::hash<rdf4cpp::rdf::bnode_mngt::WeakNodeScope> {
+    size_t operator()(rdf4cpp::rdf::bnode_mngt::WeakNodeScope const &scope) const noexcept;
+};
+
+#endif // RDF4CPP_RDF_UTIL_WEAKBLANKNODEIDSCOPE_HPP

--- a/src/rdf4cpp/rdf/bnode_mngt/reference_backends/factory/BNodeFactory.cpp
+++ b/src/rdf4cpp/rdf/bnode_mngt/reference_backends/factory/BNodeFactory.cpp
@@ -22,10 +22,10 @@ storage::node::identifier::NodeBackendHandle BNodeFactory::make_node(IIdGenerato
         if (scope != nullptr) {
             WeakNodeScope weak = scope->downgrade();
             return node_storage.find_or_make_id(storage::node::view::BNodeBackendView{.identifier = identifier,
-                                                                                      .scope = &weak});
+                                                                                      .scope = weak});
         } else {
             return node_storage.find_or_make_id(storage::node::view::BNodeBackendView{.identifier = identifier,
-                                                                                      .scope = nullptr});
+                                                                                      .scope = std::nullopt});
         }
     }();
 

--- a/src/rdf4cpp/rdf/storage/node/INodeStorageBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/INodeStorageBackend.hpp
@@ -27,6 +27,11 @@ public:
     [[nodiscard]] virtual size_t size() const noexcept = 0;
 
     /**
+     * Requests the removal of unused capacity.
+     */
+    virtual void shrink_to_fit() = 0;
+
+    /**
      * Backend for NodeStorage::has_specialized_storage_for(datatype)
      * @param datatype datatype of specialized storage to check for
      * @return whether this implementation has specialized storage for the given datatype

--- a/src/rdf4cpp/rdf/storage/node/NodeStorage.cpp
+++ b/src/rdf4cpp/rdf/storage/node/NodeStorage.cpp
@@ -253,6 +253,11 @@ size_t NodeStorage::ref_count() const noexcept {
 size_t NodeStorage::size() const noexcept {
     return this->cached_backend_ptr->size();
 }
+
+void NodeStorage::shrink_to_fit() {
+    this->cached_backend_ptr->shrink_to_fit();
+}
+
 bool NodeStorage::has_specialized_storage_for(identifier::LiteralType datatype) const noexcept {
     return this->cached_backend_ptr->has_specialized_storage_for(datatype);
 }

--- a/src/rdf4cpp/rdf/storage/node/NodeStorage.hpp
+++ b/src/rdf4cpp/rdf/storage/node/NodeStorage.hpp
@@ -235,6 +235,11 @@ public:
     [[nodiscard]] size_t size() const noexcept;
 
     /**
+     * Requests the removal of unused capacity.
+     */
+    void shrink_to_fit();
+
+    /**
      * Checks if the current backend has specialized storage for the given datatype
      */
     [[nodiscard]] bool has_specialized_storage_for(identifier::LiteralType datatype) const noexcept;

--- a/src/rdf4cpp/rdf/storage/node/identifier/LiteralID.hpp
+++ b/src/rdf4cpp/rdf/storage/node/identifier/LiteralID.hpp
@@ -34,6 +34,10 @@ struct __attribute__((__packed__)) LiteralID {
         return value;
     }
 
+    explicit operator underlying_type() const noexcept {
+        return value;
+    }
+
     constexpr LiteralID operator++(int) noexcept {
         LiteralID new_literal_id{*this};
         ++value;

--- a/src/rdf4cpp/rdf/storage/node/identifier/NodeID.hpp
+++ b/src/rdf4cpp/rdf/storage/node/identifier/NodeID.hpp
@@ -79,8 +79,6 @@ public:
 
     explicit operator uint64_t() const noexcept { return value_; }
 
-    //    void value(uint64_t val) { assert(val < (1UL << 48)); value_ = val; }
-
     constexpr std::strong_ordering operator<=>(NodeID const &other) const noexcept { return value_ <=> other.value_; }
 
     constexpr bool operator==(NodeID const &other) const noexcept { return value_ == other.value_; }

--- a/src/rdf4cpp/rdf/storage/node/identifier/NodeID.hpp
+++ b/src/rdf4cpp/rdf/storage/node/identifier/NodeID.hpp
@@ -76,6 +76,9 @@ public:
      */
     [[nodiscard]] constexpr LiteralType literal_type() const noexcept { return LiteralType::from_underlying(literal_.literal_type); }
     [[nodiscard]] constexpr uint64_t value() const noexcept { return value_; }
+
+    explicit operator uint64_t() const noexcept { return value_; }
+
     //    void value(uint64_t val) { assert(val < (1UL << 48)); value_ = val; }
 
     constexpr std::strong_ordering operator<=>(NodeID const &other) const noexcept { return value_ <=> other.value_; }

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/BNodeBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/BNodeBackend.hpp
@@ -12,16 +12,16 @@ struct BNodeBackend {
     using Id = identifier::NodeID;
 
     size_t hash;
-    ConstString identifier;
+    detail::ConstString identifier;
     std::optional<rdf4cpp::rdf::bnode_mngt::WeakNodeScope> scope;
 
     explicit BNodeBackend(View const &view) noexcept : hash{view.hash()},
                                                        identifier{view.identifier},
-                                                       scope{view.scope == nullptr ? std::nullopt : std::optional{*view.scope}} {
+                                                       scope{view.scope} {
     }
 
     explicit operator View() const noexcept {
-        return View{.identifier = identifier, .scope = scope.has_value() ? &*scope : nullptr};
+        return View{.identifier = identifier, .scope = scope};
     }
 };
 

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/BNodeBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/BNodeBackend.hpp
@@ -10,6 +10,7 @@ namespace rdf4cpp::rdf::storage::node::reference_node_storage {
 
 struct BNodeBackend {
     using View = view::BNodeBackendView;
+    using Id = identifier::NodeID;
 
     size_t hash;
     std::string identifier;

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/BNodeBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/BNodeBackend.hpp
@@ -3,8 +3,7 @@
 
 #include <rdf4cpp/rdf/storage/node/view/BNodeBackendView.hpp>
 #include <rdf4cpp/rdf/bnode_mngt/NodeScope.hpp>
-
-#include <string>
+#include <rdf4cpp/rdf/storage/node/reference_node_storage/detail/ConstString.hpp>
 
 namespace rdf4cpp::rdf::storage::node::reference_node_storage {
 
@@ -13,7 +12,7 @@ struct BNodeBackend {
     using Id = identifier::NodeID;
 
     size_t hash;
-    std::string identifier;
+    ConstString identifier;
     std::optional<rdf4cpp::rdf::bnode_mngt::WeakNodeScope> scope;
 
     explicit BNodeBackend(View const &view) noexcept : hash{view.hash()},

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/BNodeBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/BNodeBackend.hpp
@@ -8,20 +8,20 @@
 namespace rdf4cpp::rdf::storage::node::reference_node_storage {
 
 struct BNodeBackend {
-    using View = view::BNodeBackendView;
-    using Id = identifier::NodeID;
+    using view_type = view::BNodeBackendView;
+    using id_type = identifier::NodeID;
 
     size_t hash;
     detail::ConstString identifier;
     std::optional<rdf4cpp::rdf::bnode_mngt::WeakNodeScope> scope;
 
-    explicit BNodeBackend(View const &view) noexcept : hash{view.hash()},
-                                                       identifier{view.identifier},
-                                                       scope{view.scope} {
+    explicit BNodeBackend(view_type const &view) noexcept : hash{view.hash()},
+                                                            identifier{view.identifier},
+                                                            scope{view.scope} {
     }
 
-    explicit operator View() const noexcept {
-        return View{.identifier = identifier, .scope = scope};
+    explicit operator view_type() const noexcept {
+        return view_type{.identifier = identifier, .scope = scope};
     }
 };
 

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/FallbackLiteralBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/FallbackLiteralBackend.hpp
@@ -10,6 +10,7 @@ namespace rdf4cpp::rdf::storage::node::reference_node_storage {
 
 struct FallbackLiteralBackend {
     using View = view::LexicalFormLiteralBackendView;
+    using Id = identifier::LiteralID;
 
     size_t hash;
     identifier::NodeID datatype_id;
@@ -29,6 +30,14 @@ struct FallbackLiteralBackend {
                     .lexical_form = lexical_form,
                     .language_tag = language_tag,
                     .needs_escape = needs_escape};
+    }
+
+    static identifier::NodeID to_node_id(Id const id, View const view) noexcept {
+        return identifier::NodeID{id, iri_node_id_to_literal_type(view.datatype_id)};
+    }
+
+    static Id to_backend_id(identifier::NodeID const id) noexcept {
+        return id.literal_id();
     }
 };
 

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/FallbackLiteralBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/FallbackLiteralBackend.hpp
@@ -3,8 +3,7 @@
 
 #include <rdf4cpp/rdf/storage/node/identifier/NodeID.hpp>
 #include <rdf4cpp/rdf/storage/node/view/LiteralBackendView.hpp>
-
-#include <string>
+#include <rdf4cpp/rdf/storage/node/reference_node_storage/detail/ConstString.hpp>
 
 namespace rdf4cpp::rdf::storage::node::reference_node_storage {
 
@@ -14,8 +13,8 @@ struct FallbackLiteralBackend {
 
     size_t hash;
     identifier::NodeID datatype_id;
-    std::string lexical_form;
-    std::string language_tag;
+    ConstString lexical_form;
+    ConstString language_tag;
     bool needs_escape;
 
     explicit FallbackLiteralBackend(View const &view) noexcept : hash{view.hash()},

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/FallbackLiteralBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/FallbackLiteralBackend.hpp
@@ -13,8 +13,8 @@ struct FallbackLiteralBackend {
 
     size_t hash;
     identifier::NodeID datatype_id;
-    ConstString lexical_form;
-    ConstString language_tag;
+    detail::ConstString lexical_form;
+    detail::ConstString language_tag;
     bool needs_escape;
 
     explicit FallbackLiteralBackend(View const &view) noexcept : hash{view.hash()},

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/FallbackLiteralBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/FallbackLiteralBackend.hpp
@@ -8,8 +8,8 @@
 namespace rdf4cpp::rdf::storage::node::reference_node_storage {
 
 struct FallbackLiteralBackend {
-    using View = view::LexicalFormLiteralBackendView;
-    using Id = identifier::LiteralID;
+    using view_type = view::LexicalFormLiteralBackendView;
+    using id_type = identifier::LiteralID;
 
     size_t hash;
     identifier::NodeID datatype_id;
@@ -17,25 +17,25 @@ struct FallbackLiteralBackend {
     detail::ConstString language_tag;
     bool needs_escape;
 
-    explicit FallbackLiteralBackend(View const &view) noexcept : hash{view.hash()},
-                                                                 datatype_id{view.datatype_id},
-                                                                 lexical_form{view.lexical_form},
-                                                                 language_tag{view.language_tag},
-                                                                 needs_escape{view.needs_escape} {
+    explicit FallbackLiteralBackend(view_type const &view) noexcept : hash{view.hash()},
+                                                                      datatype_id{view.datatype_id},
+                                                                      lexical_form{view.lexical_form},
+                                                                      language_tag{view.language_tag},
+                                                                      needs_escape{view.needs_escape} {
     }
 
-    explicit operator View() const noexcept {
-        return View{.datatype_id = datatype_id,
-                    .lexical_form = lexical_form,
-                    .language_tag = language_tag,
-                    .needs_escape = needs_escape};
+    explicit operator view_type() const noexcept {
+        return view_type{.datatype_id = datatype_id,
+                         .lexical_form = lexical_form,
+                         .language_tag = language_tag,
+                         .needs_escape = needs_escape};
     }
 
-    static identifier::NodeID to_node_id(Id const id, View const view) noexcept {
+    static identifier::NodeID to_node_id(id_type const id, view_type const view) noexcept {
         return identifier::NodeID{id, iri_node_id_to_literal_type(view.datatype_id)};
     }
 
-    static Id to_backend_id(identifier::NodeID const id) noexcept {
+    static id_type to_backend_id(identifier::NodeID const id) noexcept {
         return id.literal_id();
     }
 };

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/IRIBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/IRIBackend.hpp
@@ -7,18 +7,18 @@
 namespace rdf4cpp::rdf::storage::node::reference_node_storage {
 
 struct IRIBackend {
-    using View = view::IRIBackendView;
-    using Id = identifier::NodeID;
+    using view_type = view::IRIBackendView;
+    using id_type = identifier::NodeID;
 
     size_t hash;
     detail::ConstString identifier;
 
-    explicit IRIBackend(View const &view) noexcept : hash{view.hash()},
-                                                     identifier{view.identifier} {
+    explicit IRIBackend(view_type const &view) noexcept : hash{view.hash()},
+                                                          identifier{view.identifier} {
     }
 
-    explicit operator View() const noexcept {
-        return View{.identifier = identifier};
+    explicit operator view_type() const noexcept {
+        return view_type{.identifier = identifier};
     }
 };
 

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/IRIBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/IRIBackend.hpp
@@ -2,8 +2,7 @@
 #define RDF4CPP_IRIBACKEND_HPP
 
 #include <rdf4cpp/rdf/storage/node/view/IRIBackendView.hpp>
-
-#include <string>
+#include <rdf4cpp/rdf/storage/node/reference_node_storage/detail/ConstString.hpp>
 
 namespace rdf4cpp::rdf::storage::node::reference_node_storage {
 
@@ -12,7 +11,7 @@ struct IRIBackend {
     using Id = identifier::NodeID;
 
     size_t hash;
-    std::string identifier;
+    ConstString identifier;
 
     explicit IRIBackend(View const &view) noexcept : hash{view.hash()},
                                                      identifier{view.identifier} {

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/IRIBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/IRIBackend.hpp
@@ -11,7 +11,7 @@ struct IRIBackend {
     using Id = identifier::NodeID;
 
     size_t hash;
-    ConstString identifier;
+    detail::ConstString identifier;
 
     explicit IRIBackend(View const &view) noexcept : hash{view.hash()},
                                                      identifier{view.identifier} {

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/IRIBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/IRIBackend.hpp
@@ -9,6 +9,7 @@ namespace rdf4cpp::rdf::storage::node::reference_node_storage {
 
 struct IRIBackend {
     using View = view::IRIBackendView;
+    using Id = identifier::NodeID;
 
     size_t hash;
     std::string identifier;

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/SpecializedLiteralBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/SpecializedLiteralBackend.hpp
@@ -8,52 +8,52 @@ namespace rdf4cpp::rdf::storage::node::reference_node_storage {
 
 template<datatypes::FixedIdLiteralDatatype T>
 struct SpecializedLiteralBackend {
-    using View = view::ValueLiteralBackendView;
-    using Type = T;
-    using Id = identifier::LiteralID;
+    using view_type = view::ValueLiteralBackendView;
+    using literal_type = T;
+    using id_type = identifier::LiteralID;
 
     size_t hash;
     static constexpr identifier::LiteralType datatype = T::fixed_id;
     typename T::cpp_type value;
 
-    explicit SpecializedLiteralBackend(View const &view) noexcept : hash{view.hash<Type>()},
-                                                                    value{std::any_cast<typename T::cpp_type>(view.value)} {
+    explicit SpecializedLiteralBackend(view_type const &view) noexcept : hash{view.hash<literal_type>()},
+                                                                         value{std::any_cast<typename T::cpp_type>(view.value)} {
         assert(view.datatype == SpecializedLiteralBackend::datatype);
     }
 
-    explicit operator View() const noexcept {
-        return View{.datatype = datatype,
-                    .value = value};
+    explicit operator view_type() const noexcept {
+        return view_type{.datatype = datatype,
+                         .value = value};
     }
 
-    static identifier::NodeID to_node_id(Id const id, View const view) noexcept {
+    static identifier::NodeID to_node_id(id_type const id, view_type const view) noexcept {
         return identifier::NodeID{id, view.datatype};
     }
 
-    static Id to_backend_id(identifier::NodeID const id) noexcept {
+    static id_type to_backend_id(identifier::NodeID const id) noexcept {
         return id.literal_id();
     }
 
-    struct Equal {
+    struct equal {
         using is_transparent = void;
 
-        bool operator()(View const &lhs, SpecializedLiteralBackend const &rhs) const noexcept {
+        bool operator()(view_type const &lhs, SpecializedLiteralBackend const &rhs) const noexcept {
             assert(lhs.datatype == SpecializedLiteralBackend::datatype);
-            return lhs.eq<Type>(rhs.value);
+            return lhs.eq<literal_type>(rhs.value);
         }
 
-        bool operator()(SpecializedLiteralBackend const &lhs, View const &rhs) const noexcept {
+        bool operator()(SpecializedLiteralBackend const &lhs, view_type const &rhs) const noexcept {
             assert(SpecializedLiteralBackend::datatype == rhs.datatype);
-            return rhs.eq<Type>(lhs.value);
+            return rhs.eq<literal_type>(lhs.value);
         }
     };
 
-    struct Hash {
+    struct hasher {
         using is_transparent = void;
 
-        [[nodiscard]] size_t operator()(View const &x) const noexcept {
+        [[nodiscard]] size_t operator()(view_type const &x) const noexcept {
             assert(x.datatype == SpecializedLiteralBackend::datatype);
-            return x.hash<Type>();
+            return x.hash<literal_type>();
         }
     };
 };

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/SpecializedLiteralBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/SpecializedLiteralBackend.hpp
@@ -26,10 +26,17 @@ struct SpecializedLiteralBackend {
                          .value = value};
     }
 
-    static identifier::NodeID to_node_id(id_type const id, view_type const view) noexcept {
+    /**
+     * Translates the given id_type (= LiteralID) into a NodeID by attaching the
+     * LiteralType from the given view to it.
+     */
+    static identifier::NodeID to_node_id(id_type const id, view_type const &view) noexcept {
         return identifier::NodeID{id, view.datatype};
     }
 
+    /**
+     * Translates the given NodeID into an id_type (= LiteralID) by extracting the LiteralID
+     */
     static id_type to_backend_id(identifier::NodeID const id) noexcept {
         return id.literal_id();
     }

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/SpecializedLiteralBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/SpecializedLiteralBackend.hpp
@@ -10,6 +10,7 @@ template<datatypes::FixedIdLiteralDatatype T>
 struct SpecializedLiteralBackend {
     using View = view::ValueLiteralBackendView;
     using Type = T;
+    using Id = identifier::LiteralID;
 
     size_t hash;
     static constexpr identifier::LiteralType datatype = T::fixed_id;
@@ -25,30 +26,30 @@ struct SpecializedLiteralBackend {
                     .value = value};
     }
 
+    static identifier::NodeID to_node_id(Id const id, View const view) noexcept {
+        return identifier::NodeID{id, view.datatype};
+    }
+
+    static Id to_backend_id(identifier::NodeID const id) noexcept {
+        return id.literal_id();
+    }
+
     struct Equal {
         using is_transparent = void;
 
-        bool operator()(SpecializedLiteralBackend const *lhs, SpecializedLiteralBackend const *rhs) const noexcept {
-            return lhs == rhs;
-        }
-
-        bool operator()(View const &lhs, SpecializedLiteralBackend const *rhs) const noexcept {
+        bool operator()(View const &lhs, SpecializedLiteralBackend const &rhs) const noexcept {
             assert(lhs.datatype == SpecializedLiteralBackend::datatype);
-            return lhs.eq<Type>(rhs->value);
+            return lhs.eq<Type>(rhs.value);
         }
 
-        bool operator()(SpecializedLiteralBackend const *lhs, View const &rhs) const noexcept {
+        bool operator()(SpecializedLiteralBackend const &lhs, View const &rhs) const noexcept {
             assert(SpecializedLiteralBackend::datatype == rhs.datatype);
-            return rhs.eq<Type>(lhs->value);
+            return rhs.eq<Type>(lhs.value);
         }
     };
 
     struct Hash {
         using is_transparent = void;
-
-        [[nodiscard]] size_t operator()(SpecializedLiteralBackend const *x) const noexcept {
-            return x->hash;
-        }
 
         [[nodiscard]] size_t operator()(View const &x) const noexcept {
             assert(x.datatype == SpecializedLiteralBackend::datatype);

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/SyncReferenceNodeStorageBackend.cpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/SyncReferenceNodeStorageBackend.cpp
@@ -4,25 +4,27 @@
 namespace rdf4cpp::rdf::storage::node::reference_node_storage {
 
 SyncReferenceNodeStorageBackend::SyncReferenceNodeStorageBackend() noexcept {
-    // set correct initial value for atomics
-    for (auto &id : next_specialized_literal_ids_) {
-        id = NodeID::min_literal_id.value;
-    }
+    iri_storage_.mapping.reserve(NodeID::min_iri_id);
+    bnode_storage_.mapping.reserve(NodeID::min_bnode_id);
+    variable_storage_.mapping.reserve(NodeID::min_variable_id);
+    fallback_literal_storage_.mapping.reserve(NodeID::min_literal_id);
+
+    specialization_detail::tuple_fold(specialized_literal_storage_, 0, [](auto acc, auto &storage) noexcept {
+        storage.mapping.reserve(NodeID::min_literal_id);
+        return acc;
+    });
 
     // some iri's like xsd:string are there by default
     for (const auto &[iri, literal_type] : datatypes::registry::reserved_datatype_ids) {
         auto const id = literal_type.to_underlying();
-
-        auto const [it, inserted] = iri_storage_.id2data.emplace(id, std::make_unique<IRIBackend>(view::IRIBackendView{.identifier = iri}));
-        assert(inserted);
-        iri_storage_.data2id.emplace(it->second.get(), id);
+        iri_storage_.mapping.insert_assume_not_present_at(view::IRIBackendView{.identifier = iri}, identifier::NodeID{id});
     }
 }
 
 template<typename Backend>
 static size_t storage_size(SyncNodeTypeStorage<Backend> const &storage) noexcept {
     std::shared_lock<std::shared_mutex> l{storage.mutex};
-    return storage.id2data.size();
+    return storage.mapping.size();
 }
 
 size_t SyncReferenceNodeStorageBackend::size() const noexcept {
@@ -45,19 +47,16 @@ bool SyncReferenceNodeStorageBackend::has_specialized_storage_for(identifier::Li
  * @tparam create_if_not_present enables code for creating non-existing Node Backends
  * @param view contains the data of the requested Node Backend
  * @param storage the storage where the Node Backend is looked up
- * @param next_id_func function to generate the next ID which is assigned in case a new Node Backend is created
  * @return the NodeID for the looked up Node Backend. Result is the null-id if there was no matching Node Backend.
  */
-template<bool create_if_not_present, typename Storage, typename NextIDFunc = void *>
-    requires (!create_if_not_present || std::is_nothrow_invocable_r_v<identifier::NodeID, NextIDFunc>)
+template<bool create_if_not_present, typename Storage>
 static identifier::NodeID lookup_or_insert_impl(typename Storage::BackendView const &view,
-                                                Storage &storage,
-                                                NextIDFunc next_id_func = nullptr) noexcept {
+                                                Storage &storage) noexcept {
 
     {
         std::shared_lock lock{storage.mutex};
-        if (auto const it = storage.data2id.find(view); it != storage.data2id.end()) {
-            return it->second;
+        if (auto const id = storage.mapping.lookup_id(view); id != typename Storage::BackendId{}) {
+            return Storage::to_node_id(id, view);
         }
     }
 
@@ -67,16 +66,12 @@ static identifier::NodeID lookup_or_insert_impl(typename Storage::BackendView co
         std::unique_lock lock{storage.mutex};
 
         // check again, might have changed between unlocking of shared_lock and locking of unique_lock
-        if (auto const it = storage.data2id.find(view); it != storage.data2id.end()) {
-            return it->second;
+        if (auto const id = storage.mapping.lookup_id(view); id != typename Storage::BackendId{}) {
+            return Storage::to_node_id(id, view);
         }
 
-        identifier::NodeID const next_id = next_id_func();
-        auto const [it, inserted] = storage.id2data.emplace(next_id, std::make_unique<typename Storage::Backend>(view));
-        assert(inserted);
-        storage.data2id.emplace(it->second.get(), next_id);
-
-        return next_id;
+        auto const id = storage.mapping.insert_assume_not_present(view);
+        return Storage::to_node_id(id, view);
     }
 }
 
@@ -86,68 +81,27 @@ identifier::NodeID SyncReferenceNodeStorageBackend::find_or_make_id(view::Litera
                 auto const datatype = identifier::iri_node_id_to_literal_type(lexical.datatype_id);
                 assert(!this->has_specialized_storage_for(datatype));
 
-                auto const next_id_func = [this, datatype]() noexcept {
-                    auto const id = next_fallback_literal_id_.fetch_add(1, std::memory_order_relaxed);
-                    if (id >= (1ul << LiteralID::width)) [[unlikely]] {
-                        std::abort();
-                    }
-
-                    return identifier::NodeID{identifier::LiteralID{id}, datatype};
-                };
-
-                return lookup_or_insert_impl<true>(lexical, fallback_literal_storage_, next_id_func);
+                return lookup_or_insert_impl<true>(lexical, fallback_literal_storage_);
             },
             [this](view::ValueLiteralBackendView const &any) noexcept {
                 assert(this->has_specialized_storage_for(any.datatype));
 
-                auto const next_id_func = [this, datatype = any.datatype]() noexcept {
-                    return specialization_detail::visit_specialized(next_specialized_literal_ids_, datatype, [datatype](auto &lit_id) {
-                        auto const id = lit_id.fetch_add(1, std::memory_order_relaxed);
-                        if (id >= (1ul << LiteralID::width)) [[unlikely]] {
-                            std::abort();
-                        }
-
-                        return identifier::NodeID{LiteralID{id}, datatype};
-                    });
-                };
-
                 return specialization_detail::visit_specialized(specialized_literal_storage_, any.datatype, [&](auto &storage) noexcept {
-                    return lookup_or_insert_impl<true>(any, storage, next_id_func);
+                    return lookup_or_insert_impl<true>(any, storage);
                 });
             });
 }
 
 identifier::NodeID SyncReferenceNodeStorageBackend::find_or_make_id(view::IRIBackendView const &view) noexcept {
-    return lookup_or_insert_impl<true>(view, iri_storage_, [this]() noexcept {
-        auto const id = next_iri_id_.fetch_add(1, std::memory_order_relaxed);
-        if (id >= (1ul << NodeID::width)) [[unlikely]] {
-            std::abort();
-        }
-
-        return identifier::NodeID{id};
-    });
+    return lookup_or_insert_impl<true>(view, iri_storage_);
 }
 
 identifier::NodeID SyncReferenceNodeStorageBackend::find_or_make_id(view::BNodeBackendView const &view) noexcept {
-    return lookup_or_insert_impl<true>(view, bnode_storage_, [this]() noexcept {
-        auto const id = next_bnode_id_.fetch_add(1, std::memory_order_relaxed);
-        if (id >= (1ul << NodeID::width)) [[unlikely]] {
-            std::abort();
-        }
-
-        return identifier::NodeID{id};
-    });
+    return lookup_or_insert_impl<true>(view, bnode_storage_);
 }
 
 identifier::NodeID SyncReferenceNodeStorageBackend::find_or_make_id(view::VariableBackendView const &view) noexcept {
-    return lookup_or_insert_impl<true>(view, variable_storage_, [this]() noexcept {
-        auto const id = next_variable_id_.fetch_add(1, std::memory_order_relaxed);
-        if (id >= (1ul << NodeID::width)) [[unlikely]] {
-            std::abort();
-        }
-
-        return identifier::NodeID{id};
-    });
+    return lookup_or_insert_impl<true>(view, variable_storage_);
 }
 
 identifier::NodeID SyncReferenceNodeStorageBackend::find_id(view::BNodeBackendView const &view) const noexcept {
@@ -178,10 +132,16 @@ identifier::NodeID SyncReferenceNodeStorageBackend::find_id(view::VariableBacken
     return lookup_or_insert_impl<false>(view, variable_storage_);
 }
 
-template<typename NodeTypeStorage>
-static typename NodeTypeStorage::BackendView find_backend_view(NodeTypeStorage &storage, identifier::NodeID const id) {
+template<typename Storage>
+static typename Storage::BackendView find_backend_view(Storage &storage, identifier::NodeID const id) {
     std::shared_lock<std::shared_mutex> shared_lock{storage.mutex};
-    return static_cast<typename NodeTypeStorage::BackendView>(*storage.id2data.at(id));
+
+    auto const val_ptr = storage.mapping.lookup_value(Storage::to_backend_id(id));
+    if (val_ptr == nullptr) {
+        throw std::out_of_range{"Did not find node for given id"};
+    }
+
+    return static_cast<typename Storage::BackendView>(*val_ptr);
 }
 
 view::IRIBackendView SyncReferenceNodeStorageBackend::find_iri_backend_view(identifier::NodeID const id) const {
@@ -206,22 +166,16 @@ view::VariableBackendView SyncReferenceNodeStorageBackend::find_variable_backend
     return find_backend_view(variable_storage_, id);
 }
 
-template<typename NodeTypeStorage>
-static bool erase_impl(NodeTypeStorage &storage, identifier::NodeID const id) noexcept {
+template<typename Storage>
+static bool erase_impl(Storage &storage, identifier::NodeID const id) noexcept {
     std::unique_lock lock{storage.mutex};
-    auto it = storage.id2data.find(id);
-    if (it == storage.id2data.end()) {
+
+    auto const backend_id = Storage::to_backend_id(id);
+    if (storage.mapping.lookup_value(backend_id) == nullptr) {
         return false;
     }
 
-    auto const *backend_ptr = it->second.get();
-
-    auto data_it = storage.data2id.find(static_cast<typename NodeTypeStorage::BackendView>(*backend_ptr));
-    assert(data_it != storage.data2id.end());
-
-    storage.id2data.erase(it);
-    storage.data2id.erase(data_it);
-
+    storage.mapping.erase_assume_present(backend_id);
     return true;
 }
 

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/SyncReferenceNodeStorageBackend.cpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/SyncReferenceNodeStorageBackend.cpp
@@ -4,13 +4,13 @@
 namespace rdf4cpp::rdf::storage::node::reference_node_storage {
 
 SyncReferenceNodeStorageBackend::SyncReferenceNodeStorageBackend() noexcept {
-    iri_storage_.mapping.reserve(identifier::NodeID::min_iri_id);
-    bnode_storage_.mapping.reserve(identifier::NodeID::min_bnode_id);
-    variable_storage_.mapping.reserve(identifier::NodeID::min_variable_id);
-    fallback_literal_storage_.mapping.reserve(identifier::NodeID::min_literal_id);
+    iri_storage_.mapping.reserve_until(identifier::NodeID::min_iri_id);
+    bnode_storage_.mapping.reserve_until(identifier::NodeID::min_bnode_id);
+    variable_storage_.mapping.reserve_until(identifier::NodeID::min_variable_id);
+    fallback_literal_storage_.mapping.reserve_until(identifier::NodeID::min_literal_id);
 
     specialization_detail::tuple_for_each(specialized_literal_storage_, [](auto &storage) {
-        storage.mapping.reserve(identifier::NodeID::min_literal_id);
+        storage.mapping.reserve_until(identifier::NodeID::min_literal_id);
     });
 
     // some iri's like xsd:string are there by default

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/SyncReferenceNodeStorageBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/SyncReferenceNodeStorageBackend.hpp
@@ -52,13 +52,6 @@ private:
                SyncNodeTypeStorage<SpecializedLiteralBackend<datatypes::xsd::DayTimeDuration>>,
                SyncNodeTypeStorage<SpecializedLiteralBackend<datatypes::xsd::YearMonthDuration>>> specialized_literal_storage_;
 
-    std::atomic<uint64_t> next_fallback_literal_id_{NodeID::min_literal_id.value};
-    std::array<std::atomic<uint64_t>, std::tuple_size_v<decltype(specialized_literal_storage_)>> next_specialized_literal_ids_;
-
-    std::atomic<uint64_t> next_bnode_id_{NodeID::min_bnode_id.value()};
-    std::atomic<uint64_t> next_iri_id_{NodeID::min_iri_id.value()};
-    std::atomic<uint64_t> next_variable_id_{NodeID::min_variable_id.value()};
-
 public:
     SyncReferenceNodeStorageBackend() noexcept;
 

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/SyncReferenceNodeStorageBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/SyncReferenceNodeStorageBackend.hpp
@@ -56,6 +56,7 @@ public:
     SyncReferenceNodeStorageBackend() noexcept;
 
     [[nodiscard]] size_t size() const noexcept override;
+    void shrink_to_fit() override;
 
     [[nodiscard]] bool has_specialized_storage_for(identifier::LiteralType datatype) const noexcept override;
 

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/SyncReferenceNodeStorageBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/SyncReferenceNodeStorageBackend.hpp
@@ -18,11 +18,7 @@ namespace rdf4cpp::rdf::storage::node::reference_node_storage {
 /**
  * Thread-safe reference implementation of a INodeStorageBackend.
  */
-class SyncReferenceNodeStorageBackend : public INodeStorageBackend {
-public:
-    using NodeID = identifier::NodeID;
-    using LiteralID = identifier::LiteralID;
-
+struct SyncReferenceNodeStorageBackend : INodeStorageBackend {
 private:
     SyncNodeTypeStorage<BNodeBackend> bnode_storage_;
     SyncNodeTypeStorage<IRIBackend> iri_storage_;

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/UnsyncReferenceNodeStorageBackend.cpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/UnsyncReferenceNodeStorageBackend.cpp
@@ -4,13 +4,13 @@
 namespace rdf4cpp::rdf::storage::node::reference_node_storage {
 
 UnsyncReferenceNodeStorageBackend::UnsyncReferenceNodeStorageBackend() noexcept {
-    iri_storage_.mapping.reserve(identifier::NodeID::min_iri_id);
-    bnode_storage_.mapping.reserve(identifier::NodeID::min_bnode_id);
-    variable_storage_.mapping.reserve(identifier::NodeID::min_variable_id);
-    fallback_literal_storage_.mapping.reserve(identifier::NodeID::min_literal_id);
+    iri_storage_.mapping.reserve_until(identifier::NodeID::min_iri_id);
+    bnode_storage_.mapping.reserve_until(identifier::NodeID::min_bnode_id);
+    variable_storage_.mapping.reserve_until(identifier::NodeID::min_variable_id);
+    fallback_literal_storage_.mapping.reserve_until(identifier::NodeID::min_literal_id);
 
     specialization_detail::tuple_for_each(specialized_literal_storage_, [](auto &storage) {
-        storage.mapping.reserve(identifier::NodeID::min_literal_id);
+        storage.mapping.reserve_until(identifier::NodeID::min_literal_id);
     });
 
     // some iri's like xsd:string are there by default

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/UnsyncReferenceNodeStorageBackend.cpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/UnsyncReferenceNodeStorageBackend.cpp
@@ -4,13 +4,13 @@
 namespace rdf4cpp::rdf::storage::node::reference_node_storage {
 
 UnsyncReferenceNodeStorageBackend::UnsyncReferenceNodeStorageBackend() noexcept {
-    iri_storage_.mapping.reserve(NodeID::min_iri_id);
-    bnode_storage_.mapping.reserve(NodeID::min_bnode_id);
-    variable_storage_.mapping.reserve(NodeID::min_variable_id);
-    fallback_literal_storage_.mapping.reserve(NodeID::min_literal_id);
+    iri_storage_.mapping.reserve(identifier::NodeID::min_iri_id);
+    bnode_storage_.mapping.reserve(identifier::NodeID::min_bnode_id);
+    variable_storage_.mapping.reserve(identifier::NodeID::min_variable_id);
+    fallback_literal_storage_.mapping.reserve(identifier::NodeID::min_literal_id);
 
     specialization_detail::tuple_for_each(specialized_literal_storage_, [](auto &storage) {
-        storage.mapping.reserve(NodeID::min_literal_id);
+        storage.mapping.reserve(identifier::NodeID::min_literal_id);
     });
 
     // some iri's like xsd:string are there by default
@@ -54,10 +54,10 @@ bool UnsyncReferenceNodeStorageBackend::has_specialized_storage_for(identifier::
  * @return the NodeID for the looked up Node Backend. Result is the null-id if there was no matching Node Backend.
  */
 template<bool create_if_not_present, typename Storage>
-static identifier::NodeID lookup_or_insert_impl(typename Storage::BackendView const &view,
+static identifier::NodeID lookup_or_insert_impl(typename Storage::backend_view_type const &view,
                                                 Storage &storage) noexcept {
 
-    if (auto const id = storage.mapping.lookup_id(view); id != typename Storage::BackendId{}) {
+    if (auto const id = storage.mapping.lookup_id(view); id != typename Storage::backend_id_type{}) {
         return Storage::to_node_id(id, view);
     }
 
@@ -127,7 +127,7 @@ identifier::NodeID UnsyncReferenceNodeStorageBackend::find_id(view::VariableBack
 }
 
 template<typename NodeTypeStorage>
-static typename NodeTypeStorage::BackendView find_backend_view(NodeTypeStorage &storage, identifier::NodeID const id) {
+static typename NodeTypeStorage::backend_view_type find_backend_view(NodeTypeStorage &storage, identifier::NodeID const id) {
     if (auto view = storage.mapping.lookup_value(NodeTypeStorage::to_backend_id(id)); view.has_value()) {
         return *view;
     } else {

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/UnsyncReferenceNodeStorageBackend.cpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/UnsyncReferenceNodeStorageBackend.cpp
@@ -4,28 +4,22 @@
 namespace rdf4cpp::rdf::storage::node::reference_node_storage {
 
 UnsyncReferenceNodeStorageBackend::UnsyncReferenceNodeStorageBackend() noexcept {
-    // set correct initial value for atomics
-    for (auto &id : next_specialized_literal_ids_) {
-        id = NodeID::min_literal_id.value;
-    }
+    iri_storage_.mapping.reserve(identifier::NodeID::min_iri_id);
 
     // some iri's like xsd:string are there by default
     for (const auto &[iri, literal_type] : datatypes::registry::reserved_datatype_ids) {
         auto const id = literal_type.to_underlying();
-
-        auto const [it, inserted] = iri_storage_.id2data.emplace(id, std::make_unique<IRIBackend>(view::IRIBackendView{.identifier = iri}));
-        assert(inserted);
-        iri_storage_.data2id.emplace(it->second.get(), id);
+        iri_storage_.mapping.insert_assume_not_present_at(view::IRIBackendView{.identifier = iri}, identifier::NodeID{id});
     }
 }
 
 size_t UnsyncReferenceNodeStorageBackend::size() const noexcept {
-    return iri_storage_.id2data.size() +
-           bnode_storage_.id2data.size() +
-           variable_storage_.id2data.size() +
-           fallback_literal_storage_.id2data.size() +
+    return iri_storage_.mapping.size() +
+           bnode_storage_.mapping.size() +
+           variable_storage_.mapping.size() +
+           fallback_literal_storage_.mapping.size() +
            specialization_detail::tuple_fold(specialized_literal_storage_, 0, [](auto acc, auto const &storage) noexcept {
-               return acc + storage.id2data.size();
+               return acc + storage.mapping.size();
            });
 }
 
@@ -39,33 +33,21 @@ bool UnsyncReferenceNodeStorageBackend::has_specialized_storage_for(identifier::
  * @tparam create_if_not_present enables code for creating non-existing Node Backends
  * @param view contains the data of the requested Node Backend
  * @param storage the storage where the Node Backend is looked up
- * @param next_id_func function to generate the next ID which is assigned in case a new Node Backend is created
  * @return the NodeID for the looked up Node Backend. Result is the null-id if there was no matching Node Backend.
  */
-template<bool create_if_not_present, typename Storage, typename NextIDFunc = void *>
-    requires (!create_if_not_present || std::is_nothrow_invocable_r_v<identifier::NodeID, NextIDFunc>)
+template<bool create_if_not_present, typename Storage>
 static identifier::NodeID lookup_or_insert_impl(typename Storage::BackendView const &view,
-                                                Storage &storage,
-                                                NextIDFunc next_id_func = nullptr) noexcept {
+                                                Storage &storage) noexcept {
 
-    if (auto const it = storage.data2id.find(view); it != storage.data2id.end()) {
-        return it->second;
+    if (auto const id = storage.mapping.lookup_id(view); id != typename Storage::BackendId{}) {
+        return Storage::to_node_id(id, view);
     }
 
     if constexpr (!create_if_not_present) {
         return identifier::NodeID{};
     } else {
-        // check again, might have changed between unlocking of shared_lock and locking of unique_lock
-        if (auto const it = storage.data2id.find(view); it != storage.data2id.end()) {
-            return it->second;
-        }
-
-        identifier::NodeID const next_id = next_id_func();
-        auto const [it, inserted] = storage.id2data.emplace(next_id, std::make_unique<typename Storage::Backend>(view));
-        assert(inserted);
-        storage.data2id.emplace(it->second.get(), next_id);
-
-        return next_id;
+        auto const id = storage.mapping.insert_assume_not_present(view);
+        return Storage::to_node_id(id, view);
     }
 }
 
@@ -75,68 +57,27 @@ identifier::NodeID UnsyncReferenceNodeStorageBackend::find_or_make_id(view::Lite
                 auto const datatype = identifier::iri_node_id_to_literal_type(lexical.datatype_id);
                 assert(!this->has_specialized_storage_for(datatype));
 
-                auto const next_id_func = [this, datatype]() noexcept {
-                    auto const id = next_fallback_literal_id_++;
-                    if (id >= (1ul << LiteralID::width)) [[unlikely]] {
-                        std::abort();
-                    }
-
-                    return identifier::NodeID{identifier::LiteralID{id}, datatype};
-                };
-
-                return lookup_or_insert_impl<true>(lexical, fallback_literal_storage_, next_id_func);
+                return lookup_or_insert_impl<true>(lexical, fallback_literal_storage_);
             },
             [this](view::ValueLiteralBackendView const &any) noexcept {
                 assert(this->has_specialized_storage_for(any.datatype));
 
-                auto const next_id_func = [this, datatype = any.datatype]() noexcept {
-                    return specialization_detail::visit_specialized(next_specialized_literal_ids_, datatype, [datatype](auto &lit_id) {
-                        auto const id = lit_id++;
-                        if (id >= (1ul << LiteralID::width)) [[unlikely]] {
-                            std::abort();
-                        }
-
-                        return identifier::NodeID{LiteralID{id}, datatype};
-                    });
-                };
-
                 return specialization_detail::visit_specialized(specialized_literal_storage_, any.datatype, [&](auto &storage) noexcept {
-                    return lookup_or_insert_impl<true>(any, storage, next_id_func);
+                    return lookup_or_insert_impl<true>(any, storage);
                 });
             });
 }
 
 identifier::NodeID UnsyncReferenceNodeStorageBackend::find_or_make_id(view::IRIBackendView const &view) noexcept {
-    return lookup_or_insert_impl<true>(view, iri_storage_, [this]() noexcept {
-        auto const id = next_iri_id_++;
-        if (id >= (1ul << NodeID::width)) [[unlikely]] {
-            std::abort();
-        }
-
-        return identifier::NodeID{id};
-    });
+    return lookup_or_insert_impl<true>(view, iri_storage_);
 }
 
 identifier::NodeID UnsyncReferenceNodeStorageBackend::find_or_make_id(view::BNodeBackendView const &view) noexcept {
-    return lookup_or_insert_impl<true>(view, bnode_storage_, [this]() noexcept {
-        auto const id = next_bnode_id_++;
-        if (id >= (1ul << NodeID::width)) [[unlikely]] {
-            std::abort();
-        }
-
-        return identifier::NodeID{id};
-    });
+    return lookup_or_insert_impl<true>(view, bnode_storage_);
 }
 
 identifier::NodeID UnsyncReferenceNodeStorageBackend::find_or_make_id(view::VariableBackendView const &view) noexcept {
-    return lookup_or_insert_impl<true>(view, variable_storage_, [this]() noexcept {
-        auto const id = next_variable_id_++;
-        if (id >= (1ul << NodeID::width)) [[unlikely]] {
-            std::abort();
-        }
-
-        return identifier::NodeID{id};
-    });
+    return lookup_or_insert_impl<true>(view, variable_storage_);
 }
 
 identifier::NodeID UnsyncReferenceNodeStorageBackend::find_id(view::BNodeBackendView const &view) const noexcept {
@@ -169,7 +110,12 @@ identifier::NodeID UnsyncReferenceNodeStorageBackend::find_id(view::VariableBack
 
 template<typename NodeTypeStorage>
 static typename NodeTypeStorage::BackendView find_backend_view(NodeTypeStorage &storage, identifier::NodeID const id) {
-    return static_cast<typename NodeTypeStorage::BackendView>(*storage.id2data.at(id));
+    auto const val_ptr = storage.mapping.lookup_value(NodeTypeStorage::to_backend_id(id));
+    if (val_ptr == nullptr) {
+        throw std::out_of_range{"Did not find node for given id"};
+    }
+
+    return static_cast<typename NodeTypeStorage::BackendView>(*val_ptr);
 }
 
 view::IRIBackendView UnsyncReferenceNodeStorageBackend::find_iri_backend_view(identifier::NodeID const id) const {
@@ -194,21 +140,15 @@ view::VariableBackendView UnsyncReferenceNodeStorageBackend::find_variable_backe
     return find_backend_view(variable_storage_, id);
 }
 
-template<typename NodeTypeStorage>
-static bool erase_impl(NodeTypeStorage &storage, identifier::NodeID const id) noexcept {
-    auto it = storage.id2data.find(id);
-    if (it == storage.id2data.end()) {
+template<typename Storage>
+static bool erase_impl(Storage &storage, identifier::NodeID const id) noexcept {
+    auto const backend_id = Storage::to_backend_id(id);
+
+    if (storage.mapping.lookup_value(backend_id) == nullptr) {
         return false;
     }
 
-    auto const *backend_ptr = it->second.get();
-
-    auto data_it = storage.data2id.find(static_cast<typename NodeTypeStorage::BackendView>(*backend_ptr));
-    assert(data_it != storage.data2id.end());
-
-    storage.id2data.erase(it);
-    storage.data2id.erase(data_it);
-
+    storage.mapping.erase_assume_present(backend_id);
     return true;
 }
 

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/UnsyncReferenceNodeStorageBackend.cpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/UnsyncReferenceNodeStorageBackend.cpp
@@ -110,12 +110,11 @@ identifier::NodeID UnsyncReferenceNodeStorageBackend::find_id(view::VariableBack
 
 template<typename NodeTypeStorage>
 static typename NodeTypeStorage::BackendView find_backend_view(NodeTypeStorage &storage, identifier::NodeID const id) {
-    auto const val_ptr = storage.mapping.lookup_value(NodeTypeStorage::to_backend_id(id));
-    if (val_ptr == nullptr) {
+    if (auto view = storage.mapping.lookup_value(NodeTypeStorage::to_backend_id(id)); view.has_value()) {
+        return *view;
+    } else {
         throw std::out_of_range{"Did not find node for given id"};
     }
-
-    return static_cast<typename NodeTypeStorage::BackendView>(*val_ptr);
 }
 
 view::IRIBackendView UnsyncReferenceNodeStorageBackend::find_iri_backend_view(identifier::NodeID const id) const {
@@ -143,8 +142,7 @@ view::VariableBackendView UnsyncReferenceNodeStorageBackend::find_variable_backe
 template<typename Storage>
 static bool erase_impl(Storage &storage, identifier::NodeID const id) noexcept {
     auto const backend_id = Storage::to_backend_id(id);
-
-    if (storage.mapping.lookup_value(backend_id) == nullptr) {
+    if (!storage.mapping.lookup_value(backend_id).has_value()) {
         return false;
     }
 

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/UnsyncReferenceNodeStorageBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/UnsyncReferenceNodeStorageBackend.hpp
@@ -52,13 +52,6 @@ private:
                UnsyncNodeTypeStorage<SpecializedLiteralBackend<datatypes::xsd::DayTimeDuration>>,
                UnsyncNodeTypeStorage<SpecializedLiteralBackend<datatypes::xsd::YearMonthDuration>>> specialized_literal_storage_;
 
-    uint64_t next_fallback_literal_id_{NodeID::min_literal_id.value};
-    std::array<uint64_t, std::tuple_size_v<decltype(specialized_literal_storage_)>> next_specialized_literal_ids_;
-
-    uint64_t next_bnode_id_{NodeID::min_bnode_id.value()};
-    uint64_t next_iri_id_{NodeID::min_iri_id.value()};
-    uint64_t next_variable_id_{NodeID::min_variable_id.value()};
-
 public:
     UnsyncReferenceNodeStorageBackend() noexcept;
 

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/UnsyncReferenceNodeStorageBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/UnsyncReferenceNodeStorageBackend.hpp
@@ -18,11 +18,7 @@ namespace rdf4cpp::rdf::storage::node::reference_node_storage {
 /**
  * NON-Thread-safe reference implementation of a INodeStorageBackend.
  */
-class UnsyncReferenceNodeStorageBackend : public INodeStorageBackend {
-public:
-    using NodeID = identifier::NodeID;
-    using LiteralID = identifier::LiteralID;
-
+struct UnsyncReferenceNodeStorageBackend : INodeStorageBackend {
 private:
     UnsyncNodeTypeStorage<BNodeBackend> bnode_storage_;
     UnsyncNodeTypeStorage<IRIBackend> iri_storage_;

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/UnsyncReferenceNodeStorageBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/UnsyncReferenceNodeStorageBackend.hpp
@@ -56,6 +56,7 @@ public:
     UnsyncReferenceNodeStorageBackend() noexcept;
 
     [[nodiscard]] size_t size() const noexcept override;
+    void shrink_to_fit() override;
 
     [[nodiscard]] bool has_specialized_storage_for(identifier::LiteralType datatype) const noexcept override;
 

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/VariableBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/VariableBackend.hpp
@@ -2,8 +2,7 @@
 #define RDF4CPP_VARIABLEBACKEND_HPP
 
 #include <rdf4cpp/rdf/storage/node/view/VariableBackendView.hpp>
-
-#include <string>
+#include <rdf4cpp/rdf/storage/node/reference_node_storage/detail/ConstString.hpp>
 
 namespace rdf4cpp::rdf::storage::node::reference_node_storage {
 
@@ -12,7 +11,7 @@ struct VariableBackend {
     using Id = identifier::NodeID;
 
     size_t hash;
-    std::string name;
+    ConstString name;
     bool is_anonymous;
 
     explicit VariableBackend(view::VariableBackendView const &view) noexcept : hash{view.hash()},

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/VariableBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/VariableBackend.hpp
@@ -11,7 +11,7 @@ struct VariableBackend {
     using Id = identifier::NodeID;
 
     size_t hash;
-    ConstString name;
+    detail::ConstString name;
     bool is_anonymous;
 
     explicit VariableBackend(view::VariableBackendView const &view) noexcept : hash{view.hash()},

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/VariableBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/VariableBackend.hpp
@@ -7,21 +7,21 @@
 namespace rdf4cpp::rdf::storage::node::reference_node_storage {
 
 struct VariableBackend {
-    using View = view::VariableBackendView;
-    using Id = identifier::NodeID;
+    using view_type = view::VariableBackendView;
+    using id_type = identifier::NodeID;
 
     size_t hash;
     detail::ConstString name;
     bool is_anonymous;
 
-    explicit VariableBackend(view::VariableBackendView const &view) noexcept : hash{view.hash()},
-                                                                               name{view.name},
-                                                                               is_anonymous{view.is_anonymous} {
+    explicit VariableBackend(view_type const &view) noexcept : hash{view.hash()},
+                                                               name{view.name},
+                                                               is_anonymous{view.is_anonymous} {
     }
 
-    explicit operator View() const noexcept {
-        return View{.name = name,
-                    .is_anonymous = is_anonymous};
+    explicit operator view_type() const noexcept {
+        return view_type{.name = name,
+                         .is_anonymous = is_anonymous};
     }
 };
 

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/VariableBackend.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/VariableBackend.hpp
@@ -9,6 +9,7 @@ namespace rdf4cpp::rdf::storage::node::reference_node_storage {
 
 struct VariableBackend {
     using View = view::VariableBackendView;
+    using Id = identifier::NodeID;
 
     size_t hash;
     std::string name;

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/detail/BiDirFlatMap.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/detail/BiDirFlatMap.hpp
@@ -1,0 +1,177 @@
+#ifndef RDF4CPP_RDF_REFERENCENODESTORAGE_BIDIRFLATMAP_HPP
+#define RDF4CPP_RDF_REFERENCENODESTORAGE_BIDIRFLATMAP_HPP
+
+#include <dice/sparse-map/sparse_set.hpp>
+
+namespace rdf4cpp::rdf::storage::node::reference_node_storage {
+
+template<typename Id, typename Value, typename View, typename Hash, typename Equal, typename Allocator = std::allocator<Value>>
+struct BiDirFlatMap {
+    using id_type = Id;
+    using mapped_type = Value;
+    using view_type = View;
+    using size_type = size_t;
+    using allocator_type = Allocator;
+
+private:
+    struct backward_key_type {
+        size_t hash_;
+        id_type id_;
+    };
+
+    struct backward_key_equal {
+        using is_transparent = void;
+
+        std::vector<mapped_type *> const *reference_;
+        [[no_unique_address]] Equal eq_;
+
+        bool operator()(backward_key_type const &a, backward_key_type const &b) const noexcept {
+            return a.id_ == b.id_;
+        }
+
+        bool operator()(backward_key_type const &a, view_type const &b) const noexcept {
+            auto const *ref = (*reference_)[to_index(a.id_)];
+            if (ref == nullptr) {
+                return false;
+            }
+
+            return eq_(*ref, b);
+        }
+
+        bool operator()(view_type const &a, backward_key_type const &b) const noexcept {
+            auto const *ref = (*reference_)[to_index(b.id_)];
+            if (ref == nullptr) {
+                return false;
+            }
+
+            return eq_(a, *ref);
+        }
+    };
+
+    struct backward_hasher {
+        using is_transparent = void;
+
+        [[no_unique_address]] Hash hash_;
+
+        size_t operator()(backward_key_type const &a) const noexcept {
+            return a.hash_;
+        }
+
+        size_t operator()(View const &a) const noexcept {
+            return hash_(a);
+        }
+    };
+
+    using forward_allocator_type = typename std::allocator_traits<Allocator>::template rebind_alloc<mapped_type *>;
+    using backward_allocator_type = typename std::allocator_traits<Allocator>::template rebind_alloc<backward_key_type>;
+
+    std::vector<mapped_type *, forward_allocator_type> forward_;
+    dice::sparse_map::sparse_set<backward_key_type, backward_hasher, backward_key_equal, backward_allocator_type> backward_;
+    [[no_unique_address]] allocator_type alloc_;
+
+    [[nodiscard]] static size_type to_index(id_type id) noexcept {
+        return static_cast<size_type>(id) - 1;
+    }
+
+    [[nodiscard]] static id_type to_id(size_type ix) noexcept {
+        return static_cast<id_type>(ix + 1);
+    }
+
+public:
+    explicit BiDirFlatMap(Hash const &hash = Hash{},
+                          Equal const &equal = Equal{}) noexcept : forward_{},
+                                                                   backward_{0, backward_hasher{hash}, backward_key_equal{&forward_, equal}} {
+    }
+
+    // deleted because type is self-referential
+    BiDirFlatMap(BiDirFlatMap const &) = delete;
+    BiDirFlatMap(BiDirFlatMap &&) = delete;
+    BiDirFlatMap &operator=(BiDirFlatMap const &) = delete;
+    BiDirFlatMap &operator=(BiDirFlatMap &&) = delete;
+
+    ~BiDirFlatMap() noexcept {
+        for (auto ptr : forward_) {
+            if (ptr != nullptr) {
+                std::allocator_traits<allocator_type>::destroy(alloc_, ptr);
+                std::allocator_traits<allocator_type>::deallocate(alloc_, ptr, 1);
+            }
+        }
+    }
+
+    [[nodiscard]] size_type size() const noexcept {
+        return forward_.size();
+    }
+
+    [[nodiscard]] mapped_type const *lookup_value(id_type const id) const noexcept {
+        if (id == id_type{}) [[unlikely]] {
+            return nullptr;
+        }
+
+        auto const ix = to_index(id);
+        if (ix >= forward_.size()) {
+            return nullptr;
+        }
+
+        return forward_[ix];
+    }
+
+    [[nodiscard]] id_type lookup_id(view_type const &view) const noexcept {
+        auto it = backward_.find(view);
+        if (it == backward_.end()) {
+            return Id{};
+        }
+
+        return it->id_;
+    }
+
+    void reserve(id_type const min_id) noexcept {
+        forward_.resize(to_index(min_id));
+    }
+
+    [[nodiscard]] id_type insert_assume_not_present(view_type const &view) noexcept {
+        assert(lookup_id(view) == Id{});
+
+        auto const assigned_id = to_id(forward_.size());
+
+        mapped_type *backend = std::allocator_traits<allocator_type>::allocate(alloc_, 1);
+        std::allocator_traits<allocator_type>::construct(alloc_, backend, view);
+        forward_.push_back(backend);
+
+        auto const h = backward_.hash_function().hash_(view);
+        backward_.emplace(h, assigned_id);
+
+        return assigned_id;
+    }
+
+    void insert_assume_not_present_at(view_type const &view, id_type requested_id) noexcept {
+        assert(lookup_id(view) == Id{});
+
+        auto const lookup_ix = to_index(requested_id);
+        assert(lookup_ix < forward_.size());
+        assert(forward_[lookup_ix] == nullptr);
+
+        mapped_type *backend = std::allocator_traits<allocator_type>::allocate(alloc_, 1);
+        std::allocator_traits<allocator_type>::construct(alloc_, backend, view);
+        forward_[lookup_ix] = backend;
+
+        auto const h = backward_.hash_function().hash_(view);
+        backward_.emplace(h, requested_id);
+    }
+
+    void erase_assume_present(id_type id) noexcept {
+        assert(lookup_value(id) != nullptr);
+
+        auto &value = forward_[to_index(id)];
+        auto const view = static_cast<view_type>(*value);
+
+        backward_.erase(view);
+
+        std::allocator_traits<allocator_type>::destroy(alloc_, value);
+        std::allocator_traits<allocator_type>::deallocate(alloc_, value, 1);
+        value = nullptr;
+    }
+};
+
+} // namespace rdf4cpp::rdf::storage::node::reference_node_storage
+
+#endif // RDF4CPP_RDF_REFERENCENODESTORAGE_BIDIRFLATMAP_HPP

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/detail/BiDirFlatMap.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/detail/BiDirFlatMap.hpp
@@ -3,84 +3,107 @@
 
 #include <dice/sparse-map/sparse_set.hpp>
 
-namespace rdf4cpp::rdf::storage::node::reference_node_storage {
+namespace rdf4cpp::rdf::storage::node::reference_node_storage::detail {
 
-template<typename Id, typename Value, typename View, typename Hash, typename Equal, typename Allocator = std::allocator<Value>>
+/**
+ * A bidirectional map from Id to Value
+ *
+ * @tparam Id id type
+ * @tparam Value stored value type
+ * @tparam View view of Value
+ * @tparam Hash hash for View
+ * @tparam Equal equality for View and Value
+ * @tparam Allocator allocator
+ */
+template<typename Id, typename Value, typename View, typename Hash = std::hash<View>, typename Equal = std::equal_to<>, typename Allocator = std::allocator<Value>>
 struct BiDirFlatMap {
     using id_type = Id;
     using mapped_type = Value;
     using view_type = View;
     using size_type = size_t;
     using allocator_type = Allocator;
+    using hasher = Hash;
+    using key_equal = Equal;
 
 private:
+    using forward_value_type = std::optional<mapped_type>;
+    using forward_allocator_type = typename std::allocator_traits<Allocator>::template rebind_alloc<forward_value_type>;
+    using forward_type = std::vector<forward_value_type, forward_allocator_type>;
+
     struct backward_key_type {
-        size_t hash_;
-        id_type id_;
+        size_t hash; // hash of the Value being looked up
+        id_type id;  // id into forward_
     };
 
     struct backward_key_equal {
         using is_transparent = void;
 
-        std::vector<mapped_type *> const *reference_;
-        [[no_unique_address]] Equal eq_;
+        using forward_const_pointer = typename std::allocator_traits<allocator_type>::template rebind_traits<forward_type>::const_pointer;
+
+        forward_const_pointer forward_ptr; // pointer to forward_ to be able to check for equality between View and Value
+        [[no_unique_address]] Equal eq;
 
         bool operator()(backward_key_type const &a, backward_key_type const &b) const noexcept {
-            return a.id_ == b.id_;
+            return a.id == b.id;
         }
 
         bool operator()(backward_key_type const &a, view_type const &b) const noexcept {
-            auto const *ref = (*reference_)[to_index(a.id_)];
-            if (ref == nullptr) {
+            auto const &ref = (*forward_ptr)[to_index(a.id)];
+            if (!ref.has_value()) {
                 return false;
             }
 
-            return eq_(*ref, b);
+            return eq(*ref, b);
         }
 
         bool operator()(view_type const &a, backward_key_type const &b) const noexcept {
-            auto const *ref = (*reference_)[to_index(b.id_)];
-            if (ref == nullptr) {
+            auto const &ref = (*forward_ptr)[to_index(b.id)];
+            if (!ref.has_value()) {
                 return false;
             }
 
-            return eq_(a, *ref);
+            return eq(a, *ref);
         }
     };
 
     struct backward_hasher {
         using is_transparent = void;
 
-        [[no_unique_address]] Hash hash_;
+        [[no_unique_address]] Hash hash;
 
         size_t operator()(backward_key_type const &a) const noexcept {
-            return a.hash_;
+            return a.hash;
         }
 
-        size_t operator()(View const &a) const noexcept {
-            return hash_(a);
+        size_t operator()(view_type const &a) const noexcept {
+            return hash(a);
         }
     };
 
-    using forward_allocator_type = typename std::allocator_traits<Allocator>::template rebind_alloc<mapped_type *>;
     using backward_allocator_type = typename std::allocator_traits<Allocator>::template rebind_alloc<backward_key_type>;
+    using backward_type = dice::sparse_map::sparse_set<backward_key_type, backward_hasher, backward_key_equal, backward_allocator_type>;
 
-    std::vector<mapped_type *, forward_allocator_type> forward_;
-    dice::sparse_map::sparse_set<backward_key_type, backward_hasher, backward_key_equal, backward_allocator_type> backward_;
+    forward_type forward_;   // forward_[id] stores Value for Id id
+    backward_type backward_; // backward_[view] stores Id into forward_
     [[no_unique_address]] allocator_type alloc_;
 
-    [[nodiscard]] static size_type to_index(id_type id) noexcept {
+    [[nodiscard]] static constexpr size_type to_index(id_type id) noexcept {
         return static_cast<size_type>(id) - 1;
     }
 
-    [[nodiscard]] static id_type to_id(size_type ix) noexcept {
+    [[nodiscard]] static constexpr id_type to_id(size_type ix) noexcept {
         return static_cast<id_type>(ix + 1);
     }
 
 public:
-    explicit BiDirFlatMap(Hash const &hash = Hash{},
-                          Equal const &equal = Equal{}) noexcept : forward_{},
-                                                                   backward_{0, backward_hasher{hash}, backward_key_equal{&forward_, equal}} {
+    explicit BiDirFlatMap(hasher const &hash = hasher{},
+                          key_equal const &equal = key_equal{},
+                          allocator_type const &alloc = allocator_type{}) noexcept : forward_{alloc},
+                                                                                     backward_{0, backward_hasher{hash}, backward_key_equal{&forward_, equal}, alloc},
+                                                                                     alloc_{alloc} {
+    }
+
+    explicit BiDirFlatMap(allocator_type const &alloc) noexcept : BiDirFlatMap{hasher{}, key_equal{}, alloc} {
     }
 
     // deleted because type is self-referential
@@ -89,30 +112,21 @@ public:
     BiDirFlatMap &operator=(BiDirFlatMap const &) = delete;
     BiDirFlatMap &operator=(BiDirFlatMap &&) = delete;
 
-    ~BiDirFlatMap() noexcept {
-        for (auto ptr : forward_) {
-            if (ptr != nullptr) {
-                std::allocator_traits<allocator_type>::destroy(alloc_, ptr);
-                std::allocator_traits<allocator_type>::deallocate(alloc_, ptr, 1);
-            }
-        }
-    }
-
     [[nodiscard]] size_type size() const noexcept {
         return forward_.size();
     }
 
-    [[nodiscard]] mapped_type const *lookup_value(id_type const id) const noexcept {
+    [[nodiscard]] std::optional<view_type> lookup_value(id_type const id) const noexcept {
         if (id == id_type{}) [[unlikely]] {
-            return nullptr;
+            return std::nullopt;
         }
 
         auto const ix = to_index(id);
-        if (ix >= forward_.size()) {
-            return nullptr;
+        if (ix >= forward_.size() || !forward_[ix].has_value()) {
+            return std::nullopt;
         }
 
-        return forward_[ix];
+        return static_cast<view_type>(*forward_[ix]);
     }
 
     [[nodiscard]] id_type lookup_id(view_type const &view) const noexcept {
@@ -121,57 +135,49 @@ public:
             return Id{};
         }
 
-        return it->id_;
+        return it->id;
     }
 
-    void reserve(id_type const min_id) noexcept {
+    void reserve(id_type const min_id) {
         forward_.resize(to_index(min_id));
     }
 
-    [[nodiscard]] id_type insert_assume_not_present(view_type const &view) noexcept {
+    [[nodiscard]] id_type insert_assume_not_present(view_type const &view) {
         assert(lookup_id(view) == Id{});
 
         auto const assigned_id = to_id(forward_.size());
 
-        mapped_type *backend = std::allocator_traits<allocator_type>::allocate(alloc_, 1);
-        std::allocator_traits<allocator_type>::construct(alloc_, backend, view);
-        forward_.push_back(backend);
-
-        auto const h = backward_.hash_function().hash_(view);
+        forward_.push_back(std::make_obj_using_allocator<mapped_type>(alloc_, view));
+        auto const h = backward_.hash_function().hash(view);
         backward_.emplace(h, assigned_id);
 
         return assigned_id;
     }
 
-    void insert_assume_not_present_at(view_type const &view, id_type requested_id) noexcept {
+    void insert_assume_not_present_at(view_type const &view, id_type requested_id) {
         assert(lookup_id(view) == Id{});
 
         auto const lookup_ix = to_index(requested_id);
         assert(lookup_ix < forward_.size());
-        assert(forward_[lookup_ix] == nullptr);
+        assert(!forward_[lookup_ix].has_value());
 
-        mapped_type *backend = std::allocator_traits<allocator_type>::allocate(alloc_, 1);
-        std::allocator_traits<allocator_type>::construct(alloc_, backend, view);
-        forward_[lookup_ix] = backend;
+        forward_[lookup_ix] = std::make_obj_using_allocator<mapped_type>(alloc_, view);
 
-        auto const h = backward_.hash_function().hash_(view);
+        auto const h = backward_.hash_function().hash(view);
         backward_.emplace(h, requested_id);
     }
 
-    void erase_assume_present(id_type id) noexcept {
-        assert(lookup_value(id) != nullptr);
+    void erase_assume_present(id_type id) {
+        assert(lookup_value(id).has_value());
 
         auto &value = forward_[to_index(id)];
         auto const view = static_cast<view_type>(*value);
 
         backward_.erase(view);
-
-        std::allocator_traits<allocator_type>::destroy(alloc_, value);
-        std::allocator_traits<allocator_type>::deallocate(alloc_, value, 1);
-        value = nullptr;
+        value.reset();
     }
 };
 
-} // namespace rdf4cpp::rdf::storage::node::reference_node_storage
+} // namespace rdf4cpp::rdf::storage::node::reference_node_storage::detail
 
 #endif // RDF4CPP_RDF_REFERENCENODESTORAGE_BIDIRFLATMAP_HPP

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/detail/BiDirFlatMap.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/detail/BiDirFlatMap.hpp
@@ -116,6 +116,11 @@ public:
         return forward_.size();
     }
 
+    void shrink_to_fit() {
+        forward_.shrink_to_fit();
+        // TODO backward_?
+    }
+
     [[nodiscard]] std::optional<view_type> lookup_value(id_type const id) const noexcept {
         if (id == id_type{}) [[unlikely]] {
             return std::nullopt;

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/detail/ConstString.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/detail/ConstString.hpp
@@ -3,12 +3,12 @@
 
 #include <string>
 
-namespace rdf4cpp::rdf::storage::node::reference_node_storage {
+namespace rdf4cpp::rdf::storage::node::reference_node_storage::detail {
 
     template<typename Char, typename Traits = std::char_traits<Char>, typename Allocator = std::allocator<Char>>
     struct BasicConstString {
         using value_type = Char;
-        using traits_type = std::char_traits<value_type>;
+        using traits_type = Traits;
         using allocator_type = Allocator;
         using size_type = size_t;
         using different_type = std::ptrdiff_t;
@@ -20,43 +20,61 @@ namespace rdf4cpp::rdf::storage::node::reference_node_storage {
         size_type size_;
         [[no_unique_address]] allocator_type alloc_;
 
-        void drop() noexcept {
-            if (data_ == nullptr) {
-                return;
-            }
-
-            std::allocator_traits<allocator_type>::deallocate(alloc_, data_, size_);
+        static constexpr void swap_data(BasicConstString &a, BasicConstString &b) noexcept {
+            std::swap(a.data_, b.data_);
+            std::swap(a.size_, b.size_);
         }
 
     public:
-        explicit BasicConstString(std::string_view const sv, allocator_type const &alloc = allocator_type{}) : alloc_{alloc} {
-            size_ = sv.size();
+        explicit BasicConstString(std::string_view const sv,
+                                  allocator_type const &alloc = allocator_type{}) : size_{sv.size()},
+                                                                                    alloc_{alloc} {
             data_ = std::allocator_traits<allocator_type>::allocate(alloc_, size_);
             memcpy(data_, sv.data(), size_);
         }
 
+        // prevent copy constructors from being accidentally called
         BasicConstString(BasicConstString const &) = delete;
+        BasicConstString &operator=(BasicConstString const &) = delete;
 
         BasicConstString(BasicConstString &&other) noexcept : data_{std::exchange(other.data_, nullptr)},
                                                               size_{std::exchange(other.size_, 0)},
                                                               alloc_{std::move(other.alloc_)} {
         }
 
-        BasicConstString &operator=(BasicConstString const &) = delete;
-
-        BasicConstString &operator=(BasicConstString &&other) noexcept {
+        BasicConstString &operator=(BasicConstString &&other) noexcept(std::allocator_traits<Allocator>::propagate_on_container_move_assignment::value
+                                                                            || std::allocator_traits<Allocator>::is_always_equal::value) {
             assert(this != &other);
 
-            drop();
-            data_ = std::exchange(other.data_, nullptr);
-            size_ = std::exchange(other.size_, 0);
-            alloc_ = std::move(other.alloc_);
+            if constexpr (std::allocator_traits<Allocator>::propagate_on_container_move_assignment::value) {
+                swap(*this, other);
+                return *this;
+            } else if constexpr (std::allocator_traits<Allocator>::is_always_equal::value) {
+                swap_data(*this, other);
+                return *this;
+            } else {
+                if (alloc_ == other.alloc_) [[likely]] {
+                    swap_data(*this, other);
+                    return *this;
+                }
 
-            return *this;
+                // alloc_ != other.alloc_ and not allowed to propagate, need to copy
+
+                if (size_ != other.size_) [[likely]] {
+                    std::allocator_traits<allocator_type>::deallocate(alloc_, data_, size_);
+                    size_ = other.size_;
+                    data_ = std::allocator_traits<allocator_type>::allocate(alloc_, size_);
+                }
+
+                memcpy(data_, other.data_, size_);
+                return *this;
+            }
         }
 
-        ~BasicConstString() noexcept {
-            drop();
+        ~BasicConstString() {
+            if (data_ != nullptr) {
+                std::allocator_traits<allocator_type>::deallocate(alloc_, data_, size_);
+            }
         }
 
         [[nodiscard]] value_type const *data() const noexcept {
@@ -67,13 +85,19 @@ namespace rdf4cpp::rdf::storage::node::reference_node_storage {
             return size_;
         }
 
-        operator std::string_view() const noexcept {
-            return std::string_view{data_, size_};
+        operator std::basic_string_view<value_type, traits_type>() const noexcept {
+            return {data_, size_};
+        }
+
+        friend void swap(BasicConstString &a, BasicConstString &b) noexcept {
+            std::swap(a.data_, b.data_);
+            std::swap(a.size_, b.size_);
+            std::swap(a.alloc_, b.alloc_);
         }
     };
 
     using ConstString = BasicConstString<char>;
 
-} // namespace rdf4cpp::rdf::storage::node::reference_node_storage
+} // namespace rdf4cpp::rdf::storage::node::reference_node_storage::detail
 
 #endif // RDF4CPP_REFERENCENODESTORAGE_CONSTSTRING_HPP

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/detail/ConstString.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/detail/ConstString.hpp
@@ -1,0 +1,79 @@
+#ifndef RDF4CPP_REFERENCENODESTORAGE_CONSTSTRING_HPP
+#define RDF4CPP_REFERENCENODESTORAGE_CONSTSTRING_HPP
+
+#include <string>
+
+namespace rdf4cpp::rdf::storage::node::reference_node_storage {
+
+    template<typename Char, typename Traits = std::char_traits<Char>, typename Allocator = std::allocator<Char>>
+    struct BasicConstString {
+        using value_type = Char;
+        using traits_type = std::char_traits<value_type>;
+        using allocator_type = Allocator;
+        using size_type = size_t;
+        using different_type = std::ptrdiff_t;
+        using pointer = std::allocator_traits<allocator_type>::pointer;
+        using const_pointer = std::allocator_traits<allocator_type>::const_pointer;
+
+    private:
+        pointer data_;
+        size_type size_;
+        [[no_unique_address]] allocator_type alloc_;
+
+        void drop() noexcept {
+            if (data_ == nullptr) {
+                return;
+            }
+
+            std::allocator_traits<allocator_type>::deallocate(alloc_, data_, size_);
+        }
+
+    public:
+        explicit BasicConstString(std::string_view const sv, allocator_type const &alloc = allocator_type{}) : alloc_{alloc} {
+            size_ = sv.size();
+            data_ = std::allocator_traits<allocator_type>::allocate(alloc_, size_);
+            memcpy(data_, sv.data(), size_);
+        }
+
+        BasicConstString(BasicConstString const &) = delete;
+
+        BasicConstString(BasicConstString &&other) noexcept : data_{std::exchange(other.data_, nullptr)},
+                                                              size_{std::exchange(other.size_, 0)},
+                                                              alloc_{std::move(other.alloc_)} {
+        }
+
+        BasicConstString &operator=(BasicConstString const &) = delete;
+
+        BasicConstString &operator=(BasicConstString &&other) noexcept {
+            assert(this != &other);
+
+            drop();
+            data_ = std::exchange(other.data_, nullptr);
+            size_ = std::exchange(other.size_, 0);
+            alloc_ = std::move(other.alloc_);
+
+            return *this;
+        }
+
+        ~BasicConstString() noexcept {
+            drop();
+        }
+
+        [[nodiscard]] value_type const *data() const noexcept {
+            return data_;
+        }
+
+        [[nodiscard]] size_type size() const noexcept {
+            return size_;
+        }
+
+        operator std::string_view() const noexcept {
+            return std::string_view{data_, size_};
+        }
+    };
+
+    using ConstString = BasicConstString<char>;
+
+} // namespace rdf4cpp::rdf::storage::node::reference_node_storage
+
+#endif // RDF4CPP_REFERENCENODESTORAGE_CONSTSTRING_HPP

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/detail/ConstString.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/detail/ConstString.hpp
@@ -5,6 +5,10 @@
 
 namespace rdf4cpp::rdf::storage::node::reference_node_storage::detail {
 
+    /**
+     * A constant-size (i.e. non-growing), heap-allocated string type
+     * Behaves like std::string except that it cannot grow and therefore occupies 1 less word in memory (it has no capacity field).
+     */
     template<typename Char, typename Traits = std::char_traits<Char>, typename Allocator = std::allocator<Char>>
     struct BasicConstString {
         using value_type = Char;

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/detail/ConstString.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/detail/ConstString.hpp
@@ -12,8 +12,8 @@ namespace rdf4cpp::rdf::storage::node::reference_node_storage::detail {
         using allocator_type = Allocator;
         using size_type = size_t;
         using different_type = std::ptrdiff_t;
-        using pointer = std::allocator_traits<allocator_type>::pointer;
-        using const_pointer = std::allocator_traits<allocator_type>::const_pointer;
+        using pointer = typename std::allocator_traits<allocator_type>::pointer;
+        using const_pointer = typename std::allocator_traits<allocator_type>::const_pointer;
 
     private:
         pointer data_;

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/detail/IndexFreeList.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/detail/IndexFreeList.hpp
@@ -1,0 +1,143 @@
+#ifndef RDF4CPP_RDF_REFERENCENODESTORAGE_INDEXFREELIST_HPP
+#define RDF4CPP_RDF_REFERENCENODESTORAGE_INDEXFREELIST_HPP
+
+#include <cstddef>
+#include <ranges>
+#include <vector>
+
+namespace rdf4cpp::rdf::storage::node::reference_node_storage::detail {
+/**
+ * A freelist for indices inside a vector.
+ *
+ * @tparam BitmapType type used for the freelist elements
+ * @tparam Allocator allocator
+ */
+template<typename BitmapType = size_t, typename Allocator = std::allocator<size_t>>
+struct IndexFreeList {
+    using bitmap_type = BitmapType;
+    using allocator_type = Allocator;
+    using size_type = size_t;
+    using difference_type = ptrdiff_t;
+
+private:
+    static constexpr size_t bitmap_bits = sizeof(bitmap_type) * 8;
+
+    size_t next_free_ix_; //< bit index to the next free bit
+    std::vector<bitmap_type, allocator_type> occupied_bitmap_; //< nth bit of the allocation stores if slot n is occupied
+
+    /**
+     * Decomposes a bit index into slot index and bit offset
+     */
+    static constexpr std::pair<size_type, size_type> decompose(size_type const bit_ix) noexcept {
+        return std::make_pair(bit_ix / bitmap_bits, bit_ix % bitmap_bits);
+    }
+
+    /**
+     * Composes slot index and bit offset into a bit index
+     */
+    static constexpr size_type compose(size_type const slot_ix, size_type const offset) noexcept {
+        return (slot_ix * 64) + offset;
+    }
+
+    /**
+     * Sets the bit at slot_ix, offset to 1
+     */
+    void set_bit(size_type const slot_ix, size_type const offset) noexcept {
+        occupied_bitmap_[slot_ix] |= 1ul << offset;
+    }
+
+    /**
+     * Sets the bit at slot_ix, offset to 0
+     */
+    void unset_bit(size_type const slot_ix, size_type const offset) noexcept {
+        occupied_bitmap_[slot_ix] &= ~(1ul << offset);
+    }
+
+    /**
+     * Searches the next free bit after the given slot_ix, offset pair
+     *
+     * @param slot_ix slot index
+     * @param offset bit offset into slot
+     * @return index of the next free bit
+     */
+    [[nodiscard]] size_type search_next_free(size_type slot_ix, size_type const offset) const noexcept {
+        size_type new_offset = std::countr_one(occupied_bitmap_[slot_ix]);
+        assert(new_offset > offset);
+
+        if (new_offset < bitmap_bits) {
+            return compose(slot_ix, new_offset);
+        }
+
+        slot_ix += 1;
+        while (slot_ix < occupied_bitmap_.size()) {
+            new_offset = std::countr_one(occupied_bitmap_[slot_ix]);
+            if (new_offset < bitmap_bits) {
+                return compose(slot_ix, new_offset);
+            }
+
+            slot_ix += 1;
+        }
+
+        return compose(occupied_bitmap_.size(), 0);
+    }
+
+public:
+    explicit IndexFreeList(allocator_type const &alloc = allocator_type{}) noexcept : next_free_ix_{0},
+                                                                                      occupied_bitmap_{alloc} {
+    }
+
+    /**
+     * Requests the removal of unused capacity
+     */
+    void shrink_to_fit() {
+        auto const last_occupied = std::find_if(occupied_bitmap_.rbegin(), occupied_bitmap_.rend(), [](auto const bitmap) noexcept {
+            return bitmap != 0;
+        });
+
+        auto const unused_size = std::distance(occupied_bitmap_.rbegin(), last_occupied);
+        occupied_bitmap_.resize(occupied_bitmap_.size() - unused_size);
+    }
+
+    /**
+     * Marks all slots up-to (not-including) the given index as occupied
+     */
+    void occupy_until(size_type const ix) {
+        auto const [slot_ix, offset] = decompose(ix);
+        if (slot_ix >= occupied_bitmap_.size()) {
+            occupied_bitmap_.resize(0);
+            occupied_bitmap_.resize(slot_ix + 1, std::numeric_limits<bitmap_type>::max());
+        }
+
+        occupied_bitmap_[slot_ix] = (1ul << offset) - 1;
+        next_free_ix_ = ix;
+    }
+
+    /**
+     * Searches the next non-occupied index and returns it, while also marking it as occupied.
+     */
+    [[nodiscard]] size_type occupy_next_available() {
+        auto const [slot_ix, offset] = decompose(next_free_ix_);
+        if (slot_ix >= occupied_bitmap_.size()) {
+            occupied_bitmap_.push_back(0);
+        }
+
+        set_bit(slot_ix, offset);
+        return std::exchange(next_free_ix_, search_next_free(slot_ix, offset));
+    }
+
+    /**
+     * Marks index ix as not occupied
+     */
+    void vacate(size_type const ix) noexcept {
+        auto const [slot_ix, offset] = decompose(ix);
+        unset_bit(slot_ix, offset);
+
+        if (ix < next_free_ix_) {
+            next_free_ix_ = ix;
+        }
+    }
+};
+
+} // namespace rdf4cpp::rdf::storage::node::reference_node_storage::detail
+
+#endif // RDF4CPP_RDF_REFERENCENODESTORAGE_INDEXFREELIST_HPP

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/detail/SpecializationDetail.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/detail/SpecializationDetail.hpp
@@ -15,8 +15,8 @@ constexpr Acc tuple_type_fold_impl(std::index_sequence<Ixs...>, Acc init, FoldF 
 }
 
 template<typename Tuple, typename Acc, typename FoldF, size_t ...Ixs>
-constexpr Acc tuple_fold_impl(std::index_sequence<Ixs...>, Tuple const &tuple, Acc init, FoldF f) noexcept {
-    ((init = f(std::move(init), std::get<Ixs>(tuple))), ...);
+constexpr Acc tuple_fold_impl(std::index_sequence<Ixs...>, Tuple &&tuple, Acc init, FoldF f) noexcept {
+    ((init = f(std::move(init), std::get<Ixs>(std::forward<Tuple>(tuple)))), ...);
     return init;
 }
 
@@ -26,8 +26,8 @@ constexpr Acc tuple_type_fold(Acc &&init, FoldF &&f) noexcept {
 }
 
 template<typename Tuple, typename Acc, typename FoldF>
-constexpr Acc tuple_fold(Tuple const &tuple, Acc &&init, FoldF &&f) noexcept {
-    return tuple_fold_impl(std::make_index_sequence<std::tuple_size_v<Tuple>>{}, tuple, std::forward<Acc>(init), std::forward<FoldF>(f));
+constexpr Acc tuple_fold(Tuple &&tuple, Acc &&init, FoldF &&f) noexcept {
+    return tuple_fold_impl(std::make_index_sequence<std::tuple_size_v<std::remove_cvref_t<Tuple>>>{}, std::forward<Tuple>(tuple), std::forward<Acc>(init), std::forward<FoldF>(f));
 }
 
 template<typename Tuple>

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/detail/SpecializationDetail.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/detail/SpecializationDetail.hpp
@@ -15,9 +15,19 @@ constexpr Acc tuple_type_fold_impl(std::index_sequence<Ixs...>, Acc init, FoldF 
 }
 
 template<typename Tuple, typename Acc, typename FoldF, size_t ...Ixs>
-constexpr Acc tuple_fold_impl(std::index_sequence<Ixs...>, Tuple &&tuple, Acc init, FoldF f) noexcept {
-    ((init = f(std::move(init), std::get<Ixs>(std::forward<Tuple>(tuple)))), ...);
+constexpr Acc tuple_fold_impl(std::index_sequence<Ixs...>, Tuple const &tuple, Acc init, FoldF f) noexcept {
+    ((init = f(std::move(init), std::get<Ixs>(tuple))), ...);
     return init;
+}
+
+template<typename Tuple, typename F, size_t ...Ixs>
+constexpr void tuple_for_each_impl(std::index_sequence<Ixs...>, Tuple &&tuple, F f) {
+    (f(std::get<Ixs>(std::forward<Tuple>(tuple))), ...);
+}
+
+template<typename Tuple, typename F, size_t ...Ixs>
+constexpr void tuple_type_for_each_impl(std::index_sequence<Ixs...>, F f) {
+    (f.template operator()<std::tuple_element_t<Ixs, Tuple>>(), ...);
 }
 
 template<typename Tuple, typename Acc, typename FoldF>
@@ -26,17 +36,26 @@ constexpr Acc tuple_type_fold(Acc &&init, FoldF &&f) noexcept {
 }
 
 template<typename Tuple, typename Acc, typename FoldF>
-constexpr Acc tuple_fold(Tuple &&tuple, Acc &&init, FoldF &&f) noexcept {
-    return tuple_fold_impl(std::make_index_sequence<std::tuple_size_v<std::remove_cvref_t<Tuple>>>{}, std::forward<Tuple>(tuple), std::forward<Acc>(init), std::forward<FoldF>(f));
+constexpr Acc tuple_fold(Tuple const &tuple, Acc &&init, FoldF &&f) noexcept {
+    return tuple_fold_impl(std::make_index_sequence<std::tuple_size_v<std::remove_cvref_t<Tuple>>>{}, tuple, std::forward<Acc>(init), std::forward<FoldF>(f));
+}
+
+template<typename Tuple, typename F>
+constexpr void tuple_for_each(Tuple &&tuple, F &&f) {
+    return tuple_for_each_impl(std::make_index_sequence<std::tuple_size_v<std::remove_cvref_t<Tuple>>>{}, std::forward<Tuple>(tuple), std::forward<F>(f));
+}
+
+template<typename Tuple, typename F>
+constexpr void tuple_type_for_each(F &&f) {
+    return tuple_type_for_each_impl<Tuple>(std::make_index_sequence<std::tuple_size_v<Tuple>>{}, std::forward<F>(f));
 }
 
 template<typename Tuple>
 static consteval std::array<bool, 1 << identifier::LiteralType::width> make_storage_specialization_lut() noexcept {
     std::array<bool, 1 << identifier::LiteralType::width> ret{};
 
-    tuple_type_fold<Tuple>(0, [&]<typename T>(auto acc) {
+    tuple_type_for_each<Tuple>([&]<typename T>() {
         ret[T::Backend::Type::fixed_id.to_underlying()] = true;
-        return acc;
     });
 
     return ret;

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/detail/SyncNodeTypeStorage.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/detail/SyncNodeTypeStorage.hpp
@@ -12,9 +12,9 @@ namespace rdf4cpp::rdf::storage::node::reference_node_storage {
  */
 template<typename BackendType_t>
 struct SyncNodeTypeStorage : UnsyncNodeTypeStorage<BackendType_t> {
-    using Base = UnsyncNodeTypeStorage<BackendType_t>;
-    using Backend = typename Base::Backend;
-    using BackendView = typename Base::BackendView;
+    using base_type = UnsyncNodeTypeStorage<BackendType_t>;
+    using backend_type = typename base_type::backend_type;
+    using backend_view_type = typename base_type::backend_view_type;
 
     std::shared_mutex mutable mutex;
 };

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/detail/SyncNodeTypeStorage.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/detail/SyncNodeTypeStorage.hpp
@@ -15,8 +15,6 @@ struct SyncNodeTypeStorage : UnsyncNodeTypeStorage<BackendType_t> {
     using Base = UnsyncNodeTypeStorage<BackendType_t>;
     using Backend = typename Base::Backend;
     using BackendView = typename Base::BackendView;
-    using BackendEqual = typename Base::BackendEqual;
-    using BackendHash = typename Base::BackendHash;
 
     std::shared_mutex mutable mutex;
 };

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/detail/UnsyncNodeTypeStorage.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/detail/UnsyncNodeTypeStorage.hpp
@@ -67,7 +67,7 @@ public:
     using backend_id_type = typename backend_type::id_type;
 
     /**
-     * Translates the given BackenId into a NodeID
+     * Translates the given backend_id_type into a NodeID
      */
     static identifier::NodeID to_node_id(backend_id_type const id, [[maybe_unused]] backend_view_type const &view) noexcept {
         if constexpr (requires { backend_type::to_node_id(id, view); }) {
@@ -77,6 +77,9 @@ public:
         }
     }
 
+    /**
+     * Translates the given NodeID into a backend_id_type
+     */
     static backend_id_type to_backend_id(identifier::NodeID const id) noexcept {
         if constexpr (requires { backend_type::to_backend_id(id); }) {
             return backend_type::to_backend_id(id);

--- a/src/rdf4cpp/rdf/storage/node/reference_node_storage/detail/UnsyncNodeTypeStorage.hpp
+++ b/src/rdf4cpp/rdf/storage/node/reference_node_storage/detail/UnsyncNodeTypeStorage.hpp
@@ -81,7 +81,7 @@ public:
         }
     }
 
-    BiDirFlatMap<BackendId, Backend, BackendView, BackendHash, BackendEqual> mapping;
+    detail::BiDirFlatMap<BackendId, Backend, BackendView, BackendHash, BackendEqual> mapping;
 };
 
 }  // namespace rdf4cpp::rdf::storage::node::reference_node_storage

--- a/src/rdf4cpp/rdf/storage/node/view/BNodeBackendView.hpp
+++ b/src/rdf4cpp/rdf/storage/node/view/BNodeBackendView.hpp
@@ -1,18 +1,16 @@
 #ifndef RDF4CPP_BNODEBACKENDHANDLE_HPP
 #define RDF4CPP_BNODEBACKENDHANDLE_HPP
 
-#include <string>
 #include <string_view>
+#include <optional>
 
-namespace rdf4cpp::rdf::bnode_mngt {
-struct WeakNodeScope;
-} // namespace rdf4cpp::rdf::bnode_mngt
+#include <rdf4cpp/rdf/bnode_mngt/WeakNodeScope.hpp>
 
 namespace rdf4cpp::rdf::storage::node::view {
 
 struct BNodeBackendView {
     std::string_view identifier;
-    rdf4cpp::rdf::bnode_mngt::WeakNodeScope const *scope;
+    std::optional<rdf4cpp::rdf::bnode_mngt::WeakNodeScope> scope;
 
     /**
      * N-Triples conform string representation.
@@ -20,8 +18,9 @@ struct BNodeBackendView {
      */
     [[nodiscard]] std::string n_string() const noexcept;
 
-    auto operator<=>(BNodeBackendView const &) const noexcept = default;
     [[nodiscard]] size_t hash() const noexcept;
+
+    auto operator<=>(BNodeBackendView const &other) const noexcept = default;
 };
 }  // namespace rdf4cpp::rdf::storage::node::view
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,7 +54,15 @@ target_link_libraries(tests_NodeStorage_lifetime
         doctest::doctest
         rdf4cpp
         )
-add_test(NAME tests_NodeStorage_lifetime COMMAND tests_Node)
+add_test(NAME tests_NodeStorage_lifetime COMMAND tests_NodeStorage_lifetime)
+
+add_executable(tests_NodeStorage_helper_types nodes/tests_NodeStorage_helper_types.cpp)
+target_link_libraries(tests_NodeStorage_helper_types
+        doctest::doctest
+        rdf4cpp
+)
+add_test(NAME tests_NodeStorage_helper_types COMMAND tests_NodeStorage_helper_types)
+
 
 # RDF Core Types
 add_executable(tests_String datatype/tests_String.cpp)

--- a/tests/nodes/tests_NodeStorage_helper_types.cpp
+++ b/tests/nodes/tests_NodeStorage_helper_types.cpp
@@ -1,0 +1,89 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+
+#include <doctest/doctest.h>
+#include <rdf4cpp/rdf.hpp>
+#include <rdf4cpp/rdf/storage/node/reference_node_storage/SyncReferenceNodeStorageBackend.hpp>
+
+TEST_SUITE("NodeStorage helper types") {
+    using namespace rdf4cpp::rdf::storage::node::reference_node_storage::detail;
+
+    TEST_CASE("IndexFreeList") {
+        IndexFreeList<> freelist;
+        CHECK_EQ(freelist.occupy_next_available(), 0);
+        CHECK_EQ(freelist.occupy_next_available(), 1);
+
+        freelist.occupy_until(2); // noop
+        CHECK_EQ(freelist.occupy_next_available(), 2);
+
+        freelist.occupy_until(64); // first word occupied
+        CHECK_EQ(freelist.occupy_next_available(), 64);
+
+        freelist.occupy_until(280); // occupy multiple words at once
+        CHECK_EQ(freelist.occupy_next_available(), 280);
+
+
+        freelist.vacate(0);
+        freelist.vacate(3);
+
+        CHECK_EQ(freelist.occupy_next_available(), 0);
+
+        freelist.vacate(4);
+        freelist.vacate(63);
+        freelist.vacate(64);
+        freelist.vacate(185);
+
+        CHECK_EQ(freelist.occupy_next_available(), 3);
+        CHECK_EQ(freelist.occupy_next_available(), 4);
+        CHECK_EQ(freelist.occupy_next_available(), 63);
+        CHECK_EQ(freelist.occupy_next_available(), 64);
+        CHECK_EQ(freelist.occupy_next_available(), 185);
+
+        freelist.shrink_to_fit();
+        CHECK_EQ(freelist.occupy_next_available(), 281);
+    }
+
+    TEST_CASE("integration test") {
+        using namespace rdf4cpp::rdf;
+        using namespace rdf4cpp::rdf::storage::node;
+
+        NodeStorage ns = NodeStorage::new_instance();
+
+        auto l1 = Literal::make_simple("Spherical Cow", ns);
+        auto l2 = Literal::make_simple("Spherical Cow", ns);
+
+        CHECK_EQ(l1, l2);
+        CHECK_EQ(l1.backend_handle(), l2.backend_handle());
+        CHECK_EQ(l1.backend_handle().node_id().literal_id().to_underlying(), 1);
+        CHECK_EQ(l1.lexical_form(), "Spherical Cow");
+        CHECK_EQ(l1.lexical_form(), "Spherical Cow");
+
+        auto l3 = Literal::make_simple("Hello World", ns);
+        CHECK_NE(l1, l3);
+        CHECK_NE(l2, l3);
+        CHECK_EQ(l3.backend_handle().node_id().literal_id().to_underlying(), 2);
+        CHECK_EQ(l3.lexical_form(), "Hello World");
+
+
+        CHECK(ns.erase_literal(l1.backend_handle().node_id()));
+
+        try {
+            auto dummy = ns.find_literal_backend_view(l1.backend_handle().node_id());
+            FAIL("Did not throw exception");
+        } catch (...) {
+            // expecting exception
+        }
+
+        auto l4 = Literal::make_simple("Hello World", ns);
+        CHECK_EQ(l3, l4);
+        CHECK_EQ(l3.backend_handle(), l4.backend_handle());
+        CHECK_EQ(l4.lexical_form(), "Hello World");
+
+        auto l5 = Literal::make_simple("Not yet named", ns);
+        CHECK_NE(l3, l5);
+        CHECK_EQ(l5.backend_handle().node_id().literal_id().to_underlying(), 1);
+        CHECK_EQ(l5.lexical_form(), "Not yet named");
+
+        auto l6 = Literal::make_typed_from_value<datatypes::xsd::Long>(std::numeric_limits<datatypes::xsd::Long::cpp_type>::max(), ns); // different storage
+        CHECK_EQ(l6.backend_handle().node_id().literal_id().to_underlying(), 1);
+    }
+}

--- a/tests/nodes/tests_NodeStorage_helper_types.cpp
+++ b/tests/nodes/tests_NodeStorage_helper_types.cpp
@@ -42,6 +42,22 @@ TEST_SUITE("NodeStorage helper types") {
         CHECK_EQ(freelist.occupy_next_available(), 281);
     }
 
+    TEST_CASE("fill up to populated slot") {
+        IndexFreeList<> freelist;
+        freelist.occupy_until(71);
+
+        for (size_t ix = 0; ix < 70; ++ix) {
+            freelist.vacate(ix);
+        }
+
+        // only slot 70 is now populated
+
+        CHECK_EQ(freelist.occupy_next_available(), 0);
+
+        freelist.occupy_until(70); // slots 0-69 (inclusive) populated (and 70 from before)
+        CHECK_EQ(freelist.occupy_next_available(), 71);
+    }
+
     TEST_CASE("integration test") {
         using namespace rdf4cpp::rdf;
         using namespace rdf4cpp::rdf::storage::node;

--- a/tests/nodes/tests_NodeStorage_lifetime.cpp
+++ b/tests/nodes/tests_NodeStorage_lifetime.cpp
@@ -175,7 +175,7 @@ TEST_SUITE("NodeStorage lifetime and ref counting") {
         ns.erase_iri(iri.backend_handle().node_id());
 
         identifier::NodeID iri_id2 = ns.find_or_make_id(view::IRIBackendView {.identifier = "https://hello.com"});
-        CHECK(iri.backend_handle().node_id() != iri_id2);
+        CHECK(iri.backend_handle().node_id() == iri_id2);
     }
 
     /* the following functions are by nature non-deterministic, but they at least _attempt_ to detect race-conditions */

--- a/tests/serializer/tests_Serialization.cpp
+++ b/tests/serializer/tests_Serialization.cpp
@@ -95,7 +95,7 @@ void check_basic_data(const std::string &i) {
 
 TEST_CASE("basic ntriple") {
     const std::string  d = write_basic_data<writer::OutputFormat::NTriples>();
-    CHECK(d == "<http://ex/sub> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://ex/obj> .\n<http://ex/sub> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> \"5\"^^<http://www.w3.org/2001/XMLSchema#int> .\n");
+    CHECK(d == "<http://ex/sub> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> \"5\"^^<http://www.w3.org/2001/XMLSchema#int> .\n<http://ex/sub> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://ex/obj> .\n");
     writer::StringWriter ser{};
     if (!get_graph().serialize(ser))
         FAIL("write failed");
@@ -115,7 +115,7 @@ TEST_CASE("basic nquad") {
 
 TEST_CASE("basic turtle") {
     const std::string d = write_basic_data<writer::OutputFormat::Turtle>();
-    CHECK(d == "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n<http://ex/sub> a <http://ex/obj> ,\n\"5\"^^xsd:int .\n");
+    CHECK(d == "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n<http://ex/sub> a \"5\"^^xsd:int ,\n<http://ex/obj> .\n");
     writer::StringWriter ser{};
     if (!get_graph().serialize_turtle(ser))
         FAIL("write failed");


### PR DESCRIPTION
This PR attempts to optimize node-storage size and access pattern.

Size is reduced by:
  - using a custom string type that does not store the capacity (minimal improvement, but storing the capacity is not necessary)
  - using a `std::vector` instead of `sparse_map` for the forward lookup direction (not sure how much this does)

Access pattern is improved by:
  - increased data locality achieved by flattening the forward access structure (lookup by id now takes 3 indirections instead of 5)