### PR TITLE
Fix: add workaround for older boost version

### DIFF
--- a/src/rdf4cpp/BigDecimal.hpp
+++ b/src/rdf4cpp/BigDecimal.hpp
@@ -779,7 +779,7 @@ public:
      * @return
      */
     [[nodiscard]] explicit operator double() const noexcept {
-        double const v = cast_unscaled_to_double_safe(unscaled_value) * std::pow(base, -exponent);
+        double const v = cast_unscaled_to_double_safe(unscaled_value) * std::pow(static_cast<double>(base), -static_cast<double>(exponent));
         if (!std::isnan(v) && !std::isinf(v))
             return v;
         // even Javas BigDecimal has no better solution

--- a/src/rdf4cpp/BigDecimal.hpp
+++ b/src/rdf4cpp/BigDecimal.hpp
@@ -779,7 +779,7 @@ public:
      * @return
      */
     [[nodiscard]] explicit operator double() const noexcept {
-        double const v = cast_unscaled_to_double_safe(unscaled_value) * std::pow(cast_unscaled_to_double_safe(base), -cast_unscaled_to_double_safe(exponent));
+        double const v = cast_unscaled_to_double_safe(unscaled_value) * std::pow(base, -exponent);
         if (!std::isnan(v) && !std::isinf(v))
             return v;
         // even Javas BigDecimal has no better solution


### PR DESCRIPTION
Follow up to #314 

It turns out that we cannot use more recent boost versions in our other library (because of an incompatibility in another dependency).

Therefore I added a workaround, so that it still works with older versions. I will keep the version bump in the conanfile, since that is the proper fix.

Please double check that I did not miss anything