### PR TITLE
Feature: Variable and BlankNode inlining

### DIFF
--- a/src/rdf4cpp/BlankNode.cpp
+++ b/src/rdf4cpp/BlankNode.cpp
@@ -4,6 +4,8 @@
 #include <rdf4cpp/writer/TryWrite.hpp>
 #include <uni_algo/all.h>
 
+#include <cstring>
+
 namespace rdf4cpp {
 
 namespace detail_bnode_inlining {

--- a/src/rdf4cpp/BlankNode.cpp
+++ b/src/rdf4cpp/BlankNode.cpp
@@ -5,6 +5,49 @@
 #include <uni_algo/all.h>
 
 namespace rdf4cpp {
+
+namespace detail_bnode_inlining {
+    inline constexpr size_t max_inlined_name_len = storage::identifier::NodeID::width / (sizeof(char) * 8);
+
+    struct InlinedRepr {
+        char identifier[max_inlined_name_len];
+
+        [[nodiscard]] storage::view::BNodeBackendView view() const {
+            return storage::view::BNodeBackendView{.identifier = std::string_view{identifier, strnlen(identifier, max_inlined_name_len)}};
+        }
+
+        std::strong_ordering operator<=>(InlinedRepr const &other) const noexcept {
+            return view() <=> other.view();
+        }
+    };
+
+    [[nodiscard]] inline storage::identifier::NodeBackendID try_get_inlined(std::string_view const identifier) noexcept {
+        using namespace storage::identifier;
+
+        if (identifier.size() > max_inlined_name_len) {
+            return NodeBackendID{};
+        }
+
+        InlinedRepr inlined_data;
+
+        memcpy(&inlined_data.identifier, identifier.data(), identifier.size());
+        if (identifier.size() < max_inlined_name_len) {
+            // if name is shorter than max, put null terminator
+            inlined_data.identifier[identifier.size()] = '\0';
+        }
+
+        auto const node_id = std::bit_cast<NodeID>(inlined_data);
+
+        return NodeBackendID{node_id, RDFNodeType::BNode, true};
+    }
+
+    [[nodiscard]] constexpr InlinedRepr from_inlined(storage::identifier::NodeBackendID id) noexcept {
+        assert(id.is_inlined() && id.is_blank_node());
+        return std::bit_cast<InlinedRepr>(id.node_id());
+    }
+
+} // namespace detail_bnode_inlining
+
 BlankNode::BlankNode() noexcept : Node{storage::identifier::NodeBackendHandle{{}, storage::identifier::RDFNodeType::BNode, {}}} {
 }
 
@@ -24,13 +67,24 @@ BlankNode BlankNode::make(std::string_view identifier, storage::DynNodeStoragePt
 }
 
 BlankNode BlankNode::make_unchecked(std::string_view identifier, storage::DynNodeStoragePtr node_storage) {
-    return BlankNode{storage::identifier::NodeBackendHandle{node_storage.find_or_make_id(storage::view::BNodeBackendView{.identifier = identifier}),
-                                                            node_storage}};
+    auto const id = [&]() {
+        if (auto const inlined = detail_bnode_inlining::try_get_inlined(identifier); !inlined.null()) {
+            return inlined;
+        }
+
+        return node_storage.find_or_make_id(storage::view::BNodeBackendView{.identifier = identifier});
+    }();
+
+    return BlankNode{storage::identifier::NodeBackendHandle{id, node_storage}};
 }
 
 BlankNode BlankNode::to_node_storage(storage::DynNodeStoragePtr node_storage) const {
     if (handle_.storage() == node_storage || null()) {
         return *this;
+    }
+
+    if (handle_.is_inlined()) {
+        return BlankNode{storage::identifier::NodeBackendHandle{handle_.id(), node_storage}};
     }
 
     auto const node_id = node_storage.find_or_make_id(handle_.bnode_backend());
@@ -42,6 +96,10 @@ BlankNode BlankNode::try_get_in_node_storage(storage::DynNodeStoragePtr node_sto
         return *this;
     }
 
+    if (handle_.is_inlined()) {
+        return BlankNode{storage::identifier::NodeBackendHandle{handle_.id(), node_storage}};
+    }
+
     auto const node_id = node_storage.find_id(handle_.bnode_backend());
     if (node_id.null()) {
         return BlankNode{};
@@ -51,23 +109,41 @@ BlankNode BlankNode::try_get_in_node_storage(storage::DynNodeStoragePtr node_sto
 }
 
 BlankNode BlankNode::find(std::string_view identifier, storage::DynNodeStoragePtr node_storage) noexcept {
-    auto nid = node_storage.find_id(storage::view::BNodeBackendView{.identifier = identifier});
-    if (nid.null())
+    auto const nid = [&]() {
+        if (auto const inlined = detail_bnode_inlining::try_get_inlined(identifier); !inlined.null()) {
+            return inlined;
+        }
+
+        return node_storage.find_id(storage::view::BNodeBackendView{.identifier = identifier});
+    }();
+
+    if (nid.null()) {
         return BlankNode{};
+    }
+
     return BlankNode{storage::identifier::NodeBackendHandle{nid, node_storage}};
 }
 
-std::string_view BlankNode::identifier() const noexcept { return handle_.bnode_backend().identifier; }
+CowString BlankNode::identifier() const noexcept {
+    if (handle_.is_inlined()) {
+        auto const inlined = detail_bnode_inlining::from_inlined(handle_.id());
+        auto const identifier = inlined.view().identifier;
+
+        return CowString{CowString::owned, std::string{identifier}};
+    }
+
+    return CowString{CowString::borrowed, handle_.bnode_backend().identifier};
+}
 
 bool BlankNode::serialize(writer::BufWriterParts const writer) const noexcept {
     if (null()) {
         return rdf4cpp::writer::write_str("null", writer);
     }
 
-    auto const backend = handle_.bnode_backend();
+    auto const ident = identifier();
 
     RDF4CPP_DETAIL_TRY_WRITE_STR("_:");
-    RDF4CPP_DETAIL_TRY_WRITE_STR(backend.identifier);
+    RDF4CPP_DETAIL_TRY_WRITE_STR(ident.view());
     return true;
 }
 
@@ -114,6 +190,42 @@ void BlankNode::validate(std::string_view v) {
     if (lastchar == '.') {
         throw InvalidNode(std::format("invalid blank node label {}", v));
     }
+}
+
+std::strong_ordering BlankNode::order(BlankNode const &other) const noexcept {
+    if (is_inlined()) {
+        if (other.is_inlined()) {
+            return detail_bnode_inlining::from_inlined(handle_.id()) <=> detail_bnode_inlining::from_inlined(other.handle_.id());
+        }
+
+        // this is inlined but other is not, this means that the string of this must be smaller
+        // than the one of other
+        return std::strong_ordering::less;
+    } else {
+        if (other.is_inlined()) {
+            // same reasoning as above
+            return std::strong_ordering::greater;
+        }
+
+        return handle_.bnode_backend() <=> other.handle_.bnode_backend();
+    }
+}
+
+bool BlankNode::order_eq(BlankNode const &other) const noexcept {
+    return order(other) == std::strong_ordering::equivalent;
+}
+
+bool BlankNode::order_ne(BlankNode const &other) const noexcept {
+    return !order_eq(other);
+}
+
+bool BlankNode::eq(BlankNode const &other) const noexcept {
+    // there is no difference between order_eq and eq for blank nodes
+    return order_eq(other);
+}
+
+bool BlankNode::ne(BlankNode const &other) const noexcept {
+    return !eq(other);
 }
 
 inline namespace shorthands {

--- a/src/rdf4cpp/BlankNode.cpp
+++ b/src/rdf4cpp/BlankNode.cpp
@@ -28,16 +28,11 @@ namespace detail_bnode_inlining {
             return NodeBackendID{};
         }
 
-        InlinedRepr inlined_data;
-
+        InlinedRepr inlined_data{};
         memcpy(&inlined_data.identifier, identifier.data(), identifier.size());
-        if (identifier.size() < max_inlined_name_len) {
-            // if name is shorter than max, put null terminator
-            inlined_data.identifier[identifier.size()] = '\0';
-        }
+        // since inlined_data is initialized, there are implicitly nulls after the string if size is less than max
 
         auto const node_id = std::bit_cast<NodeID>(inlined_data);
-
         return NodeBackendID{node_id, RDFNodeType::BNode, true};
     }
 

--- a/src/rdf4cpp/BlankNode.hpp
+++ b/src/rdf4cpp/BlankNode.hpp
@@ -3,6 +3,7 @@
 
 #include <ostream>
 #include <rdf4cpp/Node.hpp>
+#include <rdf4cpp/CowString.hpp>
 
 namespace rdf4cpp {
 
@@ -57,12 +58,20 @@ struct BlankNode : Node {
      * Get the string identifier of this. For BlankNode `_:abc` the identifier is `abc`.
      * @return string identifier
      */
-    [[nodiscard]] std::string_view identifier() const noexcept;
+    [[nodiscard]] CowString identifier() const noexcept;
 
     /**
      * See Node::serialize
      */
     bool serialize(writer::BufWriterParts writer) const noexcept;
+
+    [[nodiscard]] std::strong_ordering order(BlankNode const &other) const noexcept;
+
+    [[nodiscard]] bool order_eq(BlankNode const &other) const noexcept;
+    [[nodiscard]] bool order_ne(BlankNode const &other) const noexcept;
+
+    [[nodiscard]] bool eq(BlankNode const &other) const noexcept;
+    [[nodiscard]] bool ne(BlankNode const &other) const noexcept;
 
     [[nodiscard]] explicit operator std::string() const noexcept;
 

--- a/src/rdf4cpp/Literal.cpp
+++ b/src/rdf4cpp/Literal.cpp
@@ -1188,7 +1188,7 @@ std::partial_ordering Literal::compare(Literal const &other) const noexcept {
     return this->compare_impl(other);
 }
 
-std::weak_ordering Literal::order(Literal const &other) const noexcept {
+std::strong_ordering Literal::order(Literal const &other) const noexcept {
     // default to equivalent; as required by compare_impl
     // see doc for compare_impl
     std::strong_ordering alternative_cmp_res = std::strong_ordering::equivalent;
@@ -1198,9 +1198,9 @@ std::weak_ordering Literal::order(Literal const &other) const noexcept {
         // return alternative ordering instead
         return alternative_cmp_res;
     } else if (cmp_res == std::partial_ordering::less) {
-        return std::weak_ordering::less;
+        return std::strong_ordering::less;
     } else { // cmp_res == std::partial_ordering::greater
-        return std::weak_ordering::greater;
+        return std::strong_ordering::greater;
     }
 }
 

--- a/src/rdf4cpp/Literal.hpp
+++ b/src/rdf4cpp/Literal.hpp
@@ -961,7 +961,7 @@ public:
      *          - at least one of the value's types is not comparable
      *          - there is no viable conversion to a common type to check for equality
      */
-    [[nodiscard]] std::weak_ordering order(Literal const &other) const noexcept;
+    [[nodiscard]] std::strong_ordering order(Literal const &other) const noexcept;
 
     [[nodiscard]] TriBool eq(Literal const &other) const noexcept;
     [[nodiscard]] bool order_eq(Literal const &other) const noexcept;

--- a/src/rdf4cpp/Node.cpp
+++ b/src/rdf4cpp/Node.cpp
@@ -144,7 +144,7 @@ TriBool Node::eq_impl(Node const &other) const noexcept {
             return handle_.iri_backend() == other.handle_.iri_backend();
         }
         case RDFNodeType::BNode: {
-            return handle_.bnode_backend() == other.handle_.bnode_backend();
+            return BlankNode{handle_}.eq(BlankNode{other.handle_});
         }
         case RDFNodeType::Variable: {
             return query::Variable{handle_}.eq(query::Variable{other.handle_});
@@ -202,7 +202,7 @@ std::strong_ordering Node::order(Node const &other) const noexcept {
         case storage::identifier::RDFNodeType::IRI:
             return this->handle_.iri_backend() <=> other.handle_.iri_backend();
         case storage::identifier::RDFNodeType::BNode:
-            return this->handle_.bnode_backend() <=> other.handle_.bnode_backend();
+            return BlankNode{handle_}.order(BlankNode{other.handle_});
         case storage::identifier::RDFNodeType::Literal:
             return Literal{handle_}.order(Literal{other.handle_});
         case storage::identifier::RDFNodeType::Variable:

--- a/src/rdf4cpp/Node.cpp
+++ b/src/rdf4cpp/Node.cpp
@@ -147,7 +147,7 @@ TriBool Node::eq_impl(Node const &other) const noexcept {
             return handle_.bnode_backend() == other.handle_.bnode_backend();
         }
         case RDFNodeType::Variable: {
-            return handle_.variable_backend() == other.handle_.variable_backend();
+            return query::Variable{handle_}.eq(query::Variable{other.handle_});
         }
         default: {
             assert(false); // unreachable
@@ -176,9 +176,9 @@ std::partial_ordering Node::compare_impl(Node const &other) const noexcept {
     return Literal{handle_}.compare(Literal{other.handle_});
 }
 
-std::weak_ordering Node::order(Node const &other) const noexcept {
+std::strong_ordering Node::order(Node const &other) const noexcept {
     if (this->handle_ == other.handle_) {
-        return std::weak_ordering::equivalent;
+        return std::strong_ordering::equivalent;
     }
 
     // null nodes are the smallest nodes
@@ -187,10 +187,10 @@ std::weak_ordering Node::order(Node const &other) const noexcept {
         return this->handle_.type() <=> other.handle_.type();
     }
     if (this->null()) {
-        return std::weak_ordering::less;
+        return std::strong_ordering::less;
     }
     if (other.null()) {
-        return std::weak_ordering::greater;
+        return std::strong_ordering::greater;
     }
 
     // different type
@@ -206,7 +206,7 @@ std::weak_ordering Node::order(Node const &other) const noexcept {
         case storage::identifier::RDFNodeType::Literal:
             return Literal{handle_}.order(Literal{other.handle_});
         case storage::identifier::RDFNodeType::Variable:
-            return this->handle_.variable_backend() <=> other.handle_.variable_backend();
+            return query::Variable{this->handle_}.order(query::Variable{other.handle_});
         default:{
             assert(false); // this will never be reached because RDFNodeType has only 4 values.
             return std::strong_ordering::less;

--- a/src/rdf4cpp/Node.hpp
+++ b/src/rdf4cpp/Node.hpp
@@ -205,7 +205,7 @@ public:
      * based on their string representation, and thus have an ordering.
      * For Literals you can find information about the differences in Literal::order
      */
-    [[nodiscard]] std::weak_ordering order(Node const &other) const noexcept;
+    [[nodiscard]] std::strong_ordering order(Node const &other) const noexcept;
 
     /**
      * The equality function for SPARQL filters (FILTER).

--- a/src/rdf4cpp/query/Variable.cpp
+++ b/src/rdf4cpp/query/Variable.cpp
@@ -34,17 +34,12 @@ namespace detail_variable_inlining {
             return NodeBackendID{};
         }
 
-        InlinedRepr inlined_data;
+        InlinedRepr inlined_data{};
         inlined_data.is_anonymous = is_anonymous;
-
         memcpy(&inlined_data.name, name.data(), name.size());
-        if (name.size() < max_inlined_name_len) {
-            // if name is shorter than max, put null terminator
-            inlined_data.name[name.size()] = '\0';
-        }
+        // since inlined_data is initialized, there are implicitly nulls after the string if size is less than max
 
         auto const node_id = std::bit_cast<NodeID>(inlined_data);
-
         return NodeBackendID{node_id, RDFNodeType::Variable, true};
     }
 

--- a/src/rdf4cpp/query/Variable.hpp
+++ b/src/rdf4cpp/query/Variable.hpp
@@ -71,6 +71,9 @@ public:
 
     [[nodiscard]] std::strong_ordering order(Variable const &other) const noexcept;
 
+    [[nodiscard]] bool order_eq(Variable const &other) const noexcept;
+    [[nodiscard]] bool order_ne(Variable const &other) const noexcept;
+
     [[nodiscard]] bool eq(Variable const &other) const noexcept;
     [[nodiscard]] bool ne(Variable const &other) const noexcept;
 

--- a/src/rdf4cpp/query/Variable.hpp
+++ b/src/rdf4cpp/query/Variable.hpp
@@ -3,6 +3,7 @@
 
 #include <ostream>
 #include <rdf4cpp/Node.hpp>
+#include <rdf4cpp/CowString.hpp>
 
 namespace rdf4cpp::query {
 
@@ -53,7 +54,7 @@ public:
 
     [[nodiscard]] bool is_anonymous() const;
 
-    [[nodiscard]] std::string_view name() const;
+    [[nodiscard]] CowString name() const;
 
     /**
      * See Node::serialize
@@ -67,6 +68,11 @@ public:
     [[nodiscard]] bool is_literal() const;
     [[nodiscard]] bool is_variable() const;
     [[nodiscard]] bool is_iri() const;
+
+    [[nodiscard]] std::strong_ordering order(Variable const &other) const noexcept;
+
+    [[nodiscard]] bool eq(Variable const &other) const noexcept;
+    [[nodiscard]] bool ne(Variable const &other) const noexcept;
 
     friend struct Node;
 

--- a/tests/nodes/tests_Node.cpp
+++ b/tests/nodes/tests_Node.cpp
@@ -360,6 +360,18 @@ TEST_CASE("variable inlining") {
     CHECK(v5.is_anonymous());
     CHECK_EQ(v5.name(), "fghijk");
     CHECK_EQ(v5.order(v4), std::strong_ordering::greater);
+
+    auto v6 = query::Variable::make_named("a");
+    CHECK(v6.is_inlined());
+    CHECK_FALSE(v6.is_anonymous());
+    CHECK_EQ(v6.name(), "a");
+
+    auto v7 = query::Variable::make_anonymous("a");
+    CHECK(v7.is_inlined());
+    CHECK(v7.is_anonymous());
+    CHECK_EQ(v7.name(), "a");
+
+    CHECK_EQ(v7.order(v6), std::strong_ordering::greater);
 }
 
 TEST_CASE("bnode inlining") {
@@ -392,4 +404,9 @@ TEST_CASE("bnode inlining") {
     CHECK_FALSE(v3.is_inlined());
     CHECK_EQ(v3.identifier(), "abcdefg");
     CHECK_EQ(v3.order(v1), std::strong_ordering::greater);
+
+    auto v4 = BlankNode::make("a");
+    CHECK(v4.is_inlined());
+    CHECK_EQ(v4.identifier(), "a");
+    CHECK_EQ(v4.order(v1), std::strong_ordering::less);
 }

--- a/tests/nodes/tests_Node.cpp
+++ b/tests/nodes/tests_Node.cpp
@@ -232,8 +232,8 @@ struct get_find_values<IRI> {
 };
 template<>
 struct get_find_values<BlankNode> {
-    static constexpr std::string_view t = "bl1";
-    static constexpr std::string_view v = "bl2";
+    static constexpr std::string_view t = "bl1aaaa";
+    static constexpr std::string_view v = "bl2aaaa";
 };
 
 TEST_CASE_TEMPLATE("IRI/BlankNode::find", T, IRI, BlankNode) {
@@ -307,15 +307,89 @@ TEST_CASE_TEMPLATE("NodeStorage erase IRI", T, reference_node_storage::SyncRefer
 }
 
 TEST_CASE("variable inlining") {
-    query::Variable v1 = query::Variable::make_named("abcde");
+    auto const check_node_storage_transfer = [](query::Variable const &var) {
+        storage::reference_node_storage::UnsyncReferenceNodeStorage ns;
+
+        auto again = [&]() {
+            if (var.is_anonymous()) {
+                return query::Variable::find_anonymous(var.name(), ns);
+            } else {
+                return query::Variable::find_named(var.name(), ns);
+            }
+        }();
+        CHECK_EQ(var.backend_handle().id(), again.backend_handle().id());
+
+        auto again2 = var.try_get_in_node_storage(ns);
+        CHECK_EQ(var.backend_handle().id(), again2.backend_handle().id());
+
+        auto again3 = var.to_node_storage(ns);
+        CHECK_EQ(var.backend_handle().id(), again3.backend_handle().id());
+    };
+
+    auto v1 = query::Variable::make_named("abcde");
     CHECK(v1.is_inlined());
     CHECK_FALSE(v1.is_anonymous());
     CHECK_EQ(v1.name(), "abcde");
+    check_node_storage_transfer(v1);
 
-    query::Variable v2 = query::Variable::make_named("fghij");
-    CHECK_FALSE(v2.is_anonymous());
+    auto v2 = query::Variable::make_named("fghij");
     CHECK(v2.is_inlined());
-
+    CHECK_FALSE(v2.is_anonymous());
+    CHECK_EQ(v2.name(), "fghij");
     CHECK_EQ(v1.name().size(), v2.name().size());
-    CHECK(v1.order(v2) == std::strong_ordering::less);
+    CHECK_EQ(v1.order(v2), std::strong_ordering::less);
+    check_node_storage_transfer(v2);
+
+    auto v3 = query::Variable::make_anonymous(v1.name());
+    CHECK(v3.is_inlined());
+    CHECK(v3.is_anonymous());
+    CHECK_EQ(v3.name(), "abcde");
+    CHECK_EQ(v3.name(), v1.name());
+    CHECK_NE(v3, v1);
+    CHECK_EQ(v3.order(v1), std::strong_ordering::greater);
+    check_node_storage_transfer(v3);
+
+    auto v4 = query::Variable::make_named("abcdef");
+    CHECK_FALSE(v4.is_inlined());
+    CHECK_FALSE(v4.is_anonymous());
+    CHECK_EQ(v4.name(), "abcdef");
+    CHECK_EQ(v4.order(v1), std::strong_ordering::greater);
+
+    auto v5 = query::Variable::make_anonymous("fghijk");
+    CHECK_FALSE(v5.is_inlined());
+    CHECK(v5.is_anonymous());
+    CHECK_EQ(v5.name(), "fghijk");
+    CHECK_EQ(v5.order(v4), std::strong_ordering::greater);
+}
+
+TEST_CASE("bnode inlining") {
+    auto const check_node_storage_transfer = [](BlankNode const &bnode) {
+        storage::reference_node_storage::UnsyncReferenceNodeStorage ns;
+
+        auto again = BlankNode::find(bnode.identifier(), ns);
+        CHECK_EQ(bnode.backend_handle().id(), again.backend_handle().id());
+
+        auto again2 = bnode.try_get_in_node_storage(ns);
+        CHECK_EQ(bnode.backend_handle().id(), again2.backend_handle().id());
+
+        auto again3 = bnode.to_node_storage(ns);
+        CHECK_EQ(bnode.backend_handle().id(), again3.backend_handle().id());
+    };
+
+    auto v1 = BlankNode::make("abcdef");
+    CHECK(v1.is_inlined());
+    CHECK_EQ(v1.identifier(), "abcdef");
+    check_node_storage_transfer(v1);
+
+    auto v2 = BlankNode::make("fghijk");
+    CHECK(v2.is_inlined());
+    CHECK_EQ(v2.identifier(), "fghijk");
+    CHECK_EQ(v1.identifier().size(), v2.identifier().size());
+    CHECK_EQ(v1.order(v2), std::strong_ordering::less);
+    check_node_storage_transfer(v2);
+
+    auto v3 = BlankNode::make("abcdefg");
+    CHECK_FALSE(v3.is_inlined());
+    CHECK_EQ(v3.identifier(), "abcdefg");
+    CHECK_EQ(v3.order(v1), std::strong_ordering::greater);
 }

--- a/tests/nodes/tests_Node.cpp
+++ b/tests/nodes/tests_Node.cpp
@@ -372,6 +372,12 @@ TEST_CASE("variable inlining") {
     CHECK_EQ(v7.name(), "a");
 
     CHECK_EQ(v7.order(v6), std::strong_ordering::greater);
+
+    auto v8 = query::Variable::make_named("aaaaaa");
+    CHECK_FALSE(v8.is_inlined());
+    CHECK_FALSE(v8.is_anonymous());
+    CHECK_GT(v8.name().size(), v1.name().size());
+    CHECK_EQ(v8.order(v1), std::strong_ordering::less);
 }
 
 TEST_CASE("bnode inlining") {
@@ -409,4 +415,9 @@ TEST_CASE("bnode inlining") {
     CHECK(v4.is_inlined());
     CHECK_EQ(v4.identifier(), "a");
     CHECK_EQ(v4.order(v1), std::strong_ordering::less);
+
+    auto v5 = BlankNode::make("aaaaaaa");
+    CHECK_FALSE(v5.is_inlined());
+    CHECK_GT(v5.identifier().size(), v1.identifier().size());
+    CHECK_EQ(v5.order(v1), std::strong_ordering::less);
 }

--- a/tests/nodes/tests_Node.cpp
+++ b/tests/nodes/tests_Node.cpp
@@ -305,3 +305,17 @@ TEST_CASE_TEMPLATE("NodeStorage erase IRI", T, reference_node_storage::SyncRefer
     CHECK(!ns.erase_iri(IRI::find(rdf4cpp::datatypes::xsd::Int::identifier, ns).backend_handle().id()));
     CHECK(IRI::find(rdf4cpp::datatypes::xsd::Int::identifier, ns) != IRI());
 }
+
+TEST_CASE("variable inlining") {
+    query::Variable v1 = query::Variable::make_named("abcde");
+    CHECK(v1.is_inlined());
+    CHECK_FALSE(v1.is_anonymous());
+    CHECK_EQ(v1.name(), "abcde");
+
+    query::Variable v2 = query::Variable::make_named("fghij");
+    CHECK_FALSE(v2.is_anonymous());
+    CHECK(v2.is_inlined());
+
+    CHECK_EQ(v1.name().size(), v2.name().size());
+    CHECK(v1.order(v2) == std::strong_ordering::less);
+}

--- a/tests/query/tests_Variable.cpp
+++ b/tests/query/tests_Variable.cpp
@@ -44,8 +44,8 @@ TEST_CASE("Variable - Check for single node with anonymous false") {
 
 TEST_CASE("Variable::find") {
     storage::reference_node_storage::SyncReferenceNodeStorage nst;
-    static constexpr std::string_view v = "var";
-    static constexpr std::string_view v2 = "var2";
+    static constexpr std::string_view v = "varaaaaaaa";
+    static constexpr std::string_view v2 = "varaaaaaaaa2";
 
     CHECK(query::Variable::find_named(v, nst) == query::Variable{});
     auto qv = query::Variable::make_named(v, nst);


### PR DESCRIPTION
Implements inlining for Variables and BlankNodes to avoid node storage access for variables/bnodes with short names (which is probably very common).

Variables are inlined if their name is at most 5 characters long.
BlankNodes are inlined if their name is at most 6 characters long.

This **is** a POBR breaking change.