### PR TITLE
Fix: boost issue by version bump

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -29,7 +29,7 @@ class Recipe(ConanFile):
     generators = ("CMakeDeps", "CMakeToolchain")
 
     def requirements(self):
-        self.requires("boost/1.83.0", transitive_headers=True, libs=False)
+        self.requires("boost/1.86.0", transitive_headers=True, libs=False)
         self.requires("expected-lite/0.6.3", transitive_headers=True)
         self.requires("re2/20221201")
         self.requires("openssl/3.0.8")

--- a/tests/datatype/tests_Decimal.cpp
+++ b/tests/datatype/tests_Decimal.cpp
@@ -223,3 +223,12 @@ TEST_CASE("decimal inlining sanity check") {
         }
     }
 }
+
+TEST_CASE("decimal possible bug") {
+    // This bug only occurs in boost versions < 1.86.0
+    auto const lit1 = Literal::make_typed_from_value<datatypes::xsd::Double>(5).cast<rdf4cpp::datatypes::xsd::Decimal>();
+    auto const lit2 = Literal::make_typed_from_value<datatypes::xsd::Double>(std::numeric_limits<double>::min()).cast<rdf4cpp::datatypes::xsd::Decimal>();
+
+    auto const div_res = lit1 / lit2; // program crashes here if the bug is present
+    CHECK(div_res.null());
+}


### PR DESCRIPTION
Boost versions below 1.86.0 had a bug where casting a `boost::multiprecision::cpp_int` to a double would sometimes throw an exception inside boost (in a noexcept context) which crashed the program.

Bumping the version resolves this.