### PR TITLE
Fix: reduce requirements for node storages

### DIFF
--- a/src/rdf4cpp/storage/NodeStorage.cpp
+++ b/src/rdf4cpp/storage/NodeStorage.cpp
@@ -1,16 +1,14 @@
-#include "NodeStorage.hpp"
-
+#include <rdf4cpp/storage/NodeStorage.hpp>
 #include <rdf4cpp/storage/reference_node_storage/SyncReferenceNodeStorage.hpp>
 
 namespace rdf4cpp::storage {
 
-#ifndef DOXYGEN_PARSER
-reference_node_storage::SyncReferenceNodeStorage default_node_storage_holder_;
-DynNodeStoragePtr default_node_storage{default_node_storage_holder_};
-#endif // DOXYGEN_PARSER
+namespace reference_node_storage {
+SyncReferenceNodeStorage default_instance{};
+} // reference_node_storage
 
-void reset_default_node_storage() noexcept {
-    default_node_storage = default_node_storage_holder_;
-}
+#ifndef DOXYGEN_PARSER
+DynNodeStoragePtr default_node_storage{reference_node_storage::default_instance};
+#endif // DOXYGEN_PARSER
 
 } // namespace rdf4cpp::storage

--- a/src/rdf4cpp/storage/reference_node_storage/SyncReferenceNodeStorage.hpp
+++ b/src/rdf4cpp/storage/reference_node_storage/SyncReferenceNodeStorage.hpp
@@ -74,8 +74,9 @@ public:
     bool erase_bnode(identifier::NodeBackendID id);
     bool erase_variable(identifier::NodeBackendID id);
 };
-
 static_assert(NodeStorage<SyncReferenceNodeStorage>);
+
+extern SyncReferenceNodeStorage default_instance;
 
 }  // namespace rdf4cpp::storage::reference_node_storage
 #endif  //RDF4CPP_SYNCREFERENCENODESTORAGE_HPP


### PR DESCRIPTION
Reduces the requirements for the `NodeStorage` concept down to the bare minimum that is necessary. This has the benefit that node storages have to implement less features to qualify as `NodeStorage`s.