### PR TITLE
Single null node representation

### DIFF
--- a/private/rdf4cpp/writer/WriteQuad.hpp
+++ b/private/rdf4cpp/writer/WriteQuad.hpp
@@ -39,9 +39,9 @@ bool write_pred(Node const pred, writer::BufWriterParts const writer) {
         return false;                       \
     }
 
-[[nodiscard]] inline bool is_default_graph(Node const &graph) noexcept {
+[[nodiscard]] inline bool print_graph(Node const &graph) noexcept {
     auto const g = graph.as_iri();
-    return g.is_default_graph();
+    return !g.is_default_graph();
 }
 
 template<writer::OutputFormat F, typename Q>
@@ -53,7 +53,7 @@ bool write_quad(Q const &s, writer::BufWriterParts const writer, writer::Seriali
                     return false;
                 }
 
-                if (!is_default_graph(s.graph())) {
+                if (print_graph(s.graph())) {
                     RDF4CPP_DETAIL_TRY_WRITE_NODE(s.graph());
                     RDF4CPP_DETAIL_TRY_WRITE_STR(" {\n");
 
@@ -94,7 +94,7 @@ bool write_quad(Q const &s, writer::BufWriterParts const writer, writer::Seriali
 
     if constexpr (!writer::format_has_prefix<F>) {
         if constexpr (writer::format_has_graph<F>) {
-            if (!is_default_graph(s.graph())) {
+            if (print_graph(s.graph())) {
                 RDF4CPP_DETAIL_TRY_WRITE_STR(" ");
                 RDF4CPP_DETAIL_TRY_WRITE_NODE(s.graph());
             }

--- a/src/rdf4cpp/BlankNode.cpp
+++ b/src/rdf4cpp/BlankNode.cpp
@@ -77,10 +77,6 @@ BlankNode::operator std::string() const noexcept {
     });
 }
 
-bool BlankNode::is_literal() const noexcept { return false; }
-bool BlankNode::is_variable() const noexcept { return false; }
-bool BlankNode::is_blank_node() const noexcept { return true; }
-bool BlankNode::is_iri() const noexcept { return false; }
 std::ostream &operator<<(std::ostream &os, BlankNode const &bnode) {
     writer::BufOStreamWriter w{os};
     bnode.serialize(w);

--- a/src/rdf4cpp/BlankNode.cpp
+++ b/src/rdf4cpp/BlankNode.cpp
@@ -5,7 +5,7 @@
 #include <uni_algo/all.h>
 
 namespace rdf4cpp {
-BlankNode::BlankNode() noexcept : Node{storage::identifier::NodeBackendHandle{{}, storage::identifier::RDFNodeType::BNode, {}}} {
+BlankNode::BlankNode() noexcept : Node{storage::identifier::NodeBackendHandle{}} {
 }
 
 BlankNode::BlankNode(std::string_view identifier, storage::DynNodeStoragePtr node_storage)

--- a/src/rdf4cpp/BlankNode.hpp
+++ b/src/rdf4cpp/BlankNode.hpp
@@ -68,10 +68,10 @@ struct BlankNode : Node {
 
     friend std::ostream &operator<<(std::ostream &os, BlankNode const &node);
 
-    [[nodiscard]] bool is_literal() const noexcept;
-    [[nodiscard]] bool is_variable() const noexcept;
-    [[nodiscard]] bool is_blank_node() const noexcept;
-    [[nodiscard]] bool is_iri() const noexcept;
+    bool is_literal() const noexcept = delete;
+    bool is_variable() const noexcept = delete;
+    bool is_blank_node() const noexcept = delete;
+    bool is_iri() const noexcept = delete;
 
     friend struct Node;
 };

--- a/src/rdf4cpp/IRI.cpp
+++ b/src/rdf4cpp/IRI.cpp
@@ -139,9 +139,9 @@ IRI IRI::default_graph(storage::DynNodeStoragePtr node_storage) {
                node_storage}};
 }
 
-bool IRI::is_default_graph() const noexcept {
+TriBool IRI::is_default_graph() const noexcept {
     if (null()) {
-        return false;
+        return TriBool::Err;
     }
 
     auto const expected_id = datatypes::registry::reserved_datatype_ids[datatypes::registry::default_graph_iri];

--- a/src/rdf4cpp/IRI.cpp
+++ b/src/rdf4cpp/IRI.cpp
@@ -140,6 +140,10 @@ IRI IRI::default_graph(storage::DynNodeStoragePtr node_storage) {
 }
 
 bool IRI::is_default_graph() const noexcept {
+    if (null()) {
+        return false;
+    }
+
     auto const expected_id = datatypes::registry::reserved_datatype_ids[datatypes::registry::default_graph_iri];
     auto const this_id = storage::identifier::iri_node_id_to_literal_type(backend_handle().id());
     return this_id == expected_id;

--- a/src/rdf4cpp/IRI.cpp
+++ b/src/rdf4cpp/IRI.cpp
@@ -133,12 +133,6 @@ IRI::operator std::string() const noexcept {
     });
 }
 
-bool IRI::is_literal() const noexcept { return false; }
-bool IRI::is_variable() const noexcept { return false; }
-bool IRI::is_blank_node() const noexcept { return false; }
-bool IRI::is_iri() const noexcept { return true; }
-
-
 IRI IRI::default_graph(storage::DynNodeStoragePtr node_storage) {
     auto const id = datatypes::registry::reserved_datatype_ids[datatypes::registry::default_graph_iri];
     return IRI{storage::identifier::NodeBackendHandle{storage::identifier::literal_type_to_iri_node_id(id),

--- a/src/rdf4cpp/IRI.cpp
+++ b/src/rdf4cpp/IRI.cpp
@@ -14,7 +14,7 @@ namespace rdf4cpp {
 IRI::IRI(storage::identifier::NodeBackendHandle handle) noexcept : Node(handle) {
 }
 
-IRI::IRI() noexcept : Node{storage::identifier::NodeBackendHandle{{}, storage::identifier::RDFNodeType::IRI, {}}} {
+IRI::IRI() noexcept : Node{storage::identifier::NodeBackendHandle{}} {
 }
 
 IRI::IRI(std::string_view iri, storage::DynNodeStoragePtr node_storage)

--- a/src/rdf4cpp/IRI.hpp
+++ b/src/rdf4cpp/IRI.hpp
@@ -110,10 +110,10 @@ public:
     [[nodiscard]] explicit operator std::string() const noexcept;
     friend std::ostream &operator<<(std::ostream &os, const IRI &iri);
 
-    [[nodiscard]] bool is_literal() const noexcept;
-    [[nodiscard]] bool is_variable() const noexcept;
-    [[nodiscard]] bool is_blank_node() const noexcept;
-    [[nodiscard]] bool is_iri() const noexcept;
+    bool is_literal() const noexcept = delete;
+    bool is_variable() const noexcept = delete;
+    bool is_blank_node() const noexcept = delete;
+    bool is_iri() const noexcept = delete;
 
     friend struct Node;
     friend struct Literal;

--- a/src/rdf4cpp/IRI.hpp
+++ b/src/rdf4cpp/IRI.hpp
@@ -126,9 +126,9 @@ public:
     [[nodiscard]] static IRI default_graph(storage::DynNodeStoragePtr node_storage = storage::default_node_storage);
 
     /**
-     * @return if this IRI is the default graph IRI
+     * @return err if this is null, otherwise true iff this IRI is the default graph IRI
      */
-    [[nodiscard]] bool is_default_graph() const noexcept;
+    [[nodiscard]] TriBool is_default_graph() const noexcept;
 };
 
 inline namespace shorthands {

--- a/src/rdf4cpp/Literal.cpp
+++ b/src/rdf4cpp/Literal.cpp
@@ -804,10 +804,6 @@ Literal::operator std::string() const noexcept {
     });
 }
 
-bool Literal::is_literal() const noexcept { return true; }
-bool Literal::is_variable() const noexcept { return false; }
-bool Literal::is_blank_node() const noexcept { return false; }
-bool Literal::is_iri() const noexcept { return false; }
 bool Literal::is_numeric() const noexcept {
     using namespace datatypes::registry;
 

--- a/src/rdf4cpp/Literal.cpp
+++ b/src/rdf4cpp/Literal.cpp
@@ -39,7 +39,7 @@ static std::string run_serialize(S serialize, T const &value) {
 Literal::Literal(storage::identifier::NodeBackendHandle handle) noexcept : Node{handle} {
 }
 
-Literal::Literal() noexcept : Node{storage::identifier::NodeBackendHandle{{}, storage::identifier::RDFNodeType::Literal, {}}} {
+Literal::Literal() noexcept : Node{storage::identifier::NodeBackendHandle{}} {
 }
 
 Literal Literal::make_null() noexcept {

--- a/src/rdf4cpp/Literal.hpp
+++ b/src/rdf4cpp/Literal.hpp
@@ -934,10 +934,11 @@ public:
                 });
     }
 
-    [[nodiscard]] bool is_literal() const noexcept;
-    [[nodiscard]] bool is_variable() const noexcept;
-    [[nodiscard]] bool is_blank_node() const noexcept;
-    [[nodiscard]] bool is_iri() const noexcept;
+    bool is_literal() const noexcept = delete;
+    bool is_variable() const noexcept = delete;
+    bool is_blank_node() const noexcept = delete;
+    bool is_iri() const noexcept = delete;
+
     [[nodiscard]] bool is_numeric() const noexcept;
 
     /**

--- a/src/rdf4cpp/Node.cpp
+++ b/src/rdf4cpp/Node.cpp
@@ -103,17 +103,17 @@ Node::operator std::string() const noexcept {
     }
 }
 
-bool Node::is_literal() const noexcept {
-    return !handle_.null() && handle_.is_literal();
+TriBool Node::is_literal() const noexcept {
+    return handle_.is_literal();
 }
-bool Node::is_variable() const noexcept {
-    return !handle_.null() && handle_.is_variable();
+TriBool Node::is_variable() const noexcept {
+    return handle_.is_variable();
 }
-bool Node::is_blank_node() const noexcept {
-    return !handle_.null() && handle_.is_blank_node();
+TriBool Node::is_blank_node() const noexcept {
+    return handle_.is_blank_node();
 }
-bool Node::is_iri() const noexcept {
-    return !handle_.null() && handle_.is_iri();
+TriBool Node::is_iri() const noexcept {
+    return handle_.is_iri();
 }
 
 bool Node::is_inlined() const noexcept {

--- a/src/rdf4cpp/Node.cpp
+++ b/src/rdf4cpp/Node.cpp
@@ -104,16 +104,16 @@ Node::operator std::string() const noexcept {
 }
 
 bool Node::is_literal() const noexcept {
-    return handle_.is_literal();
+    return !handle_.null() && handle_.is_literal();
 }
 bool Node::is_variable() const noexcept {
-    return handle_.is_variable();
+    return !handle_.null() && handle_.is_variable();
 }
 bool Node::is_blank_node() const noexcept {
-    return handle_.is_blank_node();
+    return !handle_.null() && handle_.is_blank_node();
 }
 bool Node::is_iri() const noexcept {
-    return handle_.is_iri();
+    return !handle_.null() && handle_.is_iri();
 }
 
 bool Node::is_inlined() const noexcept {

--- a/src/rdf4cpp/Node.hpp
+++ b/src/rdf4cpp/Node.hpp
@@ -157,28 +157,28 @@ public:
     friend std::ostream &operator<<(std::ostream &os, const Node &node);
 
     /**
-     * Checks weather the node is a Literal. If yes, it is safe to convert it with `auto literal = (Literal) rdf_node;`
-     * @return if this is a Literal
+     * Checks whether the node is a Literal
+     * @return err if this is null, otherwise true iff this is a literal
      */
-    [[nodiscard]] bool is_literal() const noexcept;
+    [[nodiscard]] TriBool is_literal() const noexcept;
 
     /**
-     * Checks weather the node is a Variable. If yes, it is safe to convert it with `auto variable = (Variable) rdf_node;`
-     * @return if this is a Variable
+     * Checks whether the node is a variable
+     * @return err if this is null, otherwise true iff this is a variable
      */
-    [[nodiscard]] bool is_variable() const noexcept;
+    [[nodiscard]] TriBool is_variable() const noexcept;
 
     /**
-     * Checks weather the node is a BlankNode. If yes, it is safe to convert it with `auto bnode = (BlankNode) rdf_node;`
-     * @return if this is a BlankNode
+     * Checks whether the node is a blank node
+     * @return err if this is null, otherwise true iff this is a blank node
      */
-    [[nodiscard]] bool is_blank_node() const noexcept;
+    [[nodiscard]] TriBool is_blank_node() const noexcept;
 
     /**
-     * Checks weather the node is a IRI. If yes, it is safe to convert it with `auto iri = (Literal) rdf_node;`
-     * @return if this is a IRI
+     * Checks whether the node is a iri
+     * @return err if this is null, otherwise true iff this is a iri
      */
-    [[nodiscard]] bool is_iri() const noexcept;
+    [[nodiscard]] TriBool is_iri() const noexcept;
 
     /**
      * @return if the current value of this node is stored inside the handle instead of the node storage

--- a/src/rdf4cpp/Quad.cpp
+++ b/src/rdf4cpp/Quad.cpp
@@ -8,10 +8,10 @@ Quad::Quad(Node subject, Node predicate, Node object) noexcept : QuadPattern(IRI
 Quad::Quad(Node graph, Node subject, Node predicate, Node object) noexcept : QuadPattern(graph, subject, predicate, object) {}
 
 bool Quad::valid() const noexcept {
-    return (graph().is_iri() || (graph().is_blank_node() && !graph().null()))
-            && ((subject().is_iri() || subject().is_blank_node()) && !subject().null())
-            && (predicate().is_iri() && !predicate().null())
-            && ((object().is_iri() || object().is_literal() || object().is_blank_node()) && !object().null());
+    return (graph().is_iri() || graph().is_blank_node())
+            && (subject().is_iri() || subject().is_blank_node())
+            && (predicate().is_iri())
+            && (object().is_iri() || object().is_literal() || object().is_blank_node());
 }
 
 std::optional<Quad> Quad::create_validated(Node graph, Node subject, Node predicate, Node object) noexcept {

--- a/src/rdf4cpp/query/QuadPattern.cpp
+++ b/src/rdf4cpp/query/QuadPattern.cpp
@@ -8,9 +8,9 @@ QuadPattern::QuadPattern(Node graph, Node subject, Node predicate, Node object) 
 }
 
 bool QuadPattern::valid() const noexcept {
-    return !graph().null() && (graph().is_iri() || graph().is_variable())
-            && !subject().null() && !subject().is_literal()
-            && !predicate().null() && (predicate().is_iri() || predicate().is_variable())
+    return (graph().is_iri() || graph().is_variable())
+            && !subject().is_literal()
+            && (predicate().is_iri() || predicate().is_variable())
             && !object().null();
 }
 

--- a/src/rdf4cpp/query/Variable.cpp
+++ b/src/rdf4cpp/query/Variable.cpp
@@ -6,7 +6,7 @@
 #include <uni_algo/all.h>
 
 namespace rdf4cpp::query {
-Variable::Variable() noexcept : Node{storage::identifier::NodeBackendHandle{{}, storage::identifier::RDFNodeType::Variable, {}}} {
+Variable::Variable() noexcept : Node{storage::identifier::NodeBackendHandle{}} {
 }
 
 Variable::Variable(std::string_view name, bool anonymous, storage::DynNodeStoragePtr node_storage)

--- a/src/rdf4cpp/query/Variable.cpp
+++ b/src/rdf4cpp/query/Variable.cpp
@@ -95,11 +95,6 @@ Variable::operator std::string() const {
     });
 }
 
-bool Variable::is_literal() const { return false; }
-bool Variable::is_variable() const { return true; }
-bool Variable::is_blank_node() const { return false; }
-bool Variable::is_iri() const { return false; }
-
 std::ostream &operator<<(std::ostream &os, Variable const &variable) {
     writer::BufOStreamWriter w{os};
     variable.serialize(w);

--- a/src/rdf4cpp/query/Variable.hpp
+++ b/src/rdf4cpp/query/Variable.hpp
@@ -63,10 +63,10 @@ public:
     [[nodiscard]] explicit operator std::string() const;
     friend std::ostream &operator<<(std::ostream &os, const Variable &variable);
 
-    [[nodiscard]] bool is_blank_node() const;
-    [[nodiscard]] bool is_literal() const;
-    [[nodiscard]] bool is_variable() const;
-    [[nodiscard]] bool is_iri() const;
+    bool is_blank_node() const = delete;
+    bool is_literal() const = delete;
+    bool is_variable() const = delete;
+    bool is_iri() const = delete;
 
     friend struct Node;
 

--- a/src/rdf4cpp/storage/identifier/NodeBackendHandle.hpp
+++ b/src/rdf4cpp/storage/identifier/NodeBackendHandle.hpp
@@ -58,7 +58,10 @@ public:
      * Check if the NodeBackendHandle identifies a IRI.
      * @return
      */
-    [[nodiscard]] constexpr bool is_iri() const noexcept {
+    [[nodiscard]] constexpr TriBool is_iri() const noexcept {
+        if (id_.null()) {
+            return TriBool::Err;
+        }
         return id_.is_iri();
     }
 
@@ -66,7 +69,10 @@ public:
      * Check if the NodeBackendHandle identifies a Literal.
      * @return
      */
-    [[nodiscard]] constexpr bool is_literal() const noexcept {
+    [[nodiscard]] constexpr TriBool is_literal() const noexcept {
+        if (id_.null()) {
+            return TriBool::Err;
+        }
         return id_.is_literal();
     }
 
@@ -74,7 +80,10 @@ public:
      * Check if the NodeBackendHandle identifies a BlankNode.
      * @return
      */
-    [[nodiscard]] constexpr bool is_blank_node() const noexcept {
+    [[nodiscard]] constexpr TriBool is_blank_node() const noexcept {
+        if (id_.null()) {
+            return TriBool::Err;
+        }
         return id_.is_blank_node();
     }
 
@@ -82,7 +91,10 @@ public:
      * Check if the NodeBackendHandle identifies a Variable.
      * @return
      */
-    [[nodiscard]] constexpr bool is_variable() const noexcept {
+    [[nodiscard]] constexpr TriBool is_variable() const noexcept {
+        if (id_.null()) {
+            return TriBool::Err;
+        }
         return id_.is_variable();
     }
 

--- a/src/rdf4cpp/storage/identifier/NodeBackendID.hpp
+++ b/src/rdf4cpp/storage/identifier/NodeBackendID.hpp
@@ -163,7 +163,7 @@ static_assert(alignof(NodeBackendID) == alignof(uint64_t));
  * @return the LiteralType associated with that IRI
  */
 constexpr LiteralType iri_node_id_to_literal_type(NodeBackendID const id) noexcept {
-    assert(id.null() || id.is_iri());
+    assert(id.is_iri());
     auto const value = id.node_id().to_underlying();
 
     // all ids values below min_dynamic_datatype_id (except for the null id) are reserved for fixed datatype IRIs

--- a/src/rdf4cpp/storage/identifier/NodeBackendID.hpp
+++ b/src/rdf4cpp/storage/identifier/NodeBackendID.hpp
@@ -163,7 +163,7 @@ static_assert(alignof(NodeBackendID) == alignof(uint64_t));
  * @return the LiteralType associated with that IRI
  */
 constexpr LiteralType iri_node_id_to_literal_type(NodeBackendID const id) noexcept {
-    assert(id.is_iri());
+    assert(id.null() || id.is_iri());
     auto const value = id.node_id().to_underlying();
 
     // all ids values below min_dynamic_datatype_id (except for the null id) are reserved for fixed datatype IRIs

--- a/src/rdf4cpp/storage/identifier/RDFNodeType.hpp
+++ b/src/rdf4cpp/storage/identifier/RDFNodeType.hpp
@@ -17,7 +17,7 @@ enum struct RDFNodeType : uint8_t {
     Variable
 };
 
-inline std::string_view to_string_view(RDFNodeType const node_type) noexcept {
+constexpr std::string_view to_string_view(RDFNodeType const node_type) noexcept {
     switch (node_type) {
         case RDFNodeType::Variable:
             return "variable";

--- a/tests/nodes/tests_Literal.cpp
+++ b/tests/nodes/tests_Literal.cpp
@@ -27,15 +27,19 @@ int main(int argc, char **argv) {
     }
 }
 
+void check_literal_type(Node const &lit) {
+    CHECK_FALSE(lit.is_blank_node());
+    CHECK(lit.is_literal());
+    CHECK_FALSE(lit.is_variable());
+    CHECK_FALSE(lit.is_iri());
+}
+
 TEST_CASE("Literal - Check for only lexical form") {
 
     auto iri = IRI{"http://www.w3.org/2001/XMLSchema#string"};
     auto lit1 = Literal::make_simple("Bunny");
 
-    CHECK(not lit1.is_blank_node());
-    CHECK(lit1.is_literal());
-    CHECK(not lit1.is_variable());
-    CHECK(not lit1.is_iri());
+    check_literal_type(lit1);
     CHECK_EQ(lit1.lexical_form(), "Bunny");
     CHECK_EQ(lit1.datatype(), iri);
     CHECK_EQ(lit1.language_tag(), "");
@@ -43,15 +47,11 @@ TEST_CASE("Literal - Check for only lexical form") {
 }
 
 TEST_CASE("Literal - Check for lexical form with IRI") {
-
     SUBCASE("string datatype") {
         auto iri = IRI{"http://www.w3.org/2001/XMLSchema#string"};
         auto lit1 = Literal::make_typed("Bunny", iri);
 
-        CHECK(not lit1.is_blank_node());
-        CHECK(lit1.is_literal());
-        CHECK(not lit1.is_variable());
-        CHECK(not lit1.is_iri());
+        check_literal_type(lit1);
         CHECK_EQ(lit1.lexical_form(), "Bunny");
         CHECK_EQ(lit1.datatype(), iri);
         CHECK_EQ(lit1.language_tag(), "");
@@ -66,10 +66,7 @@ TEST_CASE("Literal - Check for lexical form with IRI") {
         auto iri = IRI{"http://www.w3.org/2001/XMLSchema#int"};
         auto lit1 = Literal::make_typed("101", iri);
 
-        CHECK(not lit1.is_blank_node());
-        CHECK(lit1.is_literal());
-        CHECK(not lit1.is_variable());
-        CHECK(not lit1.is_iri());
+        check_literal_type(lit1);
         CHECK_EQ(lit1.lexical_form(), "101");
         CHECK_EQ(lit1.datatype(), iri);
         CHECK_EQ(lit1.language_tag(), "");
@@ -79,10 +76,7 @@ TEST_CASE("Literal - Check for lexical form with IRI") {
         auto iri = IRI{"http://www.w3.org/2001/XMLSchema#date"};
         auto lit1 = Literal::make_typed("2021-11-21", iri);
 
-        CHECK(not lit1.is_blank_node());
-        CHECK(lit1.is_literal());
-        CHECK(not lit1.is_variable());
-        CHECK(not lit1.is_iri());
+        check_literal_type(lit1);
         CHECK_EQ(lit1.lexical_form(), "2021-11-21");
         CHECK_EQ(lit1.datatype(), iri);
         CHECK_EQ(lit1.language_tag(), "");
@@ -92,10 +86,7 @@ TEST_CASE("Literal - Check for lexical form with IRI") {
         auto iri = IRI{"http://www.w3.org/2001/XMLSchema#decimal"};
         auto lit1 = Literal::make_typed("2.0", iri);
 
-        CHECK(not lit1.is_blank_node());
-        CHECK(lit1.is_literal());
-        CHECK(not lit1.is_variable());
-        CHECK(not lit1.is_iri());
+        check_literal_type(lit1);
         CHECK_EQ(lit1.lexical_form(), "2.0");
         CHECK_EQ(lit1.datatype(), iri);
         CHECK_EQ(lit1.language_tag(), "");
@@ -105,10 +96,7 @@ TEST_CASE("Literal - Check for lexical form with IRI") {
         auto iri = IRI{"http://www.w3.org/2001/XMLSchema#boolean"};
         auto lit1 = Literal::make_typed("true", iri);
 
-        CHECK(not lit1.is_blank_node());
-        CHECK(lit1.is_literal());
-        CHECK(not lit1.is_variable());
-        CHECK(not lit1.is_iri());
+        check_literal_type(lit1);
         CHECK_EQ(lit1.lexical_form(), "true");
         CHECK_EQ(lit1.datatype(), iri);
         CHECK_EQ(lit1.language_tag(), "");
@@ -118,10 +106,7 @@ TEST_CASE("Literal - Check for lexical form with IRI") {
         auto iri = IRI{"http://www.w3.org/2001/XMLSchema#boolean"};
         auto lit1 = Literal::make_typed("false", iri);
 
-        CHECK(not lit1.is_blank_node());
-        CHECK(lit1.is_literal());
-        CHECK(not lit1.is_variable());
-        CHECK(not lit1.is_iri());
+        check_literal_type(lit1);
         CHECK_EQ(lit1.lexical_form(), "false");
         CHECK_EQ(lit1.datatype(), iri);
         CHECK_EQ(lit1.language_tag(), "");
@@ -131,10 +116,7 @@ TEST_CASE("Literal - Check for lexical form with IRI") {
         auto iri = IRI{"http://www.w3.org/2001/XMLSchema#boolean"};
         auto lit1 = Literal::make_typed("0", iri);
 
-        CHECK(not lit1.is_blank_node());
-        CHECK(lit1.is_literal());
-        CHECK(not lit1.is_variable());
-        CHECK(not lit1.is_iri());
+        check_literal_type(lit1);
         CHECK_EQ(lit1.lexical_form(), "false");
         CHECK_EQ(lit1.datatype(), iri);
         CHECK_EQ(lit1.language_tag(), "");
@@ -144,10 +126,7 @@ TEST_CASE("Literal - Check for lexical form with IRI") {
         auto iri = IRI{"http://www.w3.org/2001/XMLSchema#boolean"};
         auto lit1 = Literal::make_typed("1", iri);
 
-        CHECK(not lit1.is_blank_node());
-        CHECK(lit1.is_literal());
-        CHECK(not lit1.is_variable());
-        CHECK(not lit1.is_iri());
+        check_literal_type(lit1);
         CHECK_EQ(lit1.lexical_form(), "true");
         CHECK_EQ(lit1.datatype(), iri);
         CHECK_EQ(lit1.language_tag(), "");
@@ -160,10 +139,7 @@ TEST_CASE("Literal - Check for lexical form with language tag") {
     auto iri = IRI{"http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"};
     auto lit1 = Literal::make_lang_tagged("Bunny", "en");
 
-    CHECK(not lit1.is_blank_node());
-    CHECK(lit1.is_literal());
-    CHECK(not lit1.is_variable());
-    CHECK(not lit1.is_iri());
+    check_literal_type(lit1);
     CHECK_EQ(lit1.lexical_form(), "Bunny");
     CHECK_EQ(lit1.datatype(), iri);
     CHECK_EQ(lit1.language_tag(), "en");

--- a/tests/nodes/tests_Node.cpp
+++ b/tests/nodes/tests_Node.cpp
@@ -164,7 +164,7 @@ TEST_SUITE("comparisons") {
         // - lexical order of types, and null smallest
         // - null Node has type BNode
         // - literal comparison
-        std::vector<Node> const expected{node, null_iri, blank_node, iri, lit4, lit, lit3, variable};
+        std::vector<Node> const expected{node, blank_node, iri, lit4, lit, lit3, variable};
 
         CHECK(v == expected);
     }
@@ -183,7 +183,7 @@ TEST_SUITE("comparisons") {
         std::unordered_set<Node> s{
                 iri, null_iri, lit, lit2, lit3, lit4, node, blank_node, variable};
 
-        CHECK(s.size() == 8);
+        CHECK(s.size() == 7);
         CHECK(s.contains(lit));
         CHECK(s.contains(lit2));
         CHECK(s.contains(lit3));
@@ -304,4 +304,44 @@ TEST_CASE_TEMPLATE("NodeStorage erase IRI", T, reference_node_storage::SyncRefer
     CHECK(IRI::find(rdf4cpp::datatypes::xsd::Int::identifier, ns) != IRI());
     CHECK(!ns.erase_iri(IRI::find(rdf4cpp::datatypes::xsd::Int::identifier, ns).backend_handle().id()));
     CHECK(IRI::find(rdf4cpp::datatypes::xsd::Int::identifier, ns) != IRI());
+}
+
+TEST_CASE("null nodes") {
+    Node n1{};
+    Literal n2{};
+    BlankNode n3{};
+    IRI n4{};
+    query::Variable n5{};
+
+    CHECK_EQ(n1, n2);
+    CHECK_EQ(n2, n3);
+    CHECK_EQ(n3, n4);
+    CHECK_EQ(n4, n5);
+    CHECK_EQ(n5, n1);
+    CHECK_EQ(n1.backend_handle(), n2.backend_handle());
+    CHECK_EQ(n2.backend_handle(), n3.backend_handle());
+    CHECK_EQ(n3.backend_handle(), n4.backend_handle());
+    CHECK_EQ(n4.backend_handle(), n5.backend_handle());
+    CHECK_EQ(n5.backend_handle(), n1.backend_handle());
+
+    auto const run_checks = [](Node node) {
+        // is_* checks are accessed via Node::is_*
+        CHECK(node.null());
+        CHECK_FALSE(node.is_blank_node());
+        CHECK_FALSE(node.is_literal());
+        CHECK_FALSE(node.is_iri());
+        CHECK_FALSE(node.is_variable());
+    };
+
+    run_checks(n1);
+    run_checks(n2);
+    run_checks(n3);
+    run_checks(n4);
+    run_checks(n5);
+
+    // is_* checks are accessed with concrete type
+    CHECK(n2.is_literal());
+    CHECK(n3.is_blank_node());
+    CHECK(n4.is_iri());
+    CHECK(n5.is_variable());
 }

--- a/tests/nodes/tests_Node.cpp
+++ b/tests/nodes/tests_Node.cpp
@@ -338,10 +338,4 @@ TEST_CASE("null nodes") {
     run_checks(n3);
     run_checks(n4);
     run_checks(n5);
-
-    // is_* checks are accessed with concrete type
-    CHECK(n2.is_literal());
-    CHECK(n3.is_blank_node());
-    CHECK(n4.is_iri());
-    CHECK(n5.is_variable());
 }

--- a/tests/query/tests_QuadPattern.cpp
+++ b/tests/query/tests_QuadPattern.cpp
@@ -190,3 +190,8 @@ TEST_CASE("QuadPattern - Check for iterators and const-iterators") {
         CHECK(*(--e_const_itr) == graph1);
     }
 }
+
+TEST_CASE("null-graph string repr") {
+    Quad const q{Node{}, IRI{"http://test.com#s"}, IRI{"http://test.com#p"}, IRI{"http://test.com#o"}};
+    CHECK_EQ(std::string{q}, "<http://test.com#s> <http://test.com#p> <http://test.com#o> .");
+}

--- a/tests/query/tests_Variable.cpp
+++ b/tests/query/tests_Variable.cpp
@@ -6,15 +6,19 @@
 
 using namespace rdf4cpp;
 
+void check_variable_type(Node const &var) {
+    CHECK_FALSE(var.is_blank_node());
+    CHECK_FALSE(var.is_literal());
+    CHECK(var.is_variable());
+    CHECK_FALSE(var.is_iri());
+}
+
 TEST_CASE("Variable - Check for single node with anonymous default") {
 
     auto variable = query::Variable{"x"};
 
     CHECK(not variable.is_anonymous());
-    CHECK(not variable.is_blank_node());
-    CHECK(not variable.is_literal());
-    CHECK(variable.is_variable());
-    CHECK(not variable.is_iri());
+    check_variable_type(variable);
     CHECK(variable.name() == "x");
 }
 
@@ -23,10 +27,7 @@ TEST_CASE("Variable - Check for single node with anonymous true") {
     auto variable = query::Variable{"x", true};
 
     CHECK(variable.is_anonymous());
-    CHECK(not variable.is_blank_node());
-    CHECK(not variable.is_literal());
-    CHECK(variable.is_variable());
-    CHECK(not variable.is_iri());
+    check_variable_type(variable);
     CHECK(variable.name() == "x");
 }
 
@@ -35,10 +36,7 @@ TEST_CASE("Variable - Check for single node with anonymous false") {
     auto variable = query::Variable{"x", false};
 
     CHECK(not variable.is_anonymous());
-    CHECK(not variable.is_blank_node());
-    CHECK(not variable.is_literal());
-    CHECK(variable.is_variable());
-    CHECK(not variable.is_iri());
+    check_variable_type(variable);
     CHECK(variable.name() == "x");
 }
 


### PR DESCRIPTION
Close #321 

## Design
- null node's backend id is all zeros. This happens to be the blank node repr, but that doesn't matter (see following points)
- `Node::is_{literal,iri,..}` now return `TriBool`. If the node is null: `TriBool::Err` is returned, otherwise the function reports the type as before.
- `{Literal,IRI,BlankNode,Variable}::is_{literal,iri,..}` are now deleted, as it does not make sense to call them if you already know the concrete type of the node.

## POBR
This is **not** a POBR breaking change **under the assumption** that null-nodes are never persisted.