### PR TITLE
Fix: Node serialization segfault

### DIFF
--- a/src/rdf4cpp/BlankNode.cpp
+++ b/src/rdf4cpp/BlankNode.cpp
@@ -57,8 +57,7 @@ std::string_view BlankNode::identifier() const noexcept { return handle_.bnode_b
 
 bool BlankNode::serialize(writer::BufWriterParts const writer) const noexcept {
     if (null()) {
-        RDF4CPP_DETAIL_TRY_WRITE_STR("null");
-        return true;
+        return rdf4cpp::writer::write_str("null", writer);
     }
 
     auto const backend = handle_.bnode_backend();

--- a/src/rdf4cpp/BlankNode.cpp
+++ b/src/rdf4cpp/BlankNode.cpp
@@ -56,6 +56,11 @@ BlankNode BlankNode::find(std::string_view identifier, storage::DynNodeStoragePt
 std::string_view BlankNode::identifier() const noexcept { return handle_.bnode_backend().identifier; }
 
 bool BlankNode::serialize(writer::BufWriterParts const writer) const noexcept {
+    if (null()) {
+        RDF4CPP_DETAIL_TRY_WRITE_STR("null");
+        return true;
+    }
+
     auto const backend = handle_.bnode_backend();
 
     RDF4CPP_DETAIL_TRY_WRITE_STR("_:");

--- a/src/rdf4cpp/IRI.cpp
+++ b/src/rdf4cpp/IRI.cpp
@@ -107,8 +107,7 @@ IRI::operator datatypes::registry::DatatypeIDView() const noexcept {
 
 bool IRI::serialize(writer::BufWriterParts const writer) const noexcept {
     if (null()) {
-        RDF4CPP_DETAIL_TRY_WRITE_STR("null");
-        return true;
+        return rdf4cpp::writer::write_str("null", writer);
     }
 
     auto const backend = handle_.iri_backend();

--- a/src/rdf4cpp/IRI.cpp
+++ b/src/rdf4cpp/IRI.cpp
@@ -106,6 +106,11 @@ IRI::operator datatypes::registry::DatatypeIDView() const noexcept {
 }
 
 bool IRI::serialize(writer::BufWriterParts const writer) const noexcept {
+    if (null()) {
+        RDF4CPP_DETAIL_TRY_WRITE_STR("null");
+        return true;
+    }
+
     auto const backend = handle_.iri_backend();
 
     RDF4CPP_DETAIL_TRY_WRITE_STR("<");

--- a/src/rdf4cpp/Node.cpp
+++ b/src/rdf4cpp/Node.cpp
@@ -58,6 +58,10 @@ Node Node::try_get_in_node_storage(storage::DynNodeStoragePtr node_storage) cons
 }
 
 bool Node::serialize(writer::BufWriterParts const writer) const noexcept {
+    if (null()) {
+        return rdf4cpp::writer::write_str("null", writer);
+    }
+
     switch (handle_.type()) {
         [[likely]] case storage::identifier::RDFNodeType::IRI: {
             return IRI{handle_}.serialize(writer);

--- a/src/rdf4cpp/query/Variable.cpp
+++ b/src/rdf4cpp/query/Variable.cpp
@@ -67,8 +67,7 @@ std::string_view Variable::name() const {
 
 bool Variable::serialize(writer::BufWriterParts const writer) const noexcept {
     if (null()) {
-        RDF4CPP_DETAIL_TRY_WRITE_STR("null");
-        return true;
+        return rdf4cpp::writer::write_str("null", writer);
     }
 
     auto const backend = handle_.variable_backend();

--- a/src/rdf4cpp/query/Variable.cpp
+++ b/src/rdf4cpp/query/Variable.cpp
@@ -66,6 +66,11 @@ std::string_view Variable::name() const {
 }
 
 bool Variable::serialize(writer::BufWriterParts const writer) const noexcept {
+    if (null()) {
+        RDF4CPP_DETAIL_TRY_WRITE_STR("null");
+        return true;
+    }
+
     auto const backend = handle_.variable_backend();
 
     if (backend.is_anonymous) {

--- a/tests/serializer/tests_Serialize.cpp
+++ b/tests/serializer/tests_Serialize.cpp
@@ -32,20 +32,30 @@ TEST_SUITE("Serialize") {
             auto var = query::Variable::make_anonymous("y");
             run_ser_test(var);
         }
+
+        SUBCASE("null") {
+            run_ser_test(query::Variable());
+        }
     }
 
     TEST_CASE("Serialize IRI") {
         auto iri = IRI::make("http://url.com#some-iri");
         run_ser_test(iri);
+        run_ser_test(IRI());
     }
 
     TEST_CASE("Serialize BNode") {
         auto bnode = BlankNode::make("_:123abc");
         run_ser_test(bnode);
+        run_ser_test(BlankNode());
     }
 
     TEST_CASE("Serialize Literal") {
         using namespace rdf4cpp::datatypes;
+
+        SUBCASE("null") {
+            run_ser_test(Literal());
+        }
 
         SUBCASE("xsd:string") {
             auto lit = Literal::make_simple("simple");


### PR DESCRIPTION
something like `std::cout << IRI{};` would segfault, because serialization was missing null checks.
affected are `IRI`, `BlankNode`, `Variable` and `Node`