### PR TITLE
Fix: avoid default node storage access in `write_quad`

### DIFF
--- a/private/rdf4cpp/writer/WriteQuad.hpp
+++ b/private/rdf4cpp/writer/WriteQuad.hpp
@@ -41,7 +41,7 @@ bool write_pred(Node const pred, writer::BufWriterParts const writer) {
 
 [[nodiscard]] inline bool is_default_graph(Node const &graph) noexcept {
     auto const g = graph.as_iri();
-    return !g.null() && g.is_default_graph();
+    return g.is_default_graph();
 }
 
 template<writer::OutputFormat F, typename Q>

--- a/private/rdf4cpp/writer/WriteQuad.hpp
+++ b/private/rdf4cpp/writer/WriteQuad.hpp
@@ -39,6 +39,11 @@ bool write_pred(Node const pred, writer::BufWriterParts const writer) {
         return false;                       \
     }
 
+[[nodiscard]] inline bool is_default_graph(Node const &graph) noexcept {
+    auto const g = graph.as_iri();
+    return !g.null() && g.is_default_graph();
+}
+
 template<writer::OutputFormat F, typename Q>
 bool write_quad(Q const &s, writer::BufWriterParts const writer, writer::SerializationState *const state) noexcept {
     if constexpr (writer::format_has_prefix<F>) {
@@ -48,7 +53,7 @@ bool write_quad(Q const &s, writer::BufWriterParts const writer, writer::Seriali
                     return false;
                 }
 
-                if (s.graph() != IRI::default_graph()) {
+                if (!is_default_graph(s.graph())) {
                     RDF4CPP_DETAIL_TRY_WRITE_NODE(s.graph());
                     RDF4CPP_DETAIL_TRY_WRITE_STR(" {\n");
 

--- a/src/rdf4cpp/IRI.cpp
+++ b/src/rdf4cpp/IRI.cpp
@@ -140,8 +140,17 @@ bool IRI::is_iri() const noexcept { return true; }
 
 
 IRI IRI::default_graph(storage::DynNodeStoragePtr node_storage) {
-    return IRI::make_unchecked("", node_storage);
+    auto const id = datatypes::registry::reserved_datatype_ids[datatypes::registry::default_graph_iri];
+    return IRI{storage::identifier::NodeBackendHandle{storage::identifier::literal_type_to_iri_node_id(id),
+               node_storage}};
 }
+
+bool IRI::is_default_graph() const noexcept {
+    auto const expected_id = datatypes::registry::reserved_datatype_ids[datatypes::registry::default_graph_iri];
+    auto const this_id = storage::identifier::iri_node_id_to_literal_type(backend_handle().id());
+    return this_id == expected_id;
+}
+
 std::ostream &operator<<(std::ostream &os, IRI const &iri) {
     writer::BufOStreamWriter w{os};
     iri.serialize(w);

--- a/src/rdf4cpp/IRI.hpp
+++ b/src/rdf4cpp/IRI.hpp
@@ -123,7 +123,12 @@ public:
      * @param node_storage  optional custom node_storage where the returned IRI lives
      * @return default graph IRI
      */
-    static IRI default_graph(storage::DynNodeStoragePtr node_storage = storage::default_node_storage);
+    [[nodiscard]] static IRI default_graph(storage::DynNodeStoragePtr node_storage = storage::default_node_storage);
+
+    /**
+     * @return if this IRI is the default graph IRI
+     */
+    [[nodiscard]] bool is_default_graph() const noexcept;
 };
 
 inline namespace shorthands {


### PR DESCRIPTION
Avoid default node storage access in `write_quad`