### PR TITLE
Fix: crash on invalid lang str

### DIFF
--- a/src/rdf4cpp/Literal.cpp
+++ b/src/rdf4cpp/Literal.cpp
@@ -198,8 +198,7 @@ Literal Literal::make_typed(std::string_view lexical_form, IRI const &datatype, 
 
     if (datatype_identifier == datatypes::rdf::LangString::datatype_id) {
         // see: https://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal
-        throw std::invalid_argument{
-                "cannot construct rdf:langString without a language tag, please call one of the other factory functions"};
+        throw InvalidNode{"cannot construct rdf:langString without a language tag, please call one of the other factory functions"};
     }
 
     if (datatype_identifier == datatypes::xsd::String::datatype_id) {

--- a/tests/parser/tests_IStreamQuadIterator.cpp
+++ b/tests/parser/tests_IStreamQuadIterator.cpp
@@ -661,4 +661,14 @@ TEST_SUITE("IStreamQuadIterator") {
             run_overread(4096 * 2 + 100);
         }
     }
+
+    TEST_CASE("lang tagged literal in datatype style") {
+        std::istringstream iss{R"(<http://a.com#s> <http://a.com#p> "AA"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#langString> .)"};
+        IStreamQuadIterator qit{iss};
+
+        for (; qit != std::default_sentinel; ++qit) {
+            REQUIRE(!qit->has_value());
+            CHECK_EQ(qit->error().error_type, ParsingError::Type::BadLiteral);
+        }
+    }
 }


### PR DESCRIPTION
Fixes a bug where applications would unexpectedly crash when they encounted a lang string in "typed"-form `"AAA"^^rdf:langString`.

The issue was the wrong exception type being raised, which was subsequently not caught.
