### PR TITLE
Fix: serd buffer overread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ set(serd_source_files
         src/try.h
         src/uri.c
         src/uri_utils.h
+        src/warnings.h
         src/writer.c
 )
 set(style_files
@@ -58,7 +59,7 @@ set(style_files
 )
 
 foreach(serd_source_file ${serd_source_files})
-    file(DOWNLOAD "https://raw.githubusercontent.com/dice-group/serd/4352d002c55322fbc1a8baca6b0af6afa0142f5b/${serd_source_file}"
+    file(DOWNLOAD "https://raw.githubusercontent.com/dice-group/serd/58a35eb5a4b2b117b252895f1f11e7c0ebe2c15c/${serd_source_file}"
             "${CMAKE_CURRENT_BINARY_DIR}/serd/${serd_source_file}"
             TLS_VERIFY ON)
 endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,10 +158,10 @@ target_include_directories(
         rdf4cpp
         PUBLIC
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>"
-        "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/serd/include>"
-        "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/serd/src>"
         PRIVATE
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/private>"
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/serd/include>"
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/serd/src>"
 )
 
 target_link_libraries(rdf4cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(dice-template-library REQUIRED)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/version.hpp.in ${CMAKE_CURRENT_SOURCE_DIR}/src/rdf4cpp/version.hpp)
 
+set(serd_rev ea27f19617d039a9b37c87e799b18a7fac101389)
 set(serd_source_files
         include/serd/serd.h
         src/attributes.h
@@ -59,11 +60,11 @@ set(style_files
 )
 
 foreach(serd_source_file ${serd_source_files})
-    file(DOWNLOAD "https://raw.githubusercontent.com/dice-group/serd/58a35eb5a4b2b117b252895f1f11e7c0ebe2c15c/${serd_source_file}"
+    file(DOWNLOAD "https://raw.githubusercontent.com/dice-group/serd/${serd_rev}/${serd_source_file}"
             "${CMAKE_CURRENT_BINARY_DIR}/serd/${serd_source_file}"
             TLS_VERIFY ON)
 endforeach()
-file(DOWNLOAD "https://raw.githubusercontent.com/dice-group/serd/4352d002c55322fbc1a8baca6b0af6afa0142f5b/COPYING"
+file(DOWNLOAD "https://raw.githubusercontent.com/dice-group/serd/${serd_rev}/COPYING"
         "${CMAKE_CURRENT_BINARY_DIR}/serd/COPYING"
         TLS_VERIFY ON)
 foreach(style_file ${style_files})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,10 +157,10 @@ target_include_directories(
         rdf4cpp
         PUBLIC
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>"
-        PRIVATE
-        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/private>"
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/serd/include>"
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/serd/src>"
+        PRIVATE
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/private>"
 )
 
 target_link_libraries(rdf4cpp

--- a/private/rdf4cpp/parser/IStreamQuadIteratorSerdImpl.cpp
+++ b/private/rdf4cpp/parser/IStreamQuadIteratorSerdImpl.cpp
@@ -336,7 +336,10 @@ std::optional<nonstd::expected<IStreamQuadIterator::ok_type, IStreamQuadIterator
             // handle error from last time
             if (this->last_error_requires_skip) {
                 this->last_error_requires_skip = false;
-                serd_reader_skip_until_byte(this->reader, '\n');
+                if (serd_reader_skip_until_byte(this->reader, '\n') != SERD_SUCCESS) {
+                    // EOF reached
+                    this->end_flag = true;
+                }
             }
             return nonstd::make_unexpected(*std::exchange(this->last_error, std::nullopt));
         } else if (this->end_flag) {

--- a/tests/parser/tests_IStreamQuadIterator.cpp
+++ b/tests/parser/tests_IStreamQuadIterator.cpp
@@ -6,7 +6,6 @@
 
 #include <iostream>
 
-#include <serd/serd.h>
 
 using namespace rdf4cpp;
 using namespace rdf4cpp::parser;

--- a/tests/parser/tests_IStreamQuadIterator.cpp
+++ b/tests/parser/tests_IStreamQuadIterator.cpp
@@ -620,6 +620,7 @@ TEST_SUITE("IStreamQuadIterator") {
         stream->read(buffer, static_cast<std::streamsize>(count));
         auto const bytes_written = stream->gcount();
 
+        // zero the rest of the buffer to ensure serd will not read the same bytes from before again
         memset(buffer + bytes_written, 0, count - bytes_written);
         return bytes_written;
     }
@@ -668,23 +669,48 @@ TEST_SUITE("IStreamQuadIterator") {
         };
 
         SUBCASE("less than one chunk") {
-            run_overread(100);
+            SUBCASE("mitigated") {
+                run_overread(100, true);
+            }
+            SUBCASE("vulnerable") {
+                run_overread(100, false);
+            }
         }
 
         SUBCASE("exactly one chunk") {
-            run_overread(4096);
+            SUBCASE("mitigated") {
+                run_overread(4096, true);
+            }
+            SUBCASE("vulnerable") {
+                run_overread(4096, false);
+            };
         }
 
         SUBCASE("slightly more than a chunk") {
-            run_overread(4096 + 100);
+            SUBCASE("mitigated") {
+                run_overread(4096 + 100, true);
+            }
+            SUBCASE("vulnerable") {
+                run_overread(4096 + 100, false);
+            }
         }
 
         SUBCASE("exactly two chunks") {
-            run_overread(4096 * 2);
+            SUBCASE("mitigated") {
+                run_overread(4096 * 2, true);
+            }
+            SUBCASE("vulnerable") {
+                run_overread(4096 * 2, false);
+            }
         }
 
         SUBCASE("slightly more than two chunks") {
-            run_overread(4096 * 2 + 100);
+            SUBCASE("mitigated") {
+                run_overread(4096 * 2 + 100, true);
+            }
+            SUBCASE("vulnerable") {
+                run_overread(4096 * 2 + 100, false);
+            }
         }
     }
 }


### PR DESCRIPTION
Updates serd to resolve a buffer overread when reading rdf files without a newline at the end.

While this issue is not yet resolved in serd. I've implemented a mitigation in our serd fork that should hopefully fix the issue (https://github.com/dice-group/serd/commit/ea27f19617d039a9b37c87e799b18a7fac101389)