### PR TITLE
Fix: decimal inlining

### DIFF
--- a/src/rdf4cpp/BigDecimal.hpp
+++ b/src/rdf4cpp/BigDecimal.hpp
@@ -262,6 +262,13 @@ public:
      * converts this BigDecimal to its smallest internal representation.
      */
     constexpr void normalize() noexcept {
+        normalize(unscaled_value, exponent);
+    }
+
+    /**
+     * converts this BigDecimal to its smallest internal representation.
+     */
+    static constexpr void normalize(UnscaledValue_t &unscaled_value, Exponent_t &exponent) noexcept {
         while (exponent > 0 && unscaled_value % base == 0) {
             unscaled_value /= base;
             --exponent;

--- a/src/rdf4cpp/datatypes/xsd/Decimal.cpp
+++ b/src/rdf4cpp/datatypes/xsd/Decimal.cpp
@@ -179,7 +179,10 @@ template<>
 capabilities::Inlineable<xsd_decimal>::cpp_type capabilities::Inlineable<xsd_decimal>::from_inlined(storage::identifier::LiteralID inlined) noexcept {
     auto const data = util::unpack<InlinedDecimal>(inlined);
     assert(data.padding == 0);
-    return cpp_type{data.unscaled_value, data.exponent};
+
+    auto const unscaled_value = util::unpack_integral<int64_t, InlinedDecimal::unscaled_size>(data.unscaled_value);
+    auto const exponent = util::unpack_integral<uint32_t, InlinedDecimal::exponent_size>(data.exponent);
+    return cpp_type{unscaled_value, exponent};
 }
 #endif
 

--- a/src/rdf4cpp/datatypes/xsd/Decimal.cpp
+++ b/src/rdf4cpp/datatypes/xsd/Decimal.cpp
@@ -138,33 +138,47 @@ std::partial_ordering capabilities::Comparable<xsd_decimal>::compare(cpp_type co
 }
 
 struct __attribute__((__packed__)) InlinedDecimal {
-    static constexpr size_t EXPONENT_SIZE = 10;
-    static constexpr size_t UNSCALED_SIZE = storage::identifier::LiteralID::width - 10;
-    uint32_t exponent : EXPONENT_SIZE;
-    uint64_t unscaled_value : UNSCALED_SIZE;
-    uint64_t buffer : 64 - EXPONENT_SIZE - UNSCALED_SIZE = 0;
+    static constexpr size_t exponent_size = 10;
+    static constexpr size_t unscaled_size = storage::identifier::LiteralID::width - 10;
+
+    uint64_t unscaled_value : unscaled_size;
+    uint32_t exponent : exponent_size;
+    uint32_t padding : 64 - unscaled_size - exponent_size = 0;
 };
+static_assert(sizeof(InlinedDecimal) == sizeof(uint64_t));
+
 template<>
 std::optional<storage::identifier::LiteralID> capabilities::Inlineable<xsd_decimal>::try_into_inlined(cpp_type const &value) noexcept {
-    auto unscaled_value = value.get_unscaled_value();
-    if (auto const boundary = 1L << (storage::identifier::LiteralID::width - InlinedDecimal::UNSCALED_SIZE - 1); unscaled_value >= boundary || unscaled_value < -boundary) [[unlikely]] {
+    auto big_unscaled_value = value.get_unscaled_value();
+    auto exponent = value.get_exponent();
+
+    cpp_type::normalize(big_unscaled_value, exponent);
+
+    auto const unscaled_value = static_cast<int64_t>(big_unscaled_value);
+    if (big_unscaled_value != unscaled_value) {
+        // unscaled value > 64 bit, cannot fit
         return std::nullopt;
     }
 
-    auto uv = util::try_pack_integral<uint64_t, InlinedDecimal::UNSCALED_SIZE>(static_cast<int64_t>(unscaled_value));
-    if (!uv.has_value()) {
+    auto const unscaled_inlined = util::try_pack_integral<uint64_t, InlinedDecimal::unscaled_size>(unscaled_value);
+    if (!unscaled_inlined.has_value()) {
         return std::nullopt;
     }
-    auto ex = util::try_pack_integral<uint32_t, InlinedDecimal::EXPONENT_SIZE>(value.get_exponent());
-    if (!ex.has_value()) {
+
+    auto const exponent_inlined = util::try_pack_integral<uint32_t, InlinedDecimal::exponent_size>(exponent);
+    if (!exponent_inlined.has_value()) {
         return std::nullopt;
     }
-    return util::pack<storage::identifier::LiteralID>(InlinedDecimal{*ex, *uv});
+
+    InlinedDecimal const inlined{*unscaled_inlined, *exponent_inlined};
+    assert(inlined.padding == 0);
+    return util::pack<storage::identifier::LiteralID>(inlined);
 }
 
 template<>
 capabilities::Inlineable<xsd_decimal>::cpp_type capabilities::Inlineable<xsd_decimal>::from_inlined(storage::identifier::LiteralID inlined) noexcept {
-    auto data = util::unpack<InlinedDecimal>(inlined);
+    auto const data = util::unpack<InlinedDecimal>(inlined);
+    assert(data.padding == 0);
     return cpp_type{data.unscaled_value, data.exponent};
 }
 #endif

--- a/tests/datatype/tests_Decimal.cpp
+++ b/tests/datatype/tests_Decimal.cpp
@@ -158,6 +158,9 @@ TEST_CASE("decimal inlining sanity check") {
         auto const l = Literal::make_typed<Decimal>("4.2");
         CHECK(l.is_inlined());
         CHECK(static_cast<double>(l.value<Decimal>()) == 4.2);
+
+        auto const l2 = Literal::make_typed<Decimal>("-1.0");
+        CHECK_EQ(l2.value<Decimal>(), -1);
     }
 
     SUBCASE("normalization") {


### PR DESCRIPTION
Fixes 2 bugs with decimal inlining:
1. negative values were decoded incorrectly
2. decimals were not normalized, leading to different inlined representations for the same number

I basically rewrote the code from scratch, as a bonus I think its easier to understand now