### PR TITLE
Feature: `ReferenceNodeScope::clear`

### DIFF
--- a/src/rdf4cpp/bnode_mngt/reference_backends/scope/ReferenceNodeScope.hpp
+++ b/src/rdf4cpp/bnode_mngt/reference_backends/scope/ReferenceNodeScope.hpp
@@ -77,6 +77,16 @@ public:
         handle_to_label_.emplace(it->second, it->first);
         return node;
     }
+
+    /**
+     * Clear the mappings from this scope
+     * @note does not delete nodes from node storage
+     */
+    void clear() noexcept {
+        std::unique_lock lock{mutex_};
+        label_to_handle_.clear();
+        handle_to_label_.clear();
+    }
 };
 static_assert(NodeScope<ReferenceNodeScope<>>);
 

--- a/tests/util/tests_BlankNodeIdManagement.cpp
+++ b/tests/util/tests_BlankNodeIdManagement.cpp
@@ -75,6 +75,12 @@ TEST_SUITE("blank node id management") {
             auto fresh = scope.generate_node();
             CHECK(fresh != b1);
             CHECK(fresh != b2);
+
+            scope.clear();
+            CHECK(scope.try_get_node("abc").null());
+            CHECK(scope.try_get_node("bcd").null());
+            CHECK_FALSE(scope.try_get_label(b1).has_value());
+            CHECK_FALSE(scope.try_get_label(b2).has_value());
         }
 
         ReferenceNodeScope<> mng2;


### PR DESCRIPTION
Adds a clear function to the reference bnode scope