### PR TITLE
Fix: avoid default node storage access in `write_quad` 2

### DIFF
--- a/private/rdf4cpp/writer/WriteQuad.hpp
+++ b/private/rdf4cpp/writer/WriteQuad.hpp
@@ -94,7 +94,7 @@ bool write_quad(Q const &s, writer::BufWriterParts const writer, writer::Seriali
 
     if constexpr (!writer::format_has_prefix<F>) {
         if constexpr (writer::format_has_graph<F>) {
-            if (is_default_graph(s.graph())) {
+            if (!is_default_graph(s.graph())) {
                 RDF4CPP_DETAIL_TRY_WRITE_STR(" ");
                 RDF4CPP_DETAIL_TRY_WRITE_NODE(s.graph());
             }

--- a/private/rdf4cpp/writer/WriteQuad.hpp
+++ b/private/rdf4cpp/writer/WriteQuad.hpp
@@ -94,7 +94,7 @@ bool write_quad(Q const &s, writer::BufWriterParts const writer, writer::Seriali
 
     if constexpr (!writer::format_has_prefix<F>) {
         if constexpr (writer::format_has_graph<F>) {
-            if (s.graph() != IRI::default_graph()) {
+            if (is_default_graph(s.graph())) {
                 RDF4CPP_DETAIL_TRY_WRITE_STR(" ");
                 RDF4CPP_DETAIL_TRY_WRITE_NODE(s.graph());
             }


### PR DESCRIPTION
Overlooked another default graph comparison