### PR TITLE
Feature: IStreamQuadIterator node inspect function

### DIFF
--- a/private/rdf4cpp/parser/IStreamQuadIteratorSerdImpl.hpp
+++ b/private/rdf4cpp/parser/IStreamQuadIteratorSerdImpl.hpp
@@ -42,6 +42,7 @@ private:
     nonstd::expected<IRI, SerdStatus> get_iri(SerdNode const *node) noexcept;
     nonstd::expected<IRI, SerdStatus> get_prefixed_iri(SerdNode const *node) noexcept;
     nonstd::expected<Literal, SerdStatus> get_literal(SerdNode const *literal, SerdNode const *datatype, SerdNode const *lang) noexcept;
+    SerdStatus inspect_node(Node const &node) noexcept;
 
     static SerdStatus on_error(void *voided_self, SerdError const *error) noexcept;
     static SerdStatus on_base(void *voided_self, SerdNode const *uri) noexcept;

--- a/src/rdf4cpp/parser/ParsingState.hpp
+++ b/src/rdf4cpp/parser/ParsingState.hpp
@@ -48,6 +48,12 @@ struct ParsingState {
      * By default no scope is used, this means all blank nodes will keep the labels from the file.
      */
     bnode_mngt::DynNodeScopeManagerPtr blank_node_scope_manager = nullptr;
+
+    /**
+     * A function that is called for each node that is parsed.
+     * To discard a triple throw an exception from this function.
+     */
+    std::function<void(Node const &)> inspect_node_func = []([[maybe_unused]] Node const &n) { /* noop */ };
 };
 
 }  //namespace rdf4cpp::parser

--- a/tests/parser/tests_IStreamQuadIterator.cpp
+++ b/tests/parser/tests_IStreamQuadIterator.cpp
@@ -671,4 +671,43 @@ TEST_SUITE("IStreamQuadIterator") {
             CHECK_EQ(qit->error().error_type, ParsingError::Type::BadLiteral);
         }
     }
+
+    TEST_CASE("inspect and discard triple") {
+        std::istringstream iss{R"(<http://a.com#s> <http://a.com#p> <http://a.com#o> . <http://a.com#s2> <http://a.com#p2> <http://a.com#o2> . )"};
+
+        std::vector<Node> const expected_nodes{IRI::default_graph(),
+                                               IRI::default_graph(), "http://a.com#s2"_iri, "http://a.com#p2"_iri, "http://a.com#o2"_iri};
+
+        IStreamQuadIterator::state_type st{.inspect_node_func = [&expected_nodes, iter = size_t{0}](Node const &node) mutable {
+            CHECK_EQ(node, expected_nodes[iter++]);
+
+            if (iter == 1) {
+                throw std::runtime_error{"I don't want that"};
+            }
+        }};
+
+        IStreamQuadIterator qit{iss, ParsingFlags::none(), &st};
+
+        size_t iter = 0;
+        for (; qit != std::default_sentinel; ++qit) {
+            switch (iter) {
+                case 0: {
+                    REQUIRE(!qit->has_value());
+                    CHECK_EQ(qit->error().message, "Triple explicitly skipped by inspect function: I don't want that");
+                    break;
+                }
+                case 1: {
+                    REQUIRE(qit->has_value());
+                    CHECK_EQ(qit->value().subject().as_iri().identifier(), "http://a.com#s2");
+                    break;
+                }
+                default: {
+                    FAIL("too many iterations");
+                }
+            }
+
+            ++iter;
+        }
+
+    }
 }

--- a/tests/parser/tests_IStreamQuadIterator.cpp
+++ b/tests/parser/tests_IStreamQuadIterator.cpp
@@ -698,7 +698,10 @@ TEST_SUITE("IStreamQuadIterator") {
                 }
                 case 1: {
                     REQUIRE(qit->has_value());
-                    CHECK_EQ(qit->value().subject().as_iri().identifier(), "http://a.com#s2");
+                    CHECK_EQ(qit->value().graph(), IRI::default_graph());
+                    CHECK_EQ(qit->value().subject(), IRI::make("http://a.com#s2"));
+                    CHECK_EQ(qit->value().predicate(), IRI::make("http://a.com#p2"));
+                    CHECK_EQ(qit->value().object(), IRI::make("http://a.com#o2"));
                     break;
                 }
                 default: {


### PR DESCRIPTION
Adds `IStreamQuadIterator::state_type::inspect_node` to inspect nodes after they are created in the parser.