### PR TITLE
fix license copy

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -70,8 +70,8 @@ class Recipe(ConanFile):
         cmake.install()
         rmdir(self, os.path.join(self.package_folder, "cmake"))
         rmdir(self, os.path.join(self.package_folder, "share"))
-        copy(self, "LICENSE", src=self.recipe_folder, dst="licenses")
-        copy(self, os.path.join("serd", "COPYING"), src=self.build_folder, dst="licenses")
+        copy(self, "LICENSE", src=self.recipe_folder, dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, os.path.join("serd", "COPYING"), src=self.build_folder, dst=os.path.join(self.package_folder, "licenses"))
 
     def package_info(self):
         self.cpp_info.libs = ["rdf4cpp"]


### PR DESCRIPTION
Note: easiest way to validate, if the licenses get properly copied, is to run `conan create`, get the cache path from the output and check it manually