### PR TITLE
regex replace fixes

### DIFF
--- a/private/rdf4cpp/regex/RegexReplacerImpl.cpp
+++ b/private/rdf4cpp/regex/RegexReplacerImpl.cpp
@@ -76,6 +76,10 @@ RegexReplacer::Impl::Impl(Regex::Impl const &regex, std::string_view const rewri
                                                                                       rewrite{regex.flags.contains(RegexFlag::Literal)
                                                                                                       ? rewrite
                                                                                                       : detail::translate_rewrite(rewrite)} {
+    std::string err{};
+    if (!this->regex->regex.CheckRewriteString(this->rewrite, &err)) {
+        throw RegexError(err);
+    }
 }
 
 void RegexReplacer::Impl::regex_replace(std::string &str) const noexcept {

--- a/private/rdf4cpp/regex/RegexReplacerImpl.cpp
+++ b/private/rdf4cpp/regex/RegexReplacerImpl.cpp
@@ -80,6 +80,9 @@ RegexReplacer::Impl::Impl(Regex::Impl const &regex, std::string_view const rewri
     if (!this->regex->regex.CheckRewriteString(this->rewrite, &err)) {
         throw RegexError(err);
     }
+    if (this->regex->regex_match("")) {
+        throw RegexError("replace matches empty string");
+    }
 }
 
 void RegexReplacer::Impl::regex_replace(std::string &str) const noexcept {

--- a/tests/nodes/tests_Literal.cpp
+++ b/tests/nodes/tests_Literal.cpp
@@ -779,6 +779,9 @@ TEST_CASE("Literal - misc functions") {
         CHECK_EQ(Literal::make_lang_tagged("abcd", "en").regex_replace("b"_xsd_string, "Z"_xsd_string), Literal::make_lang_tagged("aZcd", "en"));
         CHECK_EQ(Literal::make_lang_tagged("abcd", "en").regex_replace(Literal::make_lang_tagged("b", "en"), "Z"_xsd_string), Literal::make_lang_tagged("aZcd", "en"));
         CHECK(Literal::make_lang_tagged("abcd", "en").regex_replace(Literal::make_lang_tagged("b", "fr"), "Z"_xsd_string).null());
+
+        CHECK(("Hello 1 World"_xsd_string).regex_replace("[0-9]"_xsd_string, "Hello \\\\hgfhf World"_xsd_string) == "Hello Hello \\hgfhf World World"_xsd_string);
+        CHECK(("Hello 1 World"_xsd_string).regex_replace("[0-9]"_xsd_string, "Hello \\hgfhf World"_xsd_string) == Literal{});
     }
 
     SUBCASE("hashes") {

--- a/tests/nodes/tests_Literal.cpp
+++ b/tests/nodes/tests_Literal.cpp
@@ -768,9 +768,7 @@ TEST_CASE("Literal - misc functions") {
         CHECK_EQ(("AAAA"_xsd_string).regex_replace("A+?"_xsd_string, "b"_xsd_string), "bbbb"_xsd_string);
         CHECK_EQ(("darted"_xsd_string).regex_replace("^(.*?)d(.*)$"_xsd_string, "$1c$2"_xsd_string), "carted"_xsd_string);
 
-        // 'The expression fn:replace("abracadabra", ".*?", "$1") raises an error, because the pattern matches the zero-length string'
-        // TODO: figure out how implement correct behaviour here (currently returns ""^^xsd:string)
-        //CHECK(("abracadabra"_xsd_string).regex_replace(".*?"_xsd_string, "$1"_xsd_string).null());
+        CHECK(("abracadabra"_xsd_string).regex_replace(".*?"_xsd_string, "$1"_xsd_string).null());
 
         CHECK_EQ(("abcd"_xsd_string).as_regex_matches(".*"_xsd_string, "q"_xsd_string).ebv(), TriBool::False);
         CHECK(("Mr. B. Obama"_xsd_string).as_regex_matches("B. OBAMA"_xsd_string, "qi"_xsd_string).ebv());


### PR DESCRIPTION
close #141 
close #132 

```
In the absence of the q flag, a dynamic error is raised [[err:FORX0004](https://www.w3.org/TR/xpath-functions/#ERRFORX0004)] if the value of $replacement contains a backslash (\) character that is not part of a \\ pair, unless it is immediately followed by a dollar sign ($) character.
```