### PR TITLE
Fix: node comparisons

### DIFF
--- a/examples/literal_datatypes.cpp
+++ b/examples/literal_datatypes.cpp
@@ -69,7 +69,7 @@ void comparisons() {
     assert(lit1 < lit2);
     assert(lit1 == lit3);
     assert(lit2 > lit3);
-    assert(lit1.compare_with_extensions(lit3) == std::partial_ordering::less);
+    assert(lit1.order(lit3) == std::partial_ordering::less);
 }
 
 int main() {

--- a/src/rdf4cpp/Literal.cpp
+++ b/src/rdf4cpp/Literal.cpp
@@ -1103,26 +1103,31 @@ Literal Literal::numeric_unop_impl(OpSelect op_select, storage::DynNodeStoragePt
     return Literal::make_typed_unchecked(std::move(*op_res.result_value), op_res.result_type_id, *result_entry, node_storage);
 }
 
+
+
 std::partial_ordering Literal::compare_impl(Literal const &other, std::strong_ordering *out_alternative_ordering) const noexcept {
     using datatypes::registry::DatatypeRegistry;
-
-    if (this->handle_ == other.handle_) {
-        return std::partial_ordering::equivalent;
-    }
 
     if (this->handle_.null() || other.handle_.null()) {
         if (out_alternative_ordering != nullptr) {
             // ordering extensions (for e.g. ORDER BY) require that null nodes
             // are always the smallest node
-            *out_alternative_ordering = this->handle_.null()
+            if (this->handle_.null() && other.handle_.null()) {
+                *out_alternative_ordering = std::strong_ordering::equivalent;
+            } else {
+                *out_alternative_ordering = this->handle_.null()
                                                 ? std::strong_ordering::less
                                                 : std::strong_ordering::greater;
+            }
         }
 
-        // TODO is an error or false?
-        // unbound == bound   => err ?
-        // unbount == unbound => err ?
+        // "Apart from BOUND, COALESCE, NOT EXISTS and EXISTS, all functions and operators operate on RDF Terms and will produce a type error if any arguments are unbound."
+        // - https://www.w3.org/TR/sparql11-query/#evaluation
         return std::partial_ordering::unordered;
+    }
+
+    if (this->handle_ == other.handle_) {
+        return std::partial_ordering::equivalent;
     }
 
     auto const this_datatype = this->datatype_id();

--- a/src/rdf4cpp/Literal.cpp
+++ b/src/rdf4cpp/Literal.cpp
@@ -1118,6 +1118,10 @@ std::partial_ordering Literal::compare_impl(Literal const &other, std::strong_or
                                                 ? std::strong_ordering::less
                                                 : std::strong_ordering::greater;
         }
+
+        // TODO is an error or false?
+        // unbound == bound   => err ?
+        // unbount == unbound => err ?
         return std::partial_ordering::unordered;
     }
 

--- a/src/rdf4cpp/Literal.cpp
+++ b/src/rdf4cpp/Literal.cpp
@@ -1179,11 +1179,7 @@ std::partial_ordering Literal::compare(Literal const &other) const noexcept {
     return this->compare_impl(other);
 }
 
-std::partial_ordering Literal::operator<=>(Literal const &other) const noexcept {
-    return this->compare(other);
-}
-
-std::weak_ordering Literal::compare_with_extensions(Literal const &other) const noexcept {
+std::weak_ordering Literal::order(Literal const &other) const noexcept {
     // default to equivalent; as required by compare_impl
     // see doc for compare_impl
     std::strong_ordering alternative_cmp_res = std::strong_ordering::equivalent;
@@ -1207,20 +1203,12 @@ Literal Literal::as_eq(Literal const &other, storage::DynNodeStoragePtr node_sto
     return Literal::make_boolean(this->eq(other), select_node_storage(node_storage));
 }
 
-TriBool Literal::operator==(Literal const &other) const noexcept {
-    return this->eq(other);
-}
-
 TriBool Literal::ne(Literal const &other) const noexcept {
     return !util::partial_weak_ordering_eq(this->compare(other), std::weak_ordering::equivalent);
 }
 
 Literal Literal::as_ne(Literal const &other, storage::DynNodeStoragePtr node_storage) const noexcept {
     return Literal::make_boolean(this->ne(other), select_node_storage(node_storage));
-}
-
-TriBool Literal::operator!=(Literal const &other) const noexcept {
-    return this->ne(other);
 }
 
 TriBool Literal::lt(Literal const &other) const noexcept {
@@ -1231,20 +1219,12 @@ Literal Literal::as_lt(Literal const &other, storage::DynNodeStoragePtr node_sto
     return Literal::make_boolean(this->lt(other), select_node_storage(node_storage));
 }
 
-TriBool Literal::operator<(Literal const &other) const noexcept {
-    return this->lt(other);
-}
-
 TriBool Literal::le(Literal const &other) const noexcept {
     return !util::partial_weak_ordering_eq(this->compare(other), std::weak_ordering::greater);
 }
 
 Literal Literal::as_le(Literal const &other, storage::DynNodeStoragePtr node_storage) const noexcept {
     return Literal::make_boolean(this->le(other), select_node_storage(node_storage));
-}
-
-TriBool Literal::operator<=(Literal const &other) const noexcept {
-    return this->le(other);
 }
 
 TriBool Literal::gt(Literal const &other) const noexcept {
@@ -1255,10 +1235,6 @@ Literal Literal::as_gt(Literal const &other, storage::DynNodeStoragePtr node_sto
     return Literal::make_boolean(this->gt(other), select_node_storage(node_storage));
 }
 
-TriBool Literal::operator>(Literal const &other) const noexcept {
-    return this->gt(other);
-}
-
 TriBool Literal::ge(Literal const &other) const noexcept {
     return !util::partial_weak_ordering_eq(this->compare(other), std::weak_ordering::less);
 }
@@ -1267,56 +1243,60 @@ Literal Literal::as_ge(Literal const &other, storage::DynNodeStoragePtr node_sto
     return Literal::make_boolean(this->ge(other), select_node_storage(node_storage));
 }
 
-TriBool Literal::operator>=(Literal const &other) const noexcept {
-    return this->ge(other);
+bool Literal::order_eq(Literal const &other) const noexcept {
+    return order(other) == std::weak_ordering::equivalent;
 }
 
-bool Literal::eq_with_extensions(Literal const &other) const noexcept {
-    return this->compare_with_extensions(other) == std::weak_ordering::equivalent;
+Literal Literal::as_order_eq(Literal const &other, storage::DynNodeStoragePtr node_storage) const noexcept {
+    return Literal::make_boolean(this->order_eq(other), select_node_storage(node_storage));
 }
 
-Literal Literal::as_eq_with_extensions(Literal const &other, storage::DynNodeStoragePtr node_storage) const noexcept {
-    return Literal::make_boolean(this->eq_with_extensions(other), select_node_storage(node_storage));
+bool Literal::order_ne(Literal const &other) const noexcept {
+    return order(other) != std::weak_ordering::equivalent;
 }
 
-bool Literal::ne_with_extensions(Literal const &other) const noexcept {
-    return this->compare_with_extensions(other) != std::weak_ordering::equivalent;
+Literal Literal::as_order_ne(Literal const &other, storage::DynNodeStoragePtr node_storage) const noexcept {
+    return Literal::make_boolean(this->order_ne(other), select_node_storage(node_storage));
 }
 
-Literal Literal::as_ne_with_extensions(Literal const &other, storage::DynNodeStoragePtr node_storage) const noexcept {
-    return Literal::make_boolean(this->ne_with_extensions(other), select_node_storage(node_storage));
+bool Literal::order_lt(Literal const &other) const noexcept {
+    return order(other) == std::weak_ordering::less;
 }
 
-bool Literal::lt_with_extensions(Literal const &other) const noexcept {
-    return this->compare_with_extensions(other) == std::weak_ordering::less;
+Literal Literal::as_order_lt(Literal const &other, storage::DynNodeStoragePtr node_storage) const noexcept {
+    return Literal::make_boolean(this->order_lt(other), select_node_storage(node_storage));
 }
 
-Literal Literal::as_lt_with_extensions(Literal const &other, storage::DynNodeStoragePtr node_storage) const noexcept {
-    return Literal::make_boolean(this->lt_with_extensions(other), select_node_storage(node_storage));
+bool Literal::order_le(Literal const &other) const noexcept {
+    return order(other) != std::weak_ordering::greater;
 }
 
-bool Literal::le_with_extensions(Literal const &other) const noexcept {
-    return this->compare_with_extensions(other) != std::weak_ordering::greater;
+Literal Literal::as_order_le(Literal const &other, storage::DynNodeStoragePtr node_storage) const noexcept {
+    return Literal::make_boolean(this->order_le(other), select_node_storage(node_storage));
 }
 
-Literal Literal::as_le_with_extensions(Literal const &other, storage::DynNodeStoragePtr node_storage) const noexcept {
-    return Literal::make_boolean(this->le_with_extensions(other), select_node_storage(node_storage));
+bool Literal::order_gt(Literal const &other) const noexcept {
+    return order(other) == std::weak_ordering::greater;
 }
 
-bool Literal::gt_with_extensions(Literal const &other) const noexcept {
-    return this->compare_with_extensions(other) == std::weak_ordering::greater;
+Literal Literal::as_order_gt(Literal const &other, storage::DynNodeStoragePtr node_storage) const noexcept {
+    return Literal::make_boolean(this->order_gt(other), select_node_storage(node_storage));
 }
 
-Literal Literal::as_gt_with_extensions(Literal const &other, storage::DynNodeStoragePtr node_storage) const noexcept {
-    return Literal::make_boolean(this->gt_with_extensions(other), select_node_storage(node_storage));
+bool Literal::order_ge(Literal const &other) const noexcept {
+    return order(other) != std::weak_ordering::less;
 }
 
-bool Literal::ge_with_extensions(Literal const &other) const noexcept {
-    return this->compare_with_extensions(other) != std::weak_ordering::less;
+Literal Literal::as_order_ge(Literal const &other, storage::DynNodeStoragePtr node_storage) const noexcept {
+    return Literal::make_boolean(this->order_ge(other), select_node_storage(node_storage));
 }
 
-Literal Literal::as_ge_with_extensions(Literal const &other, storage::DynNodeStoragePtr node_storage) const noexcept {
-    return Literal::make_boolean(this->ge_with_extensions(other), select_node_storage(node_storage));
+std::partial_ordering Literal::operator<=>(Literal const &other) const noexcept {
+    return compare(other);
+}
+
+bool Literal::operator==(Literal const &other) const noexcept {
+    return this->eq(other);
 }
 
 datatypes::registry::DatatypeIDView Literal::datatype_id() const noexcept {

--- a/src/rdf4cpp/Literal.hpp
+++ b/src/rdf4cpp/Literal.hpp
@@ -1540,6 +1540,25 @@ Literal operator""_xsd_long(unsigned long long int i);
 Literal operator""_xsd_ulong(unsigned long long int i);
 
 }  // namespace shorthands
+
+/**
+ * Less-than comparator for use of Literals in ordered container (e.g. std::set)
+ */
+struct LiteralOrderByLess {
+    bool operator()(Literal lhs, Literal rhs) const noexcept {
+        return lhs.order_lt(rhs);
+    }
+};
+
+/**
+ * Greater-than comparator for use of Literals in ordered container (e.g. std::set)
+ */
+struct LiteralOrderByGreater {
+    bool operator()(Literal lhs, Literal rhs) const noexcept {
+        return lhs.order_gt(rhs);
+    }
+};
+
 }  // namespace rdf4cpp
 
 template<>

--- a/src/rdf4cpp/Literal.hpp
+++ b/src/rdf4cpp/Literal.hpp
@@ -941,7 +941,9 @@ public:
     [[nodiscard]] bool is_numeric() const noexcept;
 
     /**
-     * The default literal comparison function for SPARQL filters (FILTER)
+     * The literal comparison function for SPARQL filters (FILTER).
+     * In contrast to Node we can provide a combined "compare" function
+     * here because in Literals the definitions of ==/!= and </<=/>/>= are not split.
      */
     [[nodiscard]] std::partial_ordering compare(Literal const &other) const noexcept;
 

--- a/src/rdf4cpp/Literal.hpp
+++ b/src/rdf4cpp/Literal.hpp
@@ -942,16 +942,19 @@ public:
 
     /**
      * The literal comparison function for SPARQL filters (FILTER).
-     * In contrast to Node we can provide a combined "compare" function
-     * here because in Literals the definitions of ==/!= and </<=/>/>= are not split.
+     * In contrast to Node, here we can provide a combined "compare" function
+     * here because for Literals the definitions of ==/!= and </<=/>/>= are not split in the SPARQL spec.
+     *
+     * https://www.w3.org/TR/sparql11-query/#OperatorMapping
      */
     [[nodiscard]] std::partial_ordering compare(Literal const &other) const noexcept;
 
     /**
      * The comparison function for SPARQL orderings (ORDER BY).
+     * For FILTER semantics use compare.
      *
      * @return similar to `compare` but:
-     *      - values of an incomparable type are all considered equivalent
+     *      - all values of an incomparable type are considered equivalent
      *      - a null literal is the smallest possible value of all types
      *      - the type ordering replaces the value ordering in the following cases
      *          - the values are equal

--- a/src/rdf4cpp/Literal.hpp
+++ b/src/rdf4cpp/Literal.hpp
@@ -192,15 +192,6 @@ private:
     template<bool simplified, typename C>
     auto serialize_lexical_form_impl(C &&consume) const noexcept;
 
-
-    [[nodiscard]] storage::DynNodeStoragePtr select_node_storage(storage::DynNodeStoragePtr node_storage) const noexcept {
-        if (node_storage == keep_node_storage) {
-            return handle_.storage();
-        } else {
-            return node_storage;
-        }
-    }
-
     explicit Literal(storage::identifier::NodeBackendHandle handle) noexcept;
 
 public:
@@ -950,20 +941,12 @@ public:
     [[nodiscard]] bool is_numeric() const noexcept;
 
     /**
-     * The default (value-only) comparison function
-     * without SPARQL operator extensions.
-     *
-     * @return the value ordering of this and other
+     * The default literal comparison function for SPARQL filters (FILTER)
      */
     [[nodiscard]] std::partial_ordering compare(Literal const &other) const noexcept;
 
     /**
-     * A convenient (and equivalent) alternative to compare.
-     */
-    std::partial_ordering operator<=>(Literal const &other) const noexcept;
-
-    /**
-     * The comparison function with SPARQL operator extensions.
+     * The comparison function for SPARQL orderings (ORDER BY).
      *
      * @return similar to `compare` but:
      *      - values of an incomparable type are all considered equivalent
@@ -973,44 +956,43 @@ public:
      *          - at least one of the value's types is not comparable
      *          - there is no viable conversion to a common type to check for equality
      */
-    [[nodiscard]] std::weak_ordering compare_with_extensions(Literal const &other) const noexcept;
+    [[nodiscard]] std::weak_ordering order(Literal const &other) const noexcept;
 
     [[nodiscard]] TriBool eq(Literal const &other) const noexcept;
-    [[nodiscard]] Literal as_eq(Literal const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
-    TriBool operator==(Literal const &other) const noexcept;
-
+    [[nodiscard]] bool order_eq(Literal const &other) const noexcept;
     [[nodiscard]] TriBool ne(Literal const &other) const noexcept;
-    [[nodiscard]] Literal as_ne(Literal const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
-    TriBool operator!=(Literal const &other) const noexcept;
-
+    [[nodiscard]] bool order_ne(Literal const &other) const noexcept;
     [[nodiscard]] TriBool lt(Literal const &other) const noexcept;
-    [[nodiscard]] Literal as_lt(Literal const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
-    TriBool operator<(Literal const &other) const noexcept;
-
+    [[nodiscard]] bool order_lt(Literal const &other) const noexcept;
     [[nodiscard]] TriBool le(Literal const &other) const noexcept;
-    [[nodiscard]] Literal as_le(Literal const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
-    TriBool operator<=(Literal const &other) const noexcept;
-
+    [[nodiscard]] bool order_le(Literal const &other) const noexcept;
     [[nodiscard]] TriBool gt(Literal const &other) const noexcept;
-    [[nodiscard]] Literal as_gt(Literal const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
-    TriBool operator>(Literal const &other) const noexcept;
-
+    [[nodiscard]] bool order_gt(Literal const &other) const noexcept;
     [[nodiscard]] TriBool ge(Literal const &other) const noexcept;
-    [[nodiscard]] Literal as_ge(Literal const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
-    TriBool operator>=(Literal const &other) const noexcept;
+    [[nodiscard]] bool order_ge(Literal const &other) const noexcept;
 
-    [[nodiscard]] bool eq_with_extensions(Literal const &other) const noexcept;
-    [[nodiscard]] Literal as_eq_with_extensions(Literal const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
-    [[nodiscard]] bool ne_with_extensions(Literal const &other) const noexcept;
-    [[nodiscard]] Literal as_ne_with_extensions(Literal const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
-    [[nodiscard]] bool lt_with_extensions(Literal const &other) const noexcept;
-    [[nodiscard]] Literal as_lt_with_extensions(Literal const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
-    [[nodiscard]] bool le_with_extensions(Literal const &other) const noexcept;
-    [[nodiscard]] Literal as_le_with_extensions(Literal const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
-    [[nodiscard]] bool gt_with_extensions(Literal const &other) const noexcept;
-    [[nodiscard]] Literal as_gt_with_extensions(Literal const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
-    [[nodiscard]] bool ge_with_extensions(Literal const &other) const noexcept;
-    [[nodiscard]] Literal as_ge_with_extensions(Literal const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
+    [[nodiscard]] Literal as_eq(Literal const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
+    [[nodiscard]] Literal as_order_eq(Literal const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
+    [[nodiscard]] Literal as_ne(Literal const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
+    [[nodiscard]] Literal as_order_ne(Literal const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
+    [[nodiscard]] Literal as_lt(Literal const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
+    [[nodiscard]] Literal as_order_lt(Literal const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
+    [[nodiscard]] Literal as_le(Literal const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
+    [[nodiscard]] Literal as_order_le(Literal const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
+    [[nodiscard]] Literal as_gt(Literal const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
+    [[nodiscard]] Literal as_order_gt(Literal const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
+    [[nodiscard]] Literal as_ge(Literal const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
+    [[nodiscard]] Literal as_order_ge(Literal const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
+
+    /**
+     * Equivalent to this->compare(other)
+     */
+    std::partial_ordering operator<=>(Literal const &other) const noexcept;
+
+    /**
+     * Equivalent to this->eq(other)
+     */
+    bool operator==(Literal const &other) const noexcept;
 
     [[nodiscard]] Literal add(Literal const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const;
     Literal operator+(Literal const &other) const;

--- a/src/rdf4cpp/Node.cpp
+++ b/src/rdf4cpp/Node.cpp
@@ -120,15 +120,6 @@ bool Node::is_inlined() const noexcept {
     return handle_.is_inlined();
 }
 
-template<typename T>
-[[nodiscard]] static std::partial_ordering eq_else_unordered(T const &a, T const &b) noexcept {
-    if (a == b) {
-        return std::partial_ordering::equivalent;
-    }
-
-    return std::partial_ordering::unordered;
-}
-
 std::partial_ordering Node::compare(Node const &other) const noexcept{
     if (handle_ == other.handle_) {
         return std::partial_ordering::equivalent;
@@ -151,13 +142,13 @@ std::partial_ordering Node::compare(Node const &other) const noexcept{
             return Literal{handle_}.compare(Literal{other.handle_});
         }
         case RDFNodeType::IRI: {
-            return eq_else_unordered(handle_.iri_backend(), other.handle_.iri_backend());
+            return handle_.iri_backend() <=> other.handle_.iri_backend();
         }
         case RDFNodeType::BNode: {
-            return eq_else_unordered(handle_.bnode_backend(), other.handle_.bnode_backend());
+            return handle_.bnode_backend() <=> other.handle_.bnode_backend();
         }
         case RDFNodeType::Variable: {
-            return eq_else_unordered(handle_.variable_backend(), other.handle_.variable_backend());
+            return handle_.variable_backend() <=> other.handle_.variable_backend();
         }
         default: {
             assert(false); // unreachable

--- a/src/rdf4cpp/Node.cpp
+++ b/src/rdf4cpp/Node.cpp
@@ -278,11 +278,11 @@ Literal Node::as_order_ge(Node const &other, storage::DynNodeStoragePtr node_sto
 }
 
 std::partial_ordering Node::operator<=>(Node const &other) const noexcept {
-    return compare(other);
+    return order(other);
 }
 
 bool Node::operator==(const Node &other) const noexcept {
-    return eq(other);
+    return order_eq(other);
 }
 
 BlankNode Node::as_blank_node() const noexcept {

--- a/src/rdf4cpp/Node.cpp
+++ b/src/rdf4cpp/Node.cpp
@@ -190,10 +190,6 @@ std::weak_ordering Node::order(Node const &other) const noexcept {
         return std::weak_ordering::greater;
     }
 
-    if (this->handle_ == other.handle_) {
-        return std::weak_ordering::equivalent;
-    }
-
     // different type
     if (std::strong_ordering const type_comp = this->handle_.type() <=> other.handle_.type(); type_comp != std::strong_ordering::equivalent){
         return type_comp;

--- a/src/rdf4cpp/Node.cpp
+++ b/src/rdf4cpp/Node.cpp
@@ -129,9 +129,11 @@ TriBool Node::eq_impl(Node const &other) const noexcept {
         return TriBool::Err;
     }
 
-    if (null()) {
-        assert(!other.null()); // otherwise handle_ would equal other.handle (handled above)
-        return TriBool::False;
+    if (null() || other.null()) {
+        // TODO is an error or false?
+        // unbound == bound   => err ?
+        // unbount == unbound => err ?
+        return TriBool::Err;
     }
 
     using storage::identifier::RDFNodeType;
@@ -164,13 +166,6 @@ std::partial_ordering Node::compare_impl(Node const &other) const noexcept{
         // mismatched node types are not comparable
         // and nodes other than literals are not comparable with <,<=,>,>=
         return std::partial_ordering::unordered;
-    }
-
-    // unbound
-    if (null()) {
-        return std::partial_ordering::less;
-    } else if (other.null()) {
-        return std::partial_ordering::greater;
     }
 
     return Literal{handle_}.compare(Literal{other.handle_});

--- a/src/rdf4cpp/Node.hpp
+++ b/src/rdf4cpp/Node.hpp
@@ -185,6 +185,17 @@ public:
      */
     [[nodiscard]] bool is_inlined() const noexcept;
 
+
+    /**
+     * Due to the split definition of ==/!= and </<=/>/>= in SPARQL
+     * we cannot provide a "compare" function for FILTER semantics.
+     * Specifically, in SPARQL IRIs,BlankNodes and Variables are comparable via == and !=, but not
+     * via <,<=,>,>=.
+     *
+     * https://www.w3.org/TR/sparql11-query/#OperatorMapping
+     */
+    // [[nodiscard]] std::partial_ordering compare(Node const &other) const noexcept;
+
     /**
      * The comparison function for SPARQL orderings (ORDER BY).
      *

--- a/src/rdf4cpp/Node.hpp
+++ b/src/rdf4cpp/Node.hpp
@@ -204,12 +204,12 @@ public:
     [[nodiscard]] Literal as_order_ge(Node const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
 
     /**
-     * Equivalent to this->eq(other)
+     * Equivalent to this->order_eq(other)
      */
     bool operator==(const Node &other) const noexcept;
 
     /**
-     * Equivalent to this->compare(other)
+     * Equivalent to this->order(other)
      */
     std::partial_ordering operator<=>(Node const &other) const noexcept;
 

--- a/src/rdf4cpp/Node.hpp
+++ b/src/rdf4cpp/Node.hpp
@@ -11,11 +11,12 @@
 #include <string>
 
 namespace rdf4cpp {
+
 struct Literal;
 struct BlankNode;
 struct IRI;
 namespace query {
-struct Variable;
+    struct Variable;
 } // namespace rdf4cpp
 
 /**
@@ -83,6 +84,14 @@ inline constexpr storage::DynNodeStoragePtr keep_node_storage{nullptr};
 struct Node {
 protected:
     storage::identifier::NodeBackendHandle handle_;
+
+    [[nodiscard]] storage::DynNodeStoragePtr select_node_storage(storage::DynNodeStoragePtr node_storage) const noexcept {
+        if (node_storage == keep_node_storage) {
+            return handle_.storage();
+        } else {
+            return node_storage;
+        }
+    }
 
 public:
     explicit Node(storage::identifier::NodeBackendHandle id) noexcept;
@@ -165,9 +174,44 @@ public:
      */
     [[nodiscard]] bool is_inlined() const noexcept;
 
+    [[nodiscard]] std::partial_ordering compare(Node const &other) const noexcept;
+    [[nodiscard]] std::weak_ordering order(Node const &other) const noexcept;
+
+    [[nodiscard]] TriBool eq(Node const &other) const noexcept;
+    [[nodiscard]] bool order_eq(Node const &other) const noexcept;
+    [[nodiscard]] TriBool ne(Node const &other) const noexcept;
+    [[nodiscard]] bool order_ne(Node const &other) const noexcept;
+    [[nodiscard]] TriBool lt(Node const &other) const noexcept;
+    [[nodiscard]] bool order_lt(Node const &other) const noexcept;
+    [[nodiscard]] TriBool le(Node const &other) const noexcept;
+    [[nodiscard]] bool order_le(Node const &other) const noexcept;
+    [[nodiscard]] TriBool gt(Node const &other) const noexcept;
+    [[nodiscard]] bool order_gt(Node const &other) const noexcept;
+    [[nodiscard]] TriBool ge(Node const &other) const noexcept;
+    [[nodiscard]] bool order_ge(Node const &other) const noexcept;
+
+    [[nodiscard]] Literal as_eq(Node const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
+    [[nodiscard]] Literal as_order_eq(Node const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
+    [[nodiscard]] Literal as_ne(Node const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
+    [[nodiscard]] Literal as_order_ne(Node const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
+    [[nodiscard]] Literal as_lt(Node const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
+    [[nodiscard]] Literal as_order_lt(Node const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
+    [[nodiscard]] Literal as_le(Node const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
+    [[nodiscard]] Literal as_order_le(Node const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
+    [[nodiscard]] Literal as_gt(Node const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
+    [[nodiscard]] Literal as_order_gt(Node const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
+    [[nodiscard]] Literal as_ge(Node const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
+    [[nodiscard]] Literal as_order_ge(Node const &other, storage::DynNodeStoragePtr node_storage = keep_node_storage) const noexcept;
+
+    /**
+     * Equivalent to this->eq(other)
+     */
     bool operator==(const Node &other) const noexcept;
 
-    std::weak_ordering operator<=>(const Node &other) const noexcept;
+    /**
+     * Equivalent to this->compare(other)
+     */
+    std::partial_ordering operator<=>(Node const &other) const noexcept;
 
     /**
      * @return the effective boolean value of this
@@ -231,6 +275,19 @@ public:
 
 static_assert(sizeof(Node) == sizeof(void *) * 3);
 static_assert(alignof(Node) == alignof(void *));
+
+
+struct OrderByLess {
+    bool operator()(Node lhs, Node rhs) const noexcept {
+        return lhs.order_lt(rhs);
+    }
+};
+
+struct OrderByGreater {
+    bool operator()(Node lhs, Node rhs) const noexcept {
+      return lhs.order_gt(rhs);
+    }
+};
 
 }  // namespace rdf4cpp
 

--- a/src/rdf4cpp/Node.hpp
+++ b/src/rdf4cpp/Node.hpp
@@ -93,6 +93,17 @@ protected:
         }
     }
 
+    /**
+     * Implementation for eq() and ne()
+     */
+    [[nodiscard]] TriBool eq_impl(Node const &other) const noexcept;
+
+    /**
+     * Implementation for lt(), gt(), le(), ge()
+     * Do not use for eq() or ne()
+     */
+    [[nodiscard]] std::partial_ordering compare_impl(Node const &other) const noexcept;
+
 public:
     explicit Node(storage::identifier::NodeBackendHandle id) noexcept;
 
@@ -174,9 +185,22 @@ public:
      */
     [[nodiscard]] bool is_inlined() const noexcept;
 
-    [[nodiscard]] std::partial_ordering compare(Node const &other) const noexcept;
+    /**
+     * The comparison function for SPARQL orderings (ORDER BY).
+     *
+     * For FILTER semantics, use eq,ne,lt,le,gt,ge.
+     *
+     * The difference between this and FILTER semantics, is that here BlankNode, Variable, IRI are compared
+     * based on their string representation, and thus have an ordering.
+     * For Literals you can find information about the differences in Literal::order
+     */
     [[nodiscard]] std::weak_ordering order(Node const &other) const noexcept;
 
+    /**
+     * The equality function for SPARQL filters (FILTER).
+     * Due to the split definition of ==/!= and </<=/>/>= in SPARQL
+     * we cannot provide a "compare" function for FILTER semantics.
+     */
     [[nodiscard]] TriBool eq(Node const &other) const noexcept;
     [[nodiscard]] bool order_eq(Node const &other) const noexcept;
     [[nodiscard]] TriBool ne(Node const &other) const noexcept;

--- a/src/rdf4cpp/Node.hpp
+++ b/src/rdf4cpp/Node.hpp
@@ -276,19 +276,6 @@ public:
 static_assert(sizeof(Node) == sizeof(void *) * 3);
 static_assert(alignof(Node) == alignof(void *));
 
-
-struct OrderByLess {
-    bool operator()(Node lhs, Node rhs) const noexcept {
-        return lhs.order_lt(rhs);
-    }
-};
-
-struct OrderByGreater {
-    bool operator()(Node lhs, Node rhs) const noexcept {
-      return lhs.order_gt(rhs);
-    }
-};
-
 }  // namespace rdf4cpp
 
 template<>

--- a/tests/datatype/tests_time_types.cpp
+++ b/tests/datatype/tests_time_types.cpp
@@ -91,7 +91,7 @@ TEST_CASE("datatype gYear") {
     CHECK(Literal::make_typed<datatypes::xsd::GYear>("12-14:00").is_inlined());
     Literal n{};
     CHECK_THROWS_WITH_AS(n = Literal::make_typed<datatypes::xsd::GYear>("abc"), "http://www.w3.org/2001/XMLSchema#gYear parsing error: found a, invalid for datatype", InvalidNode);
-    CHECK(n == Literal{}); // turn off unused and nodiscard ignored warnings
+    CHECK(n.null()); // turn off unused and nodiscard ignored warnings
 }
 
 TEST_CASE("datatype gMonth") {
@@ -118,7 +118,7 @@ TEST_CASE("datatype gMonth") {
     CHECK_THROWS_WITH_AS(a = Literal::make_typed<datatypes::xsd::GMonth>("--00"), "http://www.w3.org/2001/XMLSchema#gMonth parsing error: 00 is invalid", InvalidNode);
     CHECK_THROWS_WITH_AS(a = Literal::make_typed<datatypes::xsd::GMonth>("00"), "http://www.w3.org/2001/XMLSchema#gMonth parsing error: missing gMonth prefix", InvalidNode);
     CHECK_THROWS_AS(a = Literal::make_typed<datatypes::xsd::GMonth>("--13"), InvalidNode);
-    CHECK(a == Literal{}); // turn off unused and nodiscard ignored warnings
+    CHECK(a.null()); // turn off unused and nodiscard ignored warnings
 }
 
 TEST_CASE("datatype gDay") {
@@ -143,7 +143,7 @@ TEST_CASE("datatype gDay") {
     CHECK_THROWS_WITH_AS(a = Literal::make_typed<datatypes::xsd::GDay>("---00"), "http://www.w3.org/2001/XMLSchema#gDay parsing error: 00 is invalid", InvalidNode);
     CHECK_THROWS_WITH_AS(a = Literal::make_typed<datatypes::xsd::GDay>("-00"), "http://www.w3.org/2001/XMLSchema#gDay parsing error: missing gDay prexfix", InvalidNode);
     CHECK_THROWS_AS(a = Literal::make_typed<datatypes::xsd::GDay>("---32"), InvalidNode);
-    CHECK(a == Literal{}); // turn off unused and nodiscard ignored warnings
+    CHECK(a.null()); // turn off unused and nodiscard ignored warnings
 }
 
 TEST_CASE("datatype gYearMonth") {
@@ -173,7 +173,7 @@ TEST_CASE("datatype gYearMonth") {
     CHECK_THROWS_AS(a = Literal::make_typed<datatypes::xsd::GYearMonth>("-32768-01"), InvalidNode);
     CHECK_THROWS_AS(a = Literal::make_typed<datatypes::xsd::GYearMonth>("32767-32"), InvalidNode);
     CHECK_THROWS_AS(a = Literal::make_typed<datatypes::xsd::GYearMonth>("32768-30"), InvalidNode);
-    CHECK(a == Literal{}); // turn off unused and nodiscard ignored warnings
+    CHECK(a.null()); // turn off unused and nodiscard ignored warnings
 }
 
 TEST_CASE("datatype gMonthDay") {
@@ -202,7 +202,7 @@ TEST_CASE("datatype gMonthDay") {
     CHECK_THROWS_AS(a = Literal::make_typed<datatypes::xsd::GMonthDay>("--12-32"), InvalidNode);
     CHECK_THROWS_AS(a = Literal::make_typed<datatypes::xsd::GMonthDay>("--13-30"), InvalidNode);
     CHECK_THROWS_AS(a = Literal::make_typed<datatypes::xsd::GMonthDay>("--02-30"), InvalidNode);
-    CHECK(a == Literal{}); // turn off unused and nodiscard ignored warnings
+    CHECK(a.null()); // turn off unused and nodiscard ignored warnings
 }
 
 TEST_CASE("datatype date") {
@@ -235,7 +235,7 @@ TEST_CASE("datatype date") {
     CHECK_THROWS_WITH_AS(a = Literal::make_typed<datatypes::xsd::Date>("2042-02-30"), "http://www.w3.org/2001/XMLSchema#date parsing error: 2042-02-30 is invalid", InvalidNode);
     CHECK_THROWS_WITH_AS(a = Literal::make_typed<datatypes::xsd::Date>("1937-0-0"), "http://www.w3.org/2001/XMLSchema#date parsing error: 1937-00-00 is invalid", InvalidNode);
     CHECK_THROWS_WITH_AS(a = Literal::make_typed<datatypes::xsd::Date>("1937-1-1+18:00"), "http://www.w3.org/2001/XMLSchema#date parsing error: timezone offset too big", InvalidNode);
-    CHECK(a == Literal{}); // turn off unused and nodiscard ignored warnings
+    CHECK(a.null()); // turn off unused and nodiscard ignored warnings
 }
 
 TEST_CASE("datatype time") {
@@ -267,7 +267,7 @@ TEST_CASE("datatype time") {
     CHECK_THROWS_AS(a = Literal::make_typed<datatypes::xsd::Time>("00:00:-1.000"), InvalidNode);
     CHECK_THROWS_AS(a = Literal::make_typed<datatypes::xsd::Time>("00:00:70.000"), InvalidNode);
     CHECK_THROWS_AS(a = Literal::make_typed<datatypes::xsd::Time>("00:00:5.-100"), InvalidNode);
-    CHECK(a == Literal{}); // turn off unused and nodiscard ignored warnings
+    CHECK(a.null()); // turn off unused and nodiscard ignored warnings
 }
 
 TEST_CASE("datatype dateTime") {
@@ -328,7 +328,7 @@ TEST_CASE("datatype dateTime") {
     CHECK_THROWS_AS(a = Literal::make_typed<datatypes::xsd::DateTime>("2042-12-32T00:00:00.000"), InvalidNode);
     CHECK_THROWS_AS(a = Literal::make_typed<datatypes::xsd::DateTime>("2042-13-30T00:00:00.000"), InvalidNode);
     CHECK_THROWS_AS(a = Literal::make_typed<datatypes::xsd::DateTime>("2042-02-30T00:00:00.000"), InvalidNode);
-    CHECK(a == Literal{}); // turn off unused and nodiscard ignored warnings
+    CHECK(a.null()); // turn off unused and nodiscard ignored warnings
     CHECK(Literal::make_typed<datatypes::xsd::DateTime>("2042-05-06T00:00:00.000") == Literal::make_typed<datatypes::xsd::DateTime>("2042-05-05T24:00:00"));
     CHECK(Literal::make_typed<datatypes::xsd::DateTime>("2042-05-05T24:00:00.000").lexical_form() == "2042-05-06T00:00:00");
 }
@@ -389,7 +389,7 @@ TEST_CASE("datatype dateTimeStamp") {
     CHECK_THROWS_AS(a = Literal::make_typed<datatypes::xsd::DateTimeStamp>("2042-02-24T00:00:00.000"), InvalidNode);
     CHECK_THROWS_AS(a = Literal::make_typed<datatypes::xsd::DateTimeStamp>("2042-02-24T00:00:00.000+20:00"), InvalidNode);
     CHECK_THROWS_AS(a = Literal::make_typed<datatypes::xsd::DateTimeStamp>("2042-02-24T00:00:00.000-20:00"), InvalidNode);
-    CHECK(a == Literal{});  // turn off unused and nodiscard ignored warnings
+    CHECK(a.null());  // turn off unused and nodiscard ignored warnings
     CHECK(Literal::make_typed<datatypes::xsd::DateTimeStamp>("2042-05-06T00:00:00.000Z") == Literal::make_typed<datatypes::xsd::DateTimeStamp>("2042-05-05T24:00:00Z"));
     CHECK(Literal::make_typed<datatypes::xsd::DateTimeStamp>("2042-05-05T24:00:00.000Z").lexical_form() == "2042-05-06T00:00:00Z");
 }
@@ -422,7 +422,7 @@ TEST_CASE("datatype duration") {
     CHECK_THROWS_WITH_AS(a = Literal::make_typed<datatypes::xsd::Duration>("P5M24Y"), "http://www.w3.org/2001/XMLSchema#duration parsing error: found M, invalid for datatype", InvalidNode);
     CHECK_THROWS_WITH_AS(a = Literal::make_typed<datatypes::xsd::Duration>("P5YABC"), "http://www.w3.org/2001/XMLSchema#duration parsing error: found ABC, expected empty", InvalidNode);
     CHECK_THROWS_WITH_AS(a = Literal::make_typed<datatypes::xsd::Duration>("-P5Y-3D"), "http://www.w3.org/2001/XMLSchema#duration parsing error: found -, invalid for datatype", InvalidNode);
-    CHECK(a == Literal{}); // turn off unused and nodiscard ignored warnings
+    CHECK(a.null()); // turn off unused and nodiscard ignored warnings
 
     basic_test<datatypes::xsd::Duration>("P1M", "P30D", std::partial_ordering::unordered);
     basic_test<datatypes::xsd::Duration>("P1M", "P2M", std::partial_ordering::less);
@@ -453,7 +453,7 @@ TEST_CASE("datatype dayTimeDuration") {
     CHECK_THROWS_WITH_AS(a = Literal::make_typed<datatypes::xsd::DayTimeDuration>("P5DABC"), "http://www.w3.org/2001/XMLSchema#dayTimeDuration parsing error: found ABC, expected empty", InvalidNode);
     CHECK_THROWS_WITH_AS(a = Literal::make_typed<datatypes::xsd::DayTimeDuration>("P10Y"), "http://www.w3.org/2001/XMLSchema#dayTimeDuration parsing error: found 10Y, expected empty", InvalidNode);
     CHECK_THROWS_WITH_AS(a = Literal::make_typed<datatypes::xsd::DayTimeDuration>("P5M"), "http://www.w3.org/2001/XMLSchema#dayTimeDuration parsing error: found 5M, expected empty", InvalidNode);
-    CHECK(a == Literal{}); // turn off unused and nodiscard ignored warnings
+    CHECK(a.null()); // turn off unused and nodiscard ignored warnings
 
     basic_test<datatypes::xsd::DayTimeDuration>("PT1M", "PT30S", std::partial_ordering::greater);
     basic_test<datatypes::xsd::DayTimeDuration>("PT1M", "PT2M", std::partial_ordering::less);
@@ -479,7 +479,7 @@ TEST_CASE("datatype yearMonthDuration") {
     CHECK_THROWS_WITH_AS(a = Literal::make_typed<datatypes::xsd::YearMonthDuration>("P5YABC"), "http://www.w3.org/2001/XMLSchema#yearMonthDuration parsing error: found ABC, expected empty", InvalidNode);
     CHECK_THROWS_WITH_AS(a = Literal::make_typed<datatypes::xsd::YearMonthDuration>("PT10H"), "http://www.w3.org/2001/XMLSchema#yearMonthDuration parsing error: found T10H, expected empty", InvalidNode);
     CHECK_THROWS_WITH_AS(a = Literal::make_typed<datatypes::xsd::YearMonthDuration>("P5D"), "http://www.w3.org/2001/XMLSchema#yearMonthDuration parsing error: found 5D, expected empty", InvalidNode);
-    CHECK(a == Literal{}); // turn off unused and nodiscard ignored warnings
+    CHECK(a.null()); // turn off unused and nodiscard ignored warnings
 
     basic_test<datatypes::xsd::YearMonthDuration>("P1M", "P2M", std::partial_ordering::less);
     basic_test<datatypes::xsd::YearMonthDuration>("P1Y", "P1M", std::partial_ordering::greater);
@@ -512,8 +512,8 @@ TEST_CASE("Literal API") {
     CHECK(Literal::make_typed<datatypes::xsd::DateTimeStamp>("2042-5-6T1:2:3Z").as_year() == Literal::make_typed<datatypes::xsd::Integer>("2042"));
     CHECK(Literal::make_typed<datatypes::xsd::GYear>("2042").as_year() == Literal::make_typed<datatypes::xsd::Integer>("2042"));
     CHECK(Literal::make_typed<datatypes::xsd::GYearMonth>("2042-5").as_year() == Literal::make_typed<datatypes::xsd::Integer>("2042"));
-    CHECK(Literal::make_typed<datatypes::xsd::GDay>("---5").as_year() == Literal{});
-    CHECK(Literal::make_simple("5").as_year() == Literal{});
+    CHECK(Literal::make_typed<datatypes::xsd::GDay>("---5").as_year().null());
+    CHECK(Literal::make_simple("5").as_year().null());
 
     CHECK(Literal::make_typed<datatypes::xsd::Date>("2042-5-6").as_month() == Literal::make_typed<datatypes::xsd::Integer>("5"));
     CHECK(Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3").as_month() == Literal::make_typed<datatypes::xsd::Integer>("5"));
@@ -521,47 +521,47 @@ TEST_CASE("Literal API") {
     CHECK(Literal::make_typed<datatypes::xsd::GMonth>("--5").as_month() == Literal::make_typed<datatypes::xsd::Integer>("5"));
     CHECK(Literal::make_typed<datatypes::xsd::GMonthDay>("--5-6").as_month() == Literal::make_typed<datatypes::xsd::Integer>("5"));
     CHECK(Literal::make_typed<datatypes::xsd::GYearMonth>("2042-5").as_month() == Literal::make_typed<datatypes::xsd::Integer>("5"));
-    CHECK(Literal::make_typed<datatypes::xsd::GDay>("---5").as_month() == Literal{});
-    CHECK(Literal::make_simple("5").as_month() == Literal{});
+    CHECK(Literal::make_typed<datatypes::xsd::GDay>("---5").as_month().null());
+    CHECK(Literal::make_simple("5").as_month().null());
 
     CHECK(Literal::make_typed<datatypes::xsd::Date>("2042-5-6").as_day() == Literal::make_typed<datatypes::xsd::Integer>("6"));
     CHECK(Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3").as_day() == Literal::make_typed<datatypes::xsd::Integer>("6"));
     CHECK(Literal::make_typed<datatypes::xsd::DateTimeStamp>("2042-5-6T1:2:3Z").as_day() == Literal::make_typed<datatypes::xsd::Integer>("6"));
     CHECK(Literal::make_typed<datatypes::xsd::GDay>("---5").as_day() == Literal::make_typed<datatypes::xsd::Integer>("5"));
     CHECK(Literal::make_typed<datatypes::xsd::GMonthDay>("--5-6").as_day() == Literal::make_typed<datatypes::xsd::Integer>("6"));
-    CHECK(Literal::make_typed<datatypes::xsd::GMonth>("--5").as_day() == Literal{});
-    CHECK(Literal::make_simple("5").as_day() == Literal{});
+    CHECK(Literal::make_typed<datatypes::xsd::GMonth>("--5").as_day().null());
+    CHECK(Literal::make_simple("5").as_day().null());
 
     CHECK(Literal::make_typed<datatypes::xsd::Time>("1:2:3").as_hours() == Literal::make_typed<datatypes::xsd::Integer>("1"));
     CHECK(Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3+1:0").as_hours() == Literal::make_typed<datatypes::xsd::Integer>("1"));
     CHECK(Literal::make_typed<datatypes::xsd::DateTimeStamp>("2042-5-6T1:2:3+1:0").as_hours() == Literal::make_typed<datatypes::xsd::Integer>("1"));
-    CHECK(Literal::make_typed<datatypes::xsd::GMonth>("--5").as_hours() == Literal{});
-    CHECK(Literal::make_simple("5").as_hours() == Literal{});
+    CHECK(Literal::make_typed<datatypes::xsd::GMonth>("--5").as_hours().null());
+    CHECK(Literal::make_simple("5").as_hours().null());
 
     CHECK(Literal::make_typed<datatypes::xsd::Time>("1:2:3").as_minutes() == Literal::make_typed<datatypes::xsd::Integer>("2"));
     CHECK(Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3+1:0").as_minutes() == Literal::make_typed<datatypes::xsd::Integer>("2"));
     CHECK(Literal::make_typed<datatypes::xsd::DateTimeStamp>("2042-5-6T1:2:3+1:0").as_minutes() == Literal::make_typed<datatypes::xsd::Integer>("2"));
-    CHECK(Literal::make_typed<datatypes::xsd::GMonth>("--5").as_minutes() == Literal{});
-    CHECK(Literal::make_simple("5").as_minutes() == Literal{});
+    CHECK(Literal::make_typed<datatypes::xsd::GMonth>("--5").as_minutes().null());
+    CHECK(Literal::make_simple("5").as_minutes().null());
 
     CHECK(Literal::make_typed<datatypes::xsd::Time>("1:2:3").as_seconds() == Literal::make_typed<datatypes::xsd::Decimal>("3"));
     CHECK(Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3+1:0").as_seconds() == Literal::make_typed<datatypes::xsd::Decimal>("3"));
     CHECK(Literal::make_typed<datatypes::xsd::DateTimeStamp>("2042-5-6T1:2:3+1:0").as_seconds() == Literal::make_typed<datatypes::xsd::Decimal>("3"));
     CHECK(Literal::make_typed<datatypes::xsd::Time>("1:2:59.999").as_seconds() == Literal::make_typed<datatypes::xsd::Decimal>("59.999"));
-    CHECK(Literal::make_typed<datatypes::xsd::GMonth>("--5").as_seconds() == Literal{});
-    CHECK(Literal::make_simple("5").as_seconds() == Literal{});
+    CHECK(Literal::make_typed<datatypes::xsd::GMonth>("--5").as_seconds().null());
+    CHECK(Literal::make_simple("5").as_seconds().null());
 
     CHECK(Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3+1:0").as_timezone() == Literal::make_typed<datatypes::xsd::DayTimeDuration>("PT1H"));
     CHECK(Literal::make_typed<datatypes::xsd::DateTimeStamp>("2042-5-6T1:2:3Z").as_timezone() == Literal::make_typed<datatypes::xsd::DayTimeDuration>("PT0H"));
     CHECK(Literal::make_typed<datatypes::xsd::GDay>("---3+1:30").as_timezone() == Literal::make_typed<datatypes::xsd::DayTimeDuration>("PT1H30M"));
-    CHECK(Literal::make_typed<datatypes::xsd::GDay>("---3").as_timezone() == Literal{});
-    CHECK(Literal::make_simple("5").as_timezone() == Literal{});
+    CHECK(Literal::make_typed<datatypes::xsd::GDay>("---3").as_timezone().null());
+    CHECK(Literal::make_simple("5").as_timezone().null());
 
     CHECK(Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3+1:0").as_tz() == Literal::make_simple("+01:00"));
     CHECK(Literal::make_typed<datatypes::xsd::DateTimeStamp>("2042-5-6T1:2:3Z").as_tz() == Literal::make_simple("Z"));
     CHECK(Literal::make_typed<datatypes::xsd::GDay>("---3+1:30").as_tz() == Literal::make_simple("+01:30"));
     CHECK(Literal::make_typed<datatypes::xsd::GDay>("---3").as_tz() == Literal::make_simple(""));
-    CHECK(Literal::make_simple("5").as_tz() == Literal{});
+    CHECK(Literal::make_simple("5").as_tz().null());
 }
 
 TEST_CASE("arithmetic") {
@@ -577,7 +577,7 @@ TEST_CASE("arithmetic") {
     CHECK((Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3") - Literal::make_typed<datatypes::xsd::DateTime>("2042-5-5T1:2:3")) == Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1D"));
     CHECK((Literal::make_typed<datatypes::xsd::DateTimeStamp>("2042-5-6T1:2:3Z") - Literal::make_typed<datatypes::xsd::DateTimeStamp>("2042-5-7T1:2:3Z")) == Literal::make_typed<datatypes::xsd::DayTimeDuration>("-P1D"));
     CHECK((Literal::make_typed<datatypes::xsd::DateTimeStamp>("2042-5-6T1:2:3Z") - Literal::make_typed<datatypes::xsd::DateTimeStamp>("2042-5-6T1:2:3+10:00")) == Literal::make_typed<datatypes::xsd::DayTimeDuration>("PT10H"));
-    CHECK((Literal::make_typed_from_value<datatypes::xsd::DateTime>(std::make_pair(rdf4cpp::TimePoint{std::chrono::milliseconds{std::numeric_limits<int64_t>::min()}}, std::nullopt)) - Literal::make_typed<datatypes::xsd::DateTime>("2042-5-5T1:2:3")) == Literal{});
+    CHECK((Literal::make_typed_from_value<datatypes::xsd::DateTime>(std::make_pair(rdf4cpp::TimePoint{std::chrono::milliseconds{std::numeric_limits<int64_t>::min()}}, std::nullopt)) - Literal::make_typed<datatypes::xsd::DateTime>("2042-5-5T1:2:3")).null());
 
     CHECK((Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3") + Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1S")) == Literal::make_typed<datatypes::xsd::DateTime>("2042-5-7T1:2:4"));
     CHECK((Literal::make_typed<datatypes::xsd::DateTimeStamp>("2042-5-6T1:2:3Z") + Literal::make_typed<datatypes::xsd::DayTimeDuration>("-P1DT1S")) == Literal::make_typed<datatypes::xsd::DateTime>("2042-5-5T1:2:2Z"));
@@ -588,8 +588,8 @@ TEST_CASE("arithmetic") {
     CHECK((Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3") + Literal::make_typed<datatypes::xsd::Duration>("P1Y14MT5S")) == Literal::make_typed<datatypes::xsd::DateTime>("2044-7-6T1:2:8"));
     CHECK((Literal::make_typed<datatypes::xsd::Date>("2042-5-6") + Literal::make_typed<datatypes::xsd::YearMonthDuration>("P1Y")) == Literal::make_typed<datatypes::xsd::Date>("2043-5-6"));
     CHECK((Literal::make_typed<datatypes::xsd::Time>("1:2:3") + Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1S")) == Literal::make_typed<datatypes::xsd::Time>("1:2:4"));
-    CHECK((Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3") + Literal::make_typed_from_value<datatypes::xsd::YearMonthDuration>(std::chrono::months{std::numeric_limits<int64_t>::max()})) == Literal{});
-    CHECK((Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3") + Literal::make_typed_from_value<datatypes::xsd::DayTimeDuration>(std::chrono::milliseconds{std::numeric_limits<int64_t>::max()})) == Literal{});
+    CHECK((Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3") + Literal::make_typed_from_value<datatypes::xsd::YearMonthDuration>(std::chrono::months{std::numeric_limits<int64_t>::max()})).null());
+    CHECK((Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3") + Literal::make_typed_from_value<datatypes::xsd::DayTimeDuration>(std::chrono::milliseconds{std::numeric_limits<int64_t>::max()})).null());
 
     CHECK((Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3") - Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1S")) == Literal::make_typed<datatypes::xsd::DateTime>("2042-5-5T1:2:2"));
     CHECK((Literal::make_typed<datatypes::xsd::DateTimeStamp>("2042-5-6T1:2:3Z") - Literal::make_typed<datatypes::xsd::DayTimeDuration>("-P1DT1S")) == Literal::make_typed<datatypes::xsd::DateTime>("2042-5-7T1:2:4Z"));
@@ -597,24 +597,24 @@ TEST_CASE("arithmetic") {
     CHECK((Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3") - Literal::make_typed<datatypes::xsd::Duration>("P1Y2MT3S")) == Literal::make_typed<datatypes::xsd::DateTime>("2041-3-6T1:2:0"));
     CHECK((Literal::make_typed<datatypes::xsd::Date>("2042-5-6") - Literal::make_typed<datatypes::xsd::YearMonthDuration>("P1Y")) == Literal::make_typed<datatypes::xsd::Date>("2041-5-6"));
     CHECK((Literal::make_typed<datatypes::xsd::Time>("1:2:3") - Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1S")) == Literal::make_typed<datatypes::xsd::Time>("1:2:2"));
-    CHECK((Literal::make_typed<datatypes::xsd::DateTime>("-2042-5-6T1:2:3") - Literal::make_typed_from_value<datatypes::xsd::YearMonthDuration>(std::chrono::months{std::numeric_limits<int64_t>::max()})) == Literal{});
-    CHECK((Literal::make_typed<datatypes::xsd::DateTime>("-2042-5-6T1:2:3") - Literal::make_typed_from_value<datatypes::xsd::DayTimeDuration>(std::chrono::milliseconds{std::numeric_limits<int64_t>::max()})) == Literal{});
+    CHECK((Literal::make_typed<datatypes::xsd::DateTime>("-2042-5-6T1:2:3") - Literal::make_typed_from_value<datatypes::xsd::YearMonthDuration>(std::chrono::months{std::numeric_limits<int64_t>::max()})).null());
+    CHECK((Literal::make_typed<datatypes::xsd::DateTime>("-2042-5-6T1:2:3") - Literal::make_typed_from_value<datatypes::xsd::DayTimeDuration>(std::chrono::milliseconds{std::numeric_limits<int64_t>::max()})).null());
 
     CHECK((Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1S") + Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1H")) == Literal::make_typed<datatypes::xsd::DayTimeDuration>("P2DT1H1S"));
     CHECK((Literal::make_typed<datatypes::xsd::YearMonthDuration>("P1Y") + Literal::make_typed<datatypes::xsd::YearMonthDuration>("P1Y2M")) == Literal::make_typed<datatypes::xsd::YearMonthDuration>("P2Y2M"));
-    CHECK((Literal::make_typed_from_value<datatypes::xsd::DayTimeDuration>(std::chrono::milliseconds{std::numeric_limits<int64_t>::max()}) + Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1H")) == Literal{});
-    CHECK((Literal::make_typed_from_value<datatypes::xsd::YearMonthDuration>(std::chrono::months{std::numeric_limits<int64_t>::max()}) + Literal::make_typed<datatypes::xsd::YearMonthDuration>("P1Y2M")) == Literal{});
+    CHECK((Literal::make_typed_from_value<datatypes::xsd::DayTimeDuration>(std::chrono::milliseconds{std::numeric_limits<int64_t>::max()}) + Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1H")).null());
+    CHECK((Literal::make_typed_from_value<datatypes::xsd::YearMonthDuration>(std::chrono::months{std::numeric_limits<int64_t>::max()}) + Literal::make_typed<datatypes::xsd::YearMonthDuration>("P1Y2M")).null());
     CHECK((Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1M") - Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1S")) == Literal::make_typed<datatypes::xsd::DayTimeDuration>("PT59S"));
     CHECK((Literal::make_typed<datatypes::xsd::YearMonthDuration>("P1Y") - Literal::make_typed<datatypes::xsd::YearMonthDuration>("P2Y")) == Literal::make_typed<datatypes::xsd::YearMonthDuration>("-P1Y"));
 
     CHECK((Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1S") * Literal::make_typed<datatypes::xsd::Double>("2")) == Literal::make_typed<datatypes::xsd::DayTimeDuration>("P2DT2S"));
     CHECK((Literal::make_typed<datatypes::xsd::YearMonthDuration>("P1Y") * Literal::make_typed<datatypes::xsd::Double>("2")) == Literal::make_typed<datatypes::xsd::YearMonthDuration>("P2Y"));
-    CHECK((Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1S") * Literal::make_typed_from_value<datatypes::xsd::Double>(std::numeric_limits<double>::infinity())) == Literal{});
-    CHECK((Literal::make_typed<datatypes::xsd::YearMonthDuration>("P1Y") * Literal::make_typed_from_value<datatypes::xsd::Double>(std::numeric_limits<double>::infinity())) == Literal{});
+    CHECK((Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1S") * Literal::make_typed_from_value<datatypes::xsd::Double>(std::numeric_limits<double>::infinity())).null());
+    CHECK((Literal::make_typed<datatypes::xsd::YearMonthDuration>("P1Y") * Literal::make_typed_from_value<datatypes::xsd::Double>(std::numeric_limits<double>::infinity())).null());
     CHECK((Literal::make_typed<datatypes::xsd::DayTimeDuration>("P2DT2S") / Literal::make_typed<datatypes::xsd::Double>("2")) == Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1S"));
     CHECK((Literal::make_typed<datatypes::xsd::YearMonthDuration>("P2Y") / Literal::make_typed<datatypes::xsd::Double>("2")) == Literal::make_typed<datatypes::xsd::YearMonthDuration>("P1Y"));
-    CHECK((Literal::make_typed<datatypes::xsd::DayTimeDuration>("P2DT2S") / Literal::make_typed_from_value<datatypes::xsd::Double>(0.0)) == Literal{});
-    CHECK((Literal::make_typed<datatypes::xsd::YearMonthDuration>("P2Y") / Literal::make_typed_from_value<datatypes::xsd::Double>(0.0)) == Literal{});
+    CHECK((Literal::make_typed<datatypes::xsd::DayTimeDuration>("P2DT2S") / Literal::make_typed_from_value<datatypes::xsd::Double>(0.0)).null());
+    CHECK((Literal::make_typed<datatypes::xsd::YearMonthDuration>("P2Y") / Literal::make_typed_from_value<datatypes::xsd::Double>(0.0)).null());
     CHECK((Literal::make_typed<datatypes::xsd::DayTimeDuration>("P4D") / Literal::make_typed<datatypes::xsd::DayTimeDuration>("P2D")) == Literal::make_typed<datatypes::xsd::Decimal>("2"));
     CHECK((Literal::make_typed<datatypes::xsd::YearMonthDuration>("P4Y") / Literal::make_typed<datatypes::xsd::YearMonthDuration>("P2Y")) == Literal::make_typed<datatypes::xsd::Decimal>("2"));
 }

--- a/tests/nodes/tests_DBpediaMode.cpp
+++ b/tests/nodes/tests_DBpediaMode.cpp
@@ -35,5 +35,5 @@ TEST_CASE("date/time") {
     CHECK(Literal::make_typed<datatypes::xsd::DateTime>("1742-2-40T26:90:60") == Literal::make_typed<datatypes::xsd::DateTime>("1742-3-13T3:31:0"));
     CHECK(Literal::make_typed<datatypes::xsd::DateTimeStamp>("1742-2-40T26:90:60Z") == Literal::make_typed<datatypes::xsd::DateTimeStamp>("1742-3-13T3:31:0Z"));
     CHECK(Literal::make_typed<datatypes::xsd::DateTimeStamp>("1742-2-40T10:10:10Z") == Literal::make_typed<datatypes::xsd::DateTimeStamp>("1742-3-12T10:10:10Z"));
-    CHECK(u == Literal{});
+    CHECK(u.null());
 }

--- a/tests/nodes/tests_Literal.cpp
+++ b/tests/nodes/tests_Literal.cpp
@@ -790,7 +790,7 @@ TEST_CASE("Literal - misc functions") {
         CHECK(Literal::make_lang_tagged("abcd", "en").regex_replace(Literal::make_lang_tagged("b", "fr"), "Z"_xsd_string).null());
 
         CHECK(("Hello 1 World"_xsd_string).regex_replace("[0-9]"_xsd_string, "Hello \\\\hgfhf World"_xsd_string) == "Hello Hello \\hgfhf World World"_xsd_string);
-        CHECK(("Hello 1 World"_xsd_string).regex_replace("[0-9]"_xsd_string, "Hello \\hgfhf World"_xsd_string) == Literal{});
+        CHECK(("Hello 1 World"_xsd_string).regex_replace("[0-9]"_xsd_string, "Hello \\hgfhf World"_xsd_string).null());
 
         CHECK(Literal::make_simple("abc\ndef\ngh").regex_replace("(def)"_xsd_string, "y$1x"_xsd_string, ""_xsd_string) == Literal::make_simple("abc\nydefx\ngh"));
         CHECK(Literal::make_simple("abc\ndef\ngh").regex_replace("^(def)$"_xsd_string, "y$1x"_xsd_string, "m"_xsd_string) == Literal::make_simple("abc\nydefx\ngh"));
@@ -839,7 +839,7 @@ TEST_CASE("URI encoding") {
         CHECK_EQ(Literal::make_typed(data, IRI{"http://www.w3.org/2001/XMLSchema#string"}).encode_for_uri(), Literal::make_simple(data_encoded));
     }
     SUBCASE("invalid UTF-8") {
-        CHECK_EQ(Literal::encode_for_uri("\xce"), Literal{});
+        CHECK(Literal::encode_for_uri("\xce").null());
     }
 }
 
@@ -1087,11 +1087,11 @@ TEST_CASE_TEMPLATE("Literal::find", T, datatypes::xsd::String, datatypes::rdf::L
         static constexpr auto bv = get_find_values<T>::bv;
         auto nst = storage::reference_node_storage::SyncReferenceNodeStorage{};
 
-        CHECK(Literal::find_typed_from_value<T>(av, nst) == Literal{});
+        CHECK(Literal::find_typed_from_value<T>(av, nst).null());
         Literal l = Literal::make_typed_from_value<T>(av, nst);
         CHECK(Literal::find_typed_from_value<T>(av, nst) == l);
         CHECK(Literal::find_typed_from_value<T>(av, nst).backend_handle() == l.backend_handle());
-        CHECK(Literal::find_typed_from_value<T>(bv, nst) == Literal{});
+        CHECK(Literal::find_typed_from_value<T>(bv, nst).null());
     }
     if constexpr (requires { get_find_values<T>::inl; }) {
         auto nst = storage::reference_node_storage::SyncReferenceNodeStorage{};
@@ -1103,11 +1103,11 @@ TEST_CASE_TEMPLATE("Literal::find", T, datatypes::xsd::String, datatypes::rdf::L
         static constexpr auto bs = get_find_values<T>::bs;
         auto nst = storage::reference_node_storage::SyncReferenceNodeStorage{};
 
-        CHECK(Literal::find_typed<T>(as, nst) == Literal{});
+        CHECK(Literal::find_typed<T>(as, nst).null());
         Literal l = Literal::make_typed<T>(as, nst);
         CHECK(Literal::find_typed<T>(as, nst) == l);
         CHECK(Literal::find_typed<T>(as, nst).backend_handle() == l.backend_handle());
-        CHECK(Literal::find_typed<T>(bs, nst) == Literal{});
+        CHECK(Literal::find_typed<T>(bs, nst).null());
     }
     if constexpr (requires { get_find_values<T>::inls; }) {
         auto nst = storage::reference_node_storage::SyncReferenceNodeStorage{};

--- a/tests/nodes/tests_Node.cpp
+++ b/tests/nodes/tests_Node.cpp
@@ -71,11 +71,11 @@ TEST_SUITE("comparisions") {
         IRI iri3 = IRI{"http://www.example.org/oest"};
         Literal lit1 = Literal::make_typed_from_value<String>("testlit1");
         Literal lit2 = Literal::make_typed_from_value<String>("testlit2");
-        CHECK(iri2 < iri1);
-        CHECK(iri3 < iri1);
-        CHECK(iri3 < iri2);
-        CHECK(iri1 < lit1);
-        CHECK(lit1 < lit2);
+        CHECK(iri2.order_lt(iri1));
+        CHECK(iri3.order_lt(iri1));
+        CHECK(iri3.order_lt(iri2));
+        CHECK(iri1.order_lt(lit1));
+        CHECK(lit1.order_lt(lit2));
     }
 
     TEST_CASE("filter compare tests") {
@@ -107,41 +107,41 @@ TEST_SUITE("comparisions") {
     TEST_CASE("order by compare tests") {
         // Incomparable <=> Incomparable
         SUBCASE("incomparability") {
-            CHECK(Literal::make_typed_from_value<Incomparable>(5).compare_with_extensions(Literal::make_typed_from_value<Incomparable>(10)) == std::weak_ordering::greater);
+            CHECK(Literal::make_typed_from_value<Incomparable>(5).order(Literal::make_typed_from_value<Incomparable>(10)) == std::weak_ordering::greater);
 
             // reason: float has fixed id and any fixed id type is always less than a dynamic one
-            CHECK(Literal::make_typed_from_value<Float>(10.f).compare_with_extensions(Literal::make_typed_from_value<Incomparable>(1)) == std::weak_ordering::less);
+            CHECK(Literal::make_typed_from_value<Float>(10.f).order(Literal::make_typed_from_value<Incomparable>(1)) == std::weak_ordering::less);
 
             // reason: decimal has fixed id and any fixed id type is always less than a dynamic one
-            CHECK(Literal::make_typed_from_value<Incomparable>(1).compare_with_extensions(Literal::make_typed_from_value<Decimal>(rdf4cpp::BigDecimal(10.0))) == std::weak_ordering::greater);
+            CHECK(Literal::make_typed_from_value<Incomparable>(1).order(Literal::make_typed_from_value<Decimal>(rdf4cpp::BigDecimal(10.0))) == std::weak_ordering::greater);
         }
 
         SUBCASE("nulls") {
-            CHECK(Literal{}.compare_with_extensions(Literal{}) == std::weak_ordering::equivalent);
+            CHECK(Literal{}.order(Literal{}) == std::weak_ordering::equivalent);
 
             // null <=> other (expecting null < any other a)
-            CHECK(Literal{}.compare_with_extensions(Literal::make_typed_from_value<Int>(1)) == std::weak_ordering::less);
-            CHECK(Literal::make_typed_from_value<String>("123").compare_with_extensions(Literal{}) == std::weak_ordering::greater);
+            CHECK(Literal{}.order(Literal::make_typed_from_value<Int>(1)) == std::weak_ordering::less);
+            CHECK(Literal::make_typed_from_value<String>("123").order(Literal{}) == std::weak_ordering::greater);
         }
 
         SUBCASE("test type ordering extensions") {
             // expected: string < float < decimal < integer < int
 
-            CHECK(Literal::make_typed_from_value<Decimal>(rdf4cpp::BigDecimal(1.0)).compare_with_extensions(Literal::make_typed_from_value<Float>(1)) == std::weak_ordering::greater);
-            CHECK(Literal::make_typed_from_value<Decimal>(rdf4cpp::BigDecimal(1.0)).compare_with_extensions(Literal::make_typed_from_value<Int>(1)) == std::weak_ordering::less);
-            CHECK(Literal::make_typed_from_value<Decimal>(rdf4cpp::BigDecimal(1.0)).compare_with_extensions(Literal::make_typed_from_value<Integer>(1)) == std::weak_ordering::less);
-            CHECK(Literal::make_typed_from_value<Decimal>(rdf4cpp::BigDecimal(1.0)).compare_with_extensions(Literal::make_typed_from_value<String>("hello")) == std::weak_ordering::greater);
+            CHECK(Literal::make_typed_from_value<Decimal>(rdf4cpp::BigDecimal(1.0)).order(Literal::make_typed_from_value<Float>(1)) == std::weak_ordering::greater);
+            CHECK(Literal::make_typed_from_value<Decimal>(rdf4cpp::BigDecimal(1.0)).order(Literal::make_typed_from_value<Int>(1)) == std::weak_ordering::less);
+            CHECK(Literal::make_typed_from_value<Decimal>(rdf4cpp::BigDecimal(1.0)).order(Literal::make_typed_from_value<Integer>(1)) == std::weak_ordering::less);
+            CHECK(Literal::make_typed_from_value<Decimal>(rdf4cpp::BigDecimal(1.0)).order(Literal::make_typed_from_value<String>("hello")) == std::weak_ordering::greater);
 
-            CHECK(Literal::make_typed_from_value<Float>(1.f).compare_with_extensions(Literal::make_typed_from_value<Int>(1)) == std::weak_ordering::less);
-            CHECK(Literal::make_typed_from_value<Float>(1.f).compare_with_extensions(Literal::make_typed_from_value<Integer>(1)) == std::weak_ordering::less);
-            CHECK(Literal::make_typed_from_value<Float>(1.f).compare_with_extensions(Literal::make_typed_from_value<String>("hello")) == std::weak_ordering::greater);
+            CHECK(Literal::make_typed_from_value<Float>(1.f).order(Literal::make_typed_from_value<Int>(1)) == std::weak_ordering::less);
+            CHECK(Literal::make_typed_from_value<Float>(1.f).order(Literal::make_typed_from_value<Integer>(1)) == std::weak_ordering::less);
+            CHECK(Literal::make_typed_from_value<Float>(1.f).order(Literal::make_typed_from_value<String>("hello")) == std::weak_ordering::greater);
 
-            CHECK(Literal::make_typed_from_value<Int>(1).compare_with_extensions(Literal::make_typed_from_value<Integer>(1)) == std::weak_ordering::greater);
-            CHECK(Literal::make_typed_from_value<Int>(1).compare_with_extensions(Literal::make_typed_from_value<String>("hello")) == std::weak_ordering::greater);
+            CHECK(Literal::make_typed_from_value<Int>(1).order(Literal::make_typed_from_value<Integer>(1)) == std::weak_ordering::greater);
+            CHECK(Literal::make_typed_from_value<Int>(1).order(Literal::make_typed_from_value<String>("hello")) == std::weak_ordering::greater);
         }
 
         SUBCASE("test ordering extensions ignored when not equal") {
-            CHECK(Literal::make_typed_from_value<Float>(2.f).compare_with_extensions(Literal::make_typed_from_value<Integer>(1)) == std::weak_ordering::greater);
+            CHECK(Literal::make_typed_from_value<Float>(2.f).order(Literal::make_typed_from_value<Integer>(1)) == std::weak_ordering::greater);
         }
     }
 
@@ -156,7 +156,7 @@ TEST_SUITE("comparisions") {
         BlankNode const blank_node{"some_random_id"};
         query::Variable const variable{"a_variable"};
 
-        std::set<Node> const s{
+        std::set<Node, OrderByLess> const s{
                 lit, iri, node, lit2, blank_node, null_iri, lit3, variable, lit4};
 
         std::vector<Node> const v{s.begin(), s.end()};

--- a/tests/nodes/tests_Node.cpp
+++ b/tests/nodes/tests_Node.cpp
@@ -62,7 +62,7 @@ using Incomparable = registry::LiteralDatatypeImpl<registry::Incomparable>;
 
 
 
-TEST_SUITE("comparisions") {
+TEST_SUITE("comparisons") {
     using namespace datatypes::xsd;
 
     TEST_CASE("Ordering") {
@@ -119,7 +119,7 @@ TEST_SUITE("comparisions") {
         SUBCASE("nulls") {
             CHECK(Literal{}.order(Literal{}) == std::partial_ordering::equivalent);
 
-            // null <=> other (expecting null < any other a)
+            // null <=> other (expecting null < any other Literal)
             CHECK(Literal{}.order(Literal::make_typed_from_value<Int>(1)) == std::weak_ordering::less);
             CHECK(Literal::make_typed_from_value<String>("123").order(Literal{}) == std::weak_ordering::greater);
         }

--- a/tests/nodes/tests_Node.cpp
+++ b/tests/nodes/tests_Node.cpp
@@ -156,7 +156,7 @@ TEST_SUITE("comparisions") {
         BlankNode const blank_node{"some_random_id"};
         query::Variable const variable{"a_variable"};
 
-        std::set<Node, OrderByLess> const s{
+        std::set<Node> const s{
                 lit, iri, node, lit2, blank_node, null_iri, lit3, variable, lit4};
 
         std::vector<Node> const v{s.begin(), s.end()};

--- a/tests/nodes/tests_Node.cpp
+++ b/tests/nodes/tests_Node.cpp
@@ -80,7 +80,7 @@ TEST_SUITE("comparisions") {
 
     TEST_CASE("filter compare tests") {
         SUBCASE("nulls") {
-            CHECK(Literal{} <=> Literal{} == std::partial_ordering::equivalent);
+            CHECK(Literal{} <=> Literal{} == std::partial_ordering::unordered);
             CHECK(Literal{} <=> Literal::make_typed_from_value<Int>(1) == std::partial_ordering::unordered);
             CHECK(Literal::make_typed_from_value<Decimal>(rdf4cpp::BigDecimal(1.0)) <=> Literal{} == std::partial_ordering::unordered);
         }
@@ -117,7 +117,7 @@ TEST_SUITE("comparisions") {
         }
 
         SUBCASE("nulls") {
-            CHECK(Literal{}.order(Literal{}) == std::weak_ordering::equivalent);
+            CHECK(Literal{}.order(Literal{}) == std::partial_ordering::equivalent);
 
             // null <=> other (expecting null < any other a)
             CHECK(Literal{}.order(Literal::make_typed_from_value<Int>(1)) == std::weak_ordering::less);


### PR DESCRIPTION
# Background
In SPARQL there are two types or orderings/comparisons: `FILTER`s and `ORDER BY` clauses.
The main difference is that for `ORDER BY` we sometimes need to order `Literals` that would usually not be comparable or are equal. (e.g. so that values of different types show up as single blocks in the solutions). Additionally, in `ORDER BY` IRIs and bnodes also have an ordering whereas the following `FILTER` would error: `<iri> <= <iri2>`.

This PR adds functions to use either behaviour. That was already possible before but required some wrapper code with some special cases.

For `FILTER` semantics use: `Node::{eq,lt,as_eq,...}`, `Literal::operator{==,<=>}`. Note due to the behaviour difference of `==`/`!=` and `<`/`<=`/`>`/`>=` in SPARQL we cannot provide a `compare` function for Node

For `ORDER BY` semantics use: `Node::order`, `Node::{order_eq,order_lt,as_order_eq,...}`, `Node::operator{<=>,==}`

As you have probably noticed, `operator<=>` for `Literal` and `Node` do different things.
`Literal`s follow `FILTER` semantics, whereas `Node`s follow `ORDER BY` semantics.
The reason for this is a compromise consisting of two reasons:
- `Node` needs to use `ORDER BY` semantics because you cannot use `std::set<Node>` properly otherwise (it would not work)
- `Literal` needs to use `FILTER` semantics because otherwise the following condition would not be true: `1_xsd_int == 1_xsd_integer`. This would confuse users. If you still want to put `Literal`s in a `std::set` use the `rdf4cpp::LiteralOrderByLess` comparator.


### Table of some the semantic differences when comparing op 1 and 2
This is not new, it was just not easily accessible previously.

| op 1            | op 2          | `FILTER`  | `ORDER BY` |
| --------------- | ------------- | --------- | ---------- |
| `1_xsd_integer` | `1_xsd_int`   | equal     | less       |
| `Literal{}`     | `1_xsd_int`   | error     | less       |
| `"iri"_iri`     | `1_xsd_int`   | error     | less       |
| `"iri1"_iri`    | `"iri2"_iri`  | not-equal | less       |
| `"bn1"_bnode`   | `"bn2"_bnode` | not-equal | less       |
| `null`          | `null`        | error     | equal      |
| `null`          | `"iri"_iri`   | error     | less       |


# Changes
- rename `*::compare_with_extensions` to `*::order` to better reflect its purpose
- Add `Node::{order,eq,order_eq,as_eq,...}` for feature parity with `Literal`

# TODO
- [x] Double check how comparisons with unbound/null nodes are supposed to behave