### PR TITLE
Fix: UBSan warning in datetime tests

### DIFF
--- a/src/rdf4cpp/Literal.cpp
+++ b/src/rdf4cpp/Literal.cpp
@@ -1368,8 +1368,7 @@ Literal Literal::add(Literal const &other, storage::DynNodeStoragePtr node_stora
     }
     // DateTime(&Subclasses) + Duration(&Subclasses)
     {
-        try
-        {
+        try {
             auto this_dt = this->cast_to_supertype_value<datatypes::xsd::DateTime>();
             auto other_dt = other.cast_to_supertype_value<datatypes::xsd::Duration>();
             if (this_dt.has_value() && other_dt.has_value()) {
@@ -2278,14 +2277,14 @@ std::optional<Year> Literal::year() const noexcept {
     if (!casted.has_value())
         return std::nullopt;
     auto [date, _] = util::deconstruct_timepoint(casted->first);
-    return date.year;
+    return date.year();
 }
 
 Literal Literal::as_year(storage::DynNodeStoragePtr node_storage) const {
     auto r = this->year();
     if (!r.has_value())
         return Literal{};
-    return Literal::make_typed_from_value<datatypes::xsd::Integer>(r->year, select_node_storage(node_storage));
+    return Literal::make_typed_from_value<datatypes::xsd::Integer>(static_cast<int64_t>(*r), select_node_storage(node_storage));
 }
 
 std::optional<std::chrono::month> Literal::month() const noexcept {
@@ -2296,7 +2295,7 @@ std::optional<std::chrono::month> Literal::month() const noexcept {
     if (!casted.has_value())
         return std::nullopt;
     auto [date, _] = util::deconstruct_timepoint(casted->first);
-    return date.month;
+    return date.month();
 }
 
 Literal Literal::as_month(storage::DynNodeStoragePtr node_storage) const {
@@ -2314,7 +2313,7 @@ std::optional<std::chrono::day> Literal::day() const noexcept {
     if (!casted.has_value())
         return std::nullopt;
     auto [date, _] = util::deconstruct_timepoint(casted->first);
-    return date.day;
+    return date.day();
 }
 
 Literal Literal::as_day(storage::DynNodeStoragePtr node_storage) const {

--- a/src/rdf4cpp/Timezone.hpp
+++ b/src/rdf4cpp/Timezone.hpp
@@ -144,7 +144,7 @@ private:
     int64_t value_;
 
 public:
-    explicit constexpr Year(int64_t value = 0) noexcept : value_{value} {
+    explicit constexpr Year(int64_t y = 0) noexcept : value_{y} {
     }
 
     constexpr explicit operator int64_t() const noexcept {
@@ -246,10 +246,10 @@ public:
     }
 
     friend constexpr YearMonth operator+(YearMonth const &ym, std::chrono::years d) noexcept {
-        return YearMonth{ym.year_ + d, ym.month()};
+        return YearMonth{ym.year_ + d, ym.month_};
     }
     friend constexpr YearMonth operator+(std::chrono::years d, YearMonth const &ym) noexcept {
-        return YearMonth{ym.year_ + d, ym.month()};
+        return YearMonth{ym.year_ + d, ym.month_};
     }
 
     constexpr YearMonth& operator+=(std::chrono::years d) noexcept {
@@ -258,10 +258,10 @@ public:
     }
 
     friend constexpr YearMonth operator+(YearMonth const &ym, std::chrono::months d) noexcept {
-        return create_normalized(static_cast<int64_t>(ym.year()), static_cast<unsigned int>(ym.month()) + d.count());
+        return create_normalized(static_cast<int64_t>(ym.year_), static_cast<unsigned int>(ym.month_) + d.count());
     }
     friend constexpr YearMonth operator+(std::chrono::months d, YearMonth const &ym) noexcept {
-        return create_normalized(static_cast<int64_t>(ym.year()), static_cast<unsigned int>(ym.month()) + d.count());
+        return create_normalized(static_cast<int64_t>(ym.year_), static_cast<unsigned int>(ym.month_) + d.count());
     }
 
     constexpr YearMonth& operator+=(std::chrono::months d) noexcept {
@@ -270,14 +270,14 @@ public:
     }
 
     friend constexpr YearMonth operator-(YearMonth const &ym, std::chrono::years d) noexcept {
-        return {ym.year() - d, ym.month()};
+        return {ym.year_ - d, ym.month_};
     }
     friend constexpr YearMonth operator-(YearMonth const &ym, std::chrono::months d) noexcept {
-        return create_normalized(static_cast<int64_t>(ym.year()), static_cast<unsigned int>(ym.month()) - d.count());
+        return create_normalized(static_cast<int64_t>(ym.year_), static_cast<unsigned int>(ym.month_) - d.count());
     }
 
     friend constexpr std::chrono::months operator-(YearMonth const &a, YearMonth const &b) noexcept {
-        return (a.year() - b.year()) + (a.month() - b.month());
+        return (a.year_ - b.year_) + (a.month_ - b.month_);
     }
 
     constexpr YearMonth& operator-=(std::chrono::years d) noexcept {
@@ -302,9 +302,9 @@ private:
     Month month_ = Month{1};
     Day day_ = Day{1};
 
-    static constexpr std::chrono::day last_day_in_month(Year year, std::chrono::month month) noexcept {
+    static constexpr std::chrono::day last_day_in_month(Year year, Month month) noexcept {
         assert(month.ok());
-        constexpr unsigned char common[] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+        constexpr unsigned char common[]{31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
         auto m = static_cast<unsigned int>(month);
         return std::chrono::day{m != 2 || !year.is_leap() ? common[m - 1] : 29u};
     }
@@ -324,7 +324,7 @@ public:
     constexpr YearMonthDay(YearMonth const &ym, Day d) noexcept
         : year_(ym.year()), month_(ym.month()), day_(d) {
     }
-    constexpr YearMonthDay(YearMonth const & ym, std::chrono::last_spec) noexcept
+    constexpr YearMonthDay(YearMonth const &ym, std::chrono::last_spec) noexcept
         : YearMonthDay(ym.year(), ym.month(), std::chrono::last) {
     }
     template<typename P>

--- a/src/rdf4cpp/Timezone.hpp
+++ b/src/rdf4cpp/Timezone.hpp
@@ -132,21 +132,36 @@ struct Timezone {
 
 using OptionalTimezone = std::optional<Timezone>;
 
-struct Year {
-    // adapted from https://howardhinnant.github.io/date_algorithms.html
-    int64_t year = 0;
+using Month = std::chrono::month;
+using Day = std::chrono::day;
 
-    [[nodiscard]] constexpr bool is_leap() const noexcept(noexcept(year % 100)) {
-        return year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
+/**
+ * Like std::chrono::year, except it has a greater range.
+ * adapted from https://howardhinnant.github.io/date_algorithms.html
+ */
+struct Year {
+private:
+    int64_t value_;
+
+public:
+    explicit constexpr Year(int64_t value = 0) noexcept : value_{value} {
+    }
+
+    constexpr explicit operator int64_t() const noexcept {
+        return value_;
+    }
+
+    [[nodiscard]] constexpr bool is_leap() const noexcept(noexcept(value_ % 100)) {
+        return value_ % 4 == 0 && (value_ % 100 != 0 || value_ % 400 == 0);
     }
 
     constexpr auto operator<=>(Year const &) const noexcept = default;
 
     friend constexpr Year operator+(Year const &y, std::chrono::years d) noexcept {
-        return Year{y.year + d.count()};
+        return Year{y.value_ + d.count()};
     }
     friend constexpr Year operator+(std::chrono::years d, Year const &y) noexcept {
-        return Year{y.year + d.count()};
+        return Year{y.value_ + d.count()};
     }
 
     constexpr Year operator+=(std::chrono::years d) noexcept {
@@ -155,10 +170,10 @@ struct Year {
     }
 
     friend constexpr Year operator-(Year const &y, std::chrono::years d) noexcept {
-        return Year{y.year - d.count()};
+        return Year{y.value_ - d.count()};
     }
     friend constexpr std::chrono::years operator-(Year const &a, Year const &b) noexcept {
-        return std::chrono::years{a.year - b.year};
+        return std::chrono::years{a.value_ - b.value_};
     }
 
     constexpr Year operator-=(std::chrono::years d) noexcept {
@@ -195,28 +210,10 @@ struct Year {
 };
 
 struct YearMonth {
-    Year year = Year{0};
-    std::chrono::month month = std::chrono::month{1};
-
-    constexpr auto operator<=>(YearMonth const &) const noexcept = default;
-
-    [[nodiscard]] constexpr bool ok() const noexcept {
-        return month.ok();
-    }
-
-    friend constexpr YearMonth operator+(YearMonth const &ym, std::chrono::years d) noexcept {
-        return {ym.year + d, ym.month};
-    }
-    friend constexpr YearMonth operator+(std::chrono::years d, YearMonth const &ym) noexcept {
-        return {ym.year + d, ym.month};
-    }
-
-    constexpr YearMonth& operator+=(std::chrono::years d) noexcept {
-        *this = *this + d;
-        return *this;
-    }
-
 private:
+    Year year_ = Year{0};
+    Month month_ = Month{1};
+
     static constexpr YearMonth create_normalized(int64_t y, int64_t mo) noexcept {
         --mo;
         y += mo / 12;
@@ -225,14 +222,46 @@ private:
             --y;
             mo += 12;
         }
-        return {Year{y}, std::chrono::month{static_cast<unsigned int>(mo+1)}};
+        return YearMonth{Year{y}, std::chrono::month{static_cast<unsigned int>(mo+1)}};
     }
+
 public:
+    constexpr YearMonth() noexcept = default;
+
+    constexpr YearMonth(Year y, std::chrono::month m) noexcept : year_{y}, month_{m} {
+    }
+
+    [[nodiscard]] constexpr Year year() const noexcept {
+        return year_;
+    }
+
+    [[nodiscard]] constexpr Month month() const noexcept {
+        return month_;
+    }
+
+    constexpr auto operator<=>(YearMonth const &) const noexcept = default;
+
+    [[nodiscard]] constexpr bool ok() const noexcept {
+        return month_.ok();
+    }
+
+    friend constexpr YearMonth operator+(YearMonth const &ym, std::chrono::years d) noexcept {
+        return YearMonth{ym.year_ + d, ym.month()};
+    }
+    friend constexpr YearMonth operator+(std::chrono::years d, YearMonth const &ym) noexcept {
+        return YearMonth{ym.year_ + d, ym.month()};
+    }
+
+    constexpr YearMonth& operator+=(std::chrono::years d) noexcept {
+        *this = *this + d;
+        return *this;
+    }
+
     friend constexpr YearMonth operator+(YearMonth const &ym, std::chrono::months d) noexcept {
-        return create_normalized(ym.year.year, static_cast<unsigned int>(ym.month) + d.count());
+        return create_normalized(static_cast<int64_t>(ym.year()), static_cast<unsigned int>(ym.month()) + d.count());
     }
     friend constexpr YearMonth operator+(std::chrono::months d, YearMonth const &ym) noexcept {
-        return create_normalized(ym.year.year, static_cast<unsigned int>(ym.month) + d.count());
+        return create_normalized(static_cast<int64_t>(ym.year()), static_cast<unsigned int>(ym.month()) + d.count());
     }
 
     constexpr YearMonth& operator+=(std::chrono::months d) noexcept {
@@ -241,14 +270,14 @@ public:
     }
 
     friend constexpr YearMonth operator-(YearMonth const &ym, std::chrono::years d) noexcept {
-        return {ym.year - d, ym.month};
+        return {ym.year() - d, ym.month()};
     }
     friend constexpr YearMonth operator-(YearMonth const &ym, std::chrono::months d) noexcept {
-        return create_normalized(ym.year.year, static_cast<unsigned int>(ym.month) - d.count());
+        return create_normalized(static_cast<int64_t>(ym.year()), static_cast<unsigned int>(ym.month()) - d.count());
     }
 
     friend constexpr std::chrono::months operator-(YearMonth const &a, YearMonth const &b) noexcept {
-        return (a.year - b.year) + (a.month - b.month);
+        return (a.year() - b.year()) + (a.month() - b.month());
     }
 
     constexpr YearMonth& operator-=(std::chrono::years d) noexcept {
@@ -262,17 +291,17 @@ public:
 };
 
 struct YearMonthDay {
-    // adapted from https://howardhinnant.github.io/date_algorithms.html
-    Year year = Year{0};
-    std::chrono::month month = std::chrono::month{1};
-    std::chrono::day day = std::chrono::day{1};
-
     template<typename P>
     using time_point = std::chrono::time_point<std::chrono::system_clock, std::chrono::duration<P, std::chrono::days::period>>;
     template<typename P>
     using time_point_local = std::chrono::time_point<std::chrono::local_t, std::chrono::duration<P, std::chrono::days::period>>;
 
 private:
+    // adapted from https://howardhinnant.github.io/date_algorithms.html
+    Year year_ = Year{0};
+    Month month_ = Month{1};
+    Day day_ = Day{1};
+
     static constexpr std::chrono::day last_day_in_month(Year year, std::chrono::month month) noexcept {
         assert(month.ok());
         constexpr unsigned char common[] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
@@ -282,20 +311,21 @@ private:
 
 public:
     constexpr YearMonthDay() noexcept  = default;
+
     constexpr explicit YearMonthDay(std::chrono::year_month_day ymd) noexcept
-        : year(static_cast<int>(ymd.year())), month(ymd.month()), day(ymd.day()) {
+        : year_(static_cast<int>(ymd.year())), month_(ymd.month()), day_(ymd.day()) {
     }
-    constexpr YearMonthDay(Year const &y, std::chrono::month m, std::chrono::day d) noexcept
-        : year(y), month(m), day(d) {
+    constexpr YearMonthDay(Year const &y, Month m, std::chrono::day d) noexcept
+        : year_(y), month_(m), day_(d) {
     }
-    constexpr YearMonthDay(Year const &y, std::chrono::month m, std::chrono::last_spec) noexcept
-        : year(y), month(m), day(last_day_in_month(y, m)) {
+    constexpr YearMonthDay(Year const &y, Month m, std::chrono::last_spec) noexcept
+        : year_(y), month_(m), day_(last_day_in_month(y, m)) {
     }
-    constexpr YearMonthDay(YearMonth const & ym, std::chrono::day d) noexcept
-            : year(ym.year), month(ym.month), day(d) {
+    constexpr YearMonthDay(YearMonth const &ym, Day d) noexcept
+        : year_(ym.year()), month_(ym.month()), day_(d) {
     }
     constexpr YearMonthDay(YearMonth const & ym, std::chrono::last_spec) noexcept
-        : YearMonthDay(ym.year, ym.month, std::chrono::last) {
+        : YearMonthDay(ym.year(), ym.month(), std::chrono::last) {
     }
     template<typename P>
     constexpr explicit YearMonthDay(time_point<P> sd) noexcept(noexcept(P{} + P{} * P{} - P{} / P{})) {
@@ -312,22 +342,34 @@ public:
         auto const mp = (5 * doy + 2) / 153;                       // [0, 11]
         auto const d = doy - (153 * mp + 2) / 5 + 1;               // [1, 31]
         auto const m = mp < 10 ? mp + 3 : mp - 9;                  // [1, 12]
-        year = Year{static_cast<int64_t>(y + (m <= 2))};
-        month = std::chrono::month{static_cast<unsigned>(m)};
-        day = std::chrono::day{static_cast<unsigned>(d)};
+        year_ = Year{static_cast<int64_t>(y + (m <= 2))};
+        month_ = std::chrono::month{static_cast<unsigned>(m)};
+        day_ = std::chrono::day{static_cast<unsigned>(d)};
     }
     template<typename P>
     constexpr explicit YearMonthDay(time_point_local<P> sd) noexcept(noexcept(P{} + P{} * P{} - P{} / P{}))
         : YearMonthDay(time_point<P>(sd.time_since_epoch())) {
     }
 
+    [[nodiscard]] constexpr Year year() const noexcept {
+        return year_;
+    }
+
+    [[nodiscard]] constexpr Month month() const noexcept {
+        return month_;
+    }
+
+    [[nodiscard]] constexpr Day day() const noexcept {
+        return day_;
+    }
+
     [[nodiscard]] constexpr time_point<boost::multiprecision::checked_int128_t> to_time_point() const {
         static_assert(std::numeric_limits<unsigned>::digits >= 18, "This algorithm has not been ported to a 16 bit unsigned integer");
         static_assert(std::numeric_limits<int64_t>::digits >= 20, "This algorithm has not been ported to a 16 bit signed integer");
         static_assert(std::numeric_limits<boost::multiprecision::checked_int128_t>::digits >= 20, "This algorithm has not been ported to a 16 bit signed integer");
-        boost::multiprecision::checked_int128_t y = year.year;
-        auto m = static_cast<unsigned int>(month);
-        auto d = static_cast<unsigned int>(day);
+        boost::multiprecision::checked_int128_t y = static_cast<int64_t>(year_);
+        auto m = static_cast<unsigned int>(month_);
+        auto d = static_cast<unsigned int>(day_);
         y -= m <= 2;
         boost::multiprecision::checked_int128_t const era = (y >= 0 ? y : y - 399) / 400;
         auto const yoe = static_cast<unsigned>(y - era * 400);                 // [0, 399]
@@ -341,16 +383,16 @@ public:
     }
 
     [[nodiscard]] constexpr bool ok() const noexcept {
-        return month.ok() && day.ok() && day <= last_day_in_month(year, month);
+        return month_.ok() && day_.ok() && day_ <= last_day_in_month(year_, month_);
     }
 
     constexpr auto operator<=>(YearMonthDay const &) const noexcept = default;
 
     friend constexpr YearMonthDay operator+(YearMonthDay const &ym, std::chrono::years d) noexcept {
-        return {ym.year + d, ym.month, ym.day};
+        return {ym.year_ + d, ym.month_, ym.day_};
     }
     friend constexpr YearMonthDay operator+(std::chrono::years d, YearMonthDay const &ym) noexcept {
-        return {ym.year + d, ym.month, ym.day};
+        return {ym.year_ + d, ym.month_, ym.day_};
     }
 
     constexpr YearMonthDay & operator+=(std::chrono::years d) noexcept {
@@ -359,10 +401,10 @@ public:
     }
 
     friend constexpr YearMonthDay operator+(YearMonthDay const &d, std::chrono::months m) noexcept {
-        return YearMonthDay{YearMonth{d.year, d.month} + m, d.day};
+        return YearMonthDay{YearMonth{d.year_, d.month_} + m, d.day_};
     }
     friend constexpr YearMonthDay operator+(std::chrono::months m, YearMonthDay const &d) noexcept {
-        return YearMonthDay{YearMonth{d.year, d.month} + m, d.day};
+        return YearMonthDay{YearMonth{d.year_, d.month_} + m, d.day_};
     }
 
     constexpr YearMonthDay & operator+=(std::chrono::months d) noexcept {
@@ -371,10 +413,10 @@ public:
     }
 
     friend constexpr YearMonthDay operator-(YearMonthDay const &ym, std::chrono::years d) noexcept {
-        return {ym.year - d, ym.month, ym.day};
+        return {ym.year_ - d, ym.month_, ym.day_};
     }
     friend constexpr YearMonthDay operator-(YearMonthDay const &d, std::chrono::months m) noexcept {
-        return YearMonthDay{YearMonth{d.year, d.month} - m, d.day};
+        return YearMonthDay{YearMonth{d.year_, d.month_} - m, d.day_};
     }
 
     constexpr YearMonthDay & operator-=(std::chrono::years d) noexcept {
@@ -447,38 +489,38 @@ struct dice::hash::dice_hash_overload<Policy, ::boost::multiprecision::checked_i
 template<typename Policy>
 struct dice::hash::dice_hash_overload<Policy, rdf4cpp::Year> {
     static size_t dice_hash(rdf4cpp::Year const &x) noexcept {
-        return dice::hash::dice_hash_templates<Policy>::dice_hash(x.year);
+        return dice::hash::dice_hash_templates<Policy>::dice_hash(static_cast<int64_t>(x));
     }
 };
 template<typename Policy>
 struct dice::hash::dice_hash_overload<Policy, rdf4cpp::YearMonthDay> {
     static size_t dice_hash(rdf4cpp::YearMonthDay const &x) noexcept {
-        return dice::hash::dice_hash_templates<Policy>::dice_hash(std::tie(x.year, x.month, x.day));
+        return dice::hash::dice_hash_templates<Policy>::dice_hash(std::make_tuple(x.year(), x.month(), x.day()));
     }
 };
 template<typename Policy>
 struct dice::hash::dice_hash_overload<Policy, rdf4cpp::YearMonth> {
     static size_t dice_hash(rdf4cpp::YearMonth const &x) noexcept {
-        return dice::hash::dice_hash_templates<Policy>::dice_hash(std::tie(x.year, x.month));
+        return dice::hash::dice_hash_templates<Policy>::dice_hash(std::make_tuple(x.year(), x.month()));
     }
 };
 
 template<>
 struct std::formatter<rdf4cpp::Year> : std::formatter<string_view> {
     inline auto format(rdf4cpp::Year const &p, format_context &ctx) const {
-        return std::format_to(ctx.out(), "{:0{}}", p.year, p.year < 0 ? 5 : 4);
+        return std::format_to(ctx.out(), "{:0{}}", static_cast<int64_t>(p), static_cast<int64_t>(p) < 0 ? 5 : 4);
     }
 };
 template<>
 struct std::formatter<rdf4cpp::YearMonthDay> : std::formatter<string_view> {
     inline auto format(rdf4cpp::YearMonthDay const &p, format_context &ctx) const {
-        return std::format_to(ctx.out(), "{}-{:%m}-{:%d}", p.year, p.month, p.day);
+        return std::format_to(ctx.out(), "{}-{:%m}-{:%d}", p.year(), p.month(), p.day());
     }
 };
 template<>
 struct std::formatter<rdf4cpp::YearMonth> : std::formatter<string_view> {
     inline auto format(rdf4cpp::YearMonth const &p, format_context &ctx) const {
-        return std::format_to(ctx.out(), "{}-{:%m}", p.year, p.month);
+        return std::format_to(ctx.out(), "{}-{:%m}", p.year(), p.month());
     }
 };
 template<>

--- a/src/rdf4cpp/datatypes/xsd/time/Day.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/Day.cpp
@@ -39,7 +39,7 @@ bool capabilities::Default<xsd_gDay>::serialize_canonical_string(cpp_type const 
 template<>
 std::partial_ordering capabilities::Comparable<xsd_gDay>::compare(cpp_type const &lhs, cpp_type const &rhs) noexcept {
     auto day_to_tp = [](std::chrono::day d) noexcept -> rdf4cpp::TimePoint {
-        return rdf4cpp::util::construct_timepoint(YearMonthDay{rdf4cpp::util::time_point_replacement_date.year, rdf4cpp::util::time_point_replacement_date.month, d}, rdf4cpp::util::time_point_replacement_time_of_day);
+        return rdf4cpp::util::construct_timepoint(YearMonthDay{rdf4cpp::util::time_point_replacement_date.year(), rdf4cpp::util::time_point_replacement_date.month(), d}, rdf4cpp::util::time_point_replacement_time_of_day);
     };
     return registry::util::compare_time_points(day_to_tp(lhs.first), lhs.second, day_to_tp(rhs.first), rhs.second);
 }
@@ -64,13 +64,13 @@ capabilities::Inlineable<xsd_gDay>::cpp_type capabilities::Inlineable<xsd_gDay>:
 template<>
 template<>
 capabilities::Subtype<xsd_gDay>::super_cpp_type<0> capabilities::Subtype<xsd_gDay>::into_supertype<0>(cpp_type const &value) noexcept {
-    return std::make_pair(YearMonthDay{rdf4cpp::util::time_point_replacement_date.year, rdf4cpp::util::time_point_replacement_date.month, value.first}, value.second);
+    return std::make_pair(YearMonthDay{rdf4cpp::util::time_point_replacement_date.year(), rdf4cpp::util::time_point_replacement_date.month(), value.first}, value.second);
 }
 
 template<>
 template<>
 nonstd::expected<capabilities::Subtype<xsd_gDay>::cpp_type, DynamicError> capabilities::Subtype<xsd_gDay>::from_supertype<0>(super_cpp_type<0> const &value) noexcept {
-    return std::make_pair(value.first.day, value.second);
+    return std::make_pair(value.first.day(), value.second);
 }
 #endif
 

--- a/src/rdf4cpp/datatypes/xsd/time/Month.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/Month.cpp
@@ -39,7 +39,7 @@ bool capabilities::Default<xsd_gMonth>::serialize_canonical_string(cpp_type cons
 template<>
 std::partial_ordering capabilities::Comparable<xsd_gMonth>::compare(cpp_type const &lhs, cpp_type const &rhs) noexcept {
     auto month_to_tp = [](std::chrono::month m) noexcept -> rdf4cpp::TimePoint {
-        return rdf4cpp::util::construct_timepoint(YearMonthDay{rdf4cpp::util::time_point_replacement_date.year, m, std::chrono::last}, rdf4cpp::util::time_point_replacement_time_of_day);
+        return rdf4cpp::util::construct_timepoint(YearMonthDay{rdf4cpp::util::time_point_replacement_date.year(), m, std::chrono::last}, rdf4cpp::util::time_point_replacement_time_of_day);
     };
     return registry::util::compare_time_points(month_to_tp(lhs.first), lhs.second, month_to_tp(rhs.first), rhs.second);
 }
@@ -64,13 +64,13 @@ capabilities::Inlineable<xsd_gMonth>::cpp_type capabilities::Inlineable<xsd_gMon
 template<>
 template<>
 capabilities::Subtype<xsd_gMonth>::super_cpp_type<0> capabilities::Subtype<xsd_gMonth>::into_supertype<0>(cpp_type const &value) noexcept {
-    return std::make_pair(YearMonthDay{rdf4cpp::util::time_point_replacement_date.year, value.first, std::chrono::last}, value.second);
+    return std::make_pair(YearMonthDay{rdf4cpp::util::time_point_replacement_date.year(), value.first, std::chrono::last}, value.second);
 }
 
 template<>
 template<>
 nonstd::expected<capabilities::Subtype<xsd_gMonth>::cpp_type, DynamicError> capabilities::Subtype<xsd_gMonth>::from_supertype<0>(super_cpp_type<0> const &value) noexcept {
-    return std::make_pair(value.first.month, value.second);
+    return std::make_pair(value.first.month(), value.second);
 }
 #endif
 

--- a/src/rdf4cpp/datatypes/xsd/time/MonthDay.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/MonthDay.cpp
@@ -62,7 +62,7 @@ capabilities::Inlineable<xsd_gMonthDay>::cpp_type capabilities::Inlineable<xsd_g
 template<>
 std::partial_ordering capabilities::Comparable<xsd_gMonthDay>::compare(cpp_type const &lhs, cpp_type const &rhs) noexcept {
     auto md_to_tp = [](std::chrono::month_day md) noexcept -> rdf4cpp::TimePoint {
-        return rdf4cpp::util::construct_timepoint(YearMonthDay{rdf4cpp::util::time_point_replacement_date.year, md.month(), md.day()}, rdf4cpp::util::time_point_replacement_time_of_day);
+        return rdf4cpp::util::construct_timepoint(YearMonthDay{rdf4cpp::util::time_point_replacement_date.year(), md.month(), md.day()}, rdf4cpp::util::time_point_replacement_time_of_day);
     };
     return registry::util::compare_time_points(md_to_tp(lhs.first), lhs.second, md_to_tp(rhs.first), rhs.second);
 }
@@ -70,13 +70,13 @@ std::partial_ordering capabilities::Comparable<xsd_gMonthDay>::compare(cpp_type 
 template<>
 template<>
 capabilities::Subtype<xsd_gMonthDay>::super_cpp_type<0> capabilities::Subtype<xsd_gMonthDay>::into_supertype<0>(cpp_type const &value) noexcept {
-    return std::make_pair(YearMonthDay{rdf4cpp::util::time_point_replacement_date.year, value.first.month(), value.first.day()}, value.second);
+    return std::make_pair(YearMonthDay{rdf4cpp::util::time_point_replacement_date.year(), value.first.month(), value.first.day()}, value.second);
 }
 
 template<>
 template<>
 nonstd::expected<capabilities::Subtype<xsd_gMonthDay>::cpp_type, DynamicError> capabilities::Subtype<xsd_gMonthDay>::from_supertype<0>(super_cpp_type<0> const &value) noexcept {
-    return std::make_pair(value.first.month / value.first.day, value.second);
+    return std::make_pair(value.first.month() / value.first.day(), value.second);
 }
 #endif
 

--- a/src/rdf4cpp/datatypes/xsd/time/Year.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/Year.cpp
@@ -28,7 +28,7 @@ template<>
 std::partial_ordering capabilities::Comparable<xsd_gYear>::compare(cpp_type const &lhs, cpp_type const &rhs) noexcept {
     try {
         auto year_to_tp = [](Year const &t) -> rdf4cpp::TimePoint {
-            return rdf4cpp::util::construct_timepoint(YearMonthDay{t, rdf4cpp::util::time_point_replacement_date.month, rdf4cpp::util::time_point_replacement_date.day}, rdf4cpp::util::time_point_replacement_time_of_day);
+            return rdf4cpp::util::construct_timepoint(YearMonthDay{t, rdf4cpp::util::time_point_replacement_date.month(), rdf4cpp::util::time_point_replacement_date.day()}, rdf4cpp::util::time_point_replacement_time_of_day);
         };
         return registry::util::compare_time_points(year_to_tp(lhs.first), lhs.second, year_to_tp(rhs.first), rhs.second);
     } catch (std::overflow_error const &) {
@@ -41,10 +41,7 @@ std::optional<storage::identifier::LiteralID> capabilities::Inlineable<xsd_gYear
     if (value.second.has_value()) [[unlikely]] {
         return std::nullopt;
     }
-    if (!util::fits_into<int64_t>(value.first.year)) [[unlikely]] {
-        return std::nullopt;
-    }
-    return util::try_pack_integral<storage::identifier::LiteralID>(static_cast<int64_t>(value.first.year));
+    return util::try_pack_integral<storage::identifier::LiteralID>(static_cast<int64_t>(value.first));
 }
 
 template<>
@@ -56,13 +53,13 @@ capabilities::Inlineable<xsd_gYear>::cpp_type capabilities::Inlineable<xsd_gYear
 template<>
 template<>
 capabilities::Subtype<xsd_gYear>::super_cpp_type<0> capabilities::Subtype<xsd_gYear>::into_supertype<0>(cpp_type const &value) noexcept {
-    return std::make_pair(YearMonthDay{value.first, rdf4cpp::util::time_point_replacement_date.month, rdf4cpp::util::time_point_replacement_date.day}, value.second);
+    return std::make_pair(YearMonthDay{value.first, rdf4cpp::util::time_point_replacement_date.month(), rdf4cpp::util::time_point_replacement_date.day()}, value.second);
 }
 
 template<>
 template<>
 nonstd::expected<capabilities::Subtype<xsd_gYear>::cpp_type, DynamicError> capabilities::Subtype<xsd_gYear>::from_supertype<0>(super_cpp_type<0> const &value) noexcept {
-    return std::make_pair(value.first.year, value.second);
+    return std::make_pair(value.first.year(), value.second);
 }
 #endif
 

--- a/src/rdf4cpp/datatypes/xsd/time/YearMonth.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/YearMonth.cpp
@@ -45,11 +45,12 @@ std::optional<storage::identifier::LiteralID> capabilities::Inlineable<xsd_gYear
     if (value.second.has_value()) [[unlikely]] {
         return std::nullopt;
     }
-    if (!util::fits_into<int16_t>(value.first.year.year)) [[unlikely]] {
+    auto const yearint = static_cast<int64_t>(value.first.year());
+    if (!util::fits_into<int16_t>(yearint)) [[unlikely]] {
         return std::nullopt;
     }
-    return util::pack<storage::identifier::LiteralID>(InliningHelperYearMonth{static_cast<int16_t>(value.first.year.year),
-                                                                                    static_cast<uint8_t>(static_cast<unsigned int>(value.first.month))});
+    return util::pack<storage::identifier::LiteralID>(InliningHelperYearMonth{static_cast<int16_t>(yearint),
+                                                                                static_cast<uint8_t>(static_cast<unsigned int>(value.first.month()))});
 }
 
 template<>
@@ -61,7 +62,7 @@ capabilities::Inlineable<xsd_gYearMonth>::cpp_type capabilities::Inlineable<xsd_
 template<>
 std::partial_ordering capabilities::Comparable<xsd_gYearMonth>::compare(cpp_type const &lhs, cpp_type const &rhs) noexcept {
     auto ym_to_tp = [](YearMonth const & t) -> rdf4cpp::TimePoint {
-        return rdf4cpp::util::construct_timepoint(YearMonthDay{t.year, t.month, std::chrono::last}, rdf4cpp::util::time_point_replacement_time_of_day);
+        return rdf4cpp::util::construct_timepoint(YearMonthDay{t.year(), t.month(), std::chrono::last}, rdf4cpp::util::time_point_replacement_time_of_day);
     };
     return registry::util::compare_time_points(ym_to_tp(lhs.first), lhs.second, ym_to_tp(rhs.first), rhs.second);
 }
@@ -69,13 +70,13 @@ std::partial_ordering capabilities::Comparable<xsd_gYearMonth>::compare(cpp_type
 template<>
 template<>
 capabilities::Subtype<xsd_gYearMonth>::super_cpp_type<0> capabilities::Subtype<xsd_gYearMonth>::into_supertype<0>(cpp_type const &value) noexcept {
-    return std::make_pair(YearMonthDay{value.first.year, value.first.month, std::chrono::last}, value.second);
+    return std::make_pair(YearMonthDay{value.first.year(), value.first.month(), std::chrono::last}, value.second);
 }
 
 template<>
 template<>
 nonstd::expected<capabilities::Subtype<xsd_gYearMonth>::cpp_type, DynamicError> capabilities::Subtype<xsd_gYearMonth>::from_supertype<0>(super_cpp_type<0> const &value) noexcept {
-    return std::make_pair(YearMonth{value.first.year, value.first.month}, value.second);
+    return std::make_pair(YearMonth{value.first.year(), value.first.month()}, value.second);
 }
 #endif
 

--- a/src/rdf4cpp/util/CheckedInt.hpp
+++ b/src/rdf4cpp/util/CheckedInt.hpp
@@ -90,6 +90,20 @@ public:
         r /= other;
         return r;
     }
+
+    friend constexpr CheckedIntegral abs(CheckedIntegral const &val) noexcept {
+        if constexpr (std::is_unsigned_v<I>) {
+            return val;
+        } else {
+            if (val.value >= 0) {
+                return val;
+            }
+
+            CheckedIntegral ret{0, val.invalid};
+            ret.invalid |= __builtin_sub_overflow(0, val.value, &ret.value);
+            return ret;
+        }
+    }
 };
 
 }  // namespace rdf4cpp::util

--- a/tests/datatype/tests_time_types.cpp
+++ b/tests/datatype/tests_time_types.cpp
@@ -90,8 +90,8 @@ TEST_CASE("year api") {
     CHECK(--y(5) == y(4));
     CHECK(y(5)-- == y(5));
 
-    CHECK(y::max().year == std::numeric_limits<int64_t>::max());
-    CHECK(y::min().year == std::numeric_limits<int64_t>::min());
+    CHECK(static_cast<int64_t>(y::max()) == std::numeric_limits<int64_t>::max());
+    CHECK(static_cast<int64_t>(y::min()) == std::numeric_limits<int64_t>::min());
 }
 
 TEST_CASE("YearMonth api") {
@@ -439,7 +439,7 @@ TEST_CASE("datatype dateTime") {
     CHECK(a.null()); // turn off unused and nodiscard ignored warnings
     auto m = std::format("{}-12-31T23:59:59", std::numeric_limits<int64_t>::max());
     CHECK(Literal::make_typed<datatypes::xsd::DateTime>(m).lexical_form() == m);
-    CHECK(Literal::make_typed<datatypes::xsd::DateTime>(m).year()->year == std::numeric_limits<int64_t>::max());
+    CHECK(static_cast<int64_t>(Literal::make_typed<datatypes::xsd::DateTime>(m).year().value()) == std::numeric_limits<int64_t>::max());
     CHECK(Literal::make_typed<datatypes::xsd::DateTime>("2042-05-06T00:00:00.000") == Literal::make_typed<datatypes::xsd::DateTime>("2042-05-05T24:00:00"));
     CHECK(Literal::make_typed<datatypes::xsd::DateTime>("2042-05-05T24:00:00.000").lexical_form() == "2042-05-06T00:00:00");
 
@@ -697,7 +697,7 @@ TEST_CASE("arithmetic") {
     CHECK((Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3") + Literal::make_typed<datatypes::xsd::Duration>("P1Y14MT5S")) == Literal::make_typed<datatypes::xsd::DateTime>("2044-7-6T1:2:8"));
     CHECK((Literal::make_typed<datatypes::xsd::Date>("2042-5-6") + Literal::make_typed<datatypes::xsd::YearMonthDuration>("P1Y")) == Literal::make_typed<datatypes::xsd::Date>("2043-5-6"));
     CHECK((Literal::make_typed<datatypes::xsd::Time>("1:2:3") + Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1S")) == Literal::make_typed<datatypes::xsd::Time>("1:2:4"));
-    CHECK(!(Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3") + Literal::make_typed_from_value<datatypes::xsd::YearMonthDuration>(std::chrono::months::max() / 2)).null());
+    CHECK((Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3") + Literal::make_typed_from_value<datatypes::xsd::YearMonthDuration>(std::chrono::months::max())).null()); // overflow
     CHECK(!(Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3") + Literal::make_typed_from_value<datatypes::xsd::DayTimeDuration>(std::chrono::nanoseconds::max())).null());
 
     CHECK((Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3") - Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1S")) == Literal::make_typed<datatypes::xsd::DateTime>("2042-5-5T1:2:2"));
@@ -706,7 +706,7 @@ TEST_CASE("arithmetic") {
     CHECK((Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3") - Literal::make_typed<datatypes::xsd::Duration>("P1Y2MT3S")) == Literal::make_typed<datatypes::xsd::DateTime>("2041-3-6T1:2:0"));
     CHECK((Literal::make_typed<datatypes::xsd::Date>("2042-5-6") - Literal::make_typed<datatypes::xsd::YearMonthDuration>("P1Y")) == Literal::make_typed<datatypes::xsd::Date>("2041-5-6"));
     CHECK((Literal::make_typed<datatypes::xsd::Time>("1:2:3") - Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1S")) == Literal::make_typed<datatypes::xsd::Time>("1:2:2"));
-    CHECK(!(Literal::make_typed<datatypes::xsd::DateTime>("-2042-5-6T1:2:3") - Literal::make_typed_from_value<datatypes::xsd::YearMonthDuration>(std::chrono::months::max() / 2)).null());
+    CHECK((Literal::make_typed<datatypes::xsd::DateTime>("-2042-5-6T1:2:3") - Literal::make_typed_from_value<datatypes::xsd::YearMonthDuration>(std::chrono::months::max())).null()); // overflow
     CHECK(!(Literal::make_typed<datatypes::xsd::DateTime>("-2042-5-6T1:2:3") - Literal::make_typed_from_value<datatypes::xsd::DayTimeDuration>(std::chrono::nanoseconds::max())).null());
 
     CHECK((Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1S") + Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1H")) == Literal::make_typed<datatypes::xsd::DayTimeDuration>("P2DT1H1S"));

--- a/tests/datatype/tests_time_types.cpp
+++ b/tests/datatype/tests_time_types.cpp
@@ -442,6 +442,9 @@ TEST_CASE("datatype dateTime") {
     CHECK(Literal::make_typed<datatypes::xsd::DateTime>(m).year()->year == std::numeric_limits<int64_t>::max());
     CHECK(Literal::make_typed<datatypes::xsd::DateTime>("2042-05-06T00:00:00.000") == Literal::make_typed<datatypes::xsd::DateTime>("2042-05-05T24:00:00"));
     CHECK(Literal::make_typed<datatypes::xsd::DateTime>("2042-05-05T24:00:00.000").lexical_form() == "2042-05-06T00:00:00");
+
+    CHECK(Literal::make_typed<datatypes::xsd::DateTime>("-13798000000-01-01T00:00:00Z").lexical_form() == "-13798000000-01-01T00:00:00Z"); // check that age of universe is in range
+    CHECK(Literal::make_typed<datatypes::xsd::DateTime>("100000000000000-01-01T00:00:00Z").lexical_form() == "100000000000000-01-01T00:00:00Z");
 }
 
 TEST_CASE("datatype dateTimeStamp") {
@@ -683,7 +686,7 @@ TEST_CASE("arithmetic") {
     CHECK((Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3") - Literal::make_typed<datatypes::xsd::DateTime>("2042-5-5T1:2:3")) == Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1D"));
     CHECK((Literal::make_typed<datatypes::xsd::DateTimeStamp>("2042-5-6T1:2:3Z") - Literal::make_typed<datatypes::xsd::DateTimeStamp>("2042-5-7T1:2:3Z")) == Literal::make_typed<datatypes::xsd::DayTimeDuration>("-P1D"));
     CHECK((Literal::make_typed<datatypes::xsd::DateTimeStamp>("2042-5-6T1:2:3Z") - Literal::make_typed<datatypes::xsd::DateTimeStamp>("2042-5-6T1:2:3+10:00")) == Literal::make_typed<datatypes::xsd::DayTimeDuration>("PT10H"));
-    CHECK((Literal::make_typed_from_value<datatypes::xsd::DateTime>(std::make_pair(rdf4cpp::TimePoint{std::chrono::milliseconds{std::numeric_limits<int64_t>::min()}}, std::nullopt)) - Literal::make_typed<datatypes::xsd::DateTime>("2042-5-5T1:2:3")).null());
+    CHECK((Literal::make_typed_from_value<datatypes::xsd::DateTime>(std::make_pair(rdf4cpp::TimePoint{std::chrono::milliseconds::min()}, std::nullopt)) - Literal::make_typed<datatypes::xsd::DateTime>("2042-5-5T1:2:3")).null());
 
     CHECK((Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3") + Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1S")) == Literal::make_typed<datatypes::xsd::DateTime>("2042-5-7T1:2:4"));
     CHECK((Literal::make_typed<datatypes::xsd::DateTimeStamp>("2042-5-6T1:2:3Z") + Literal::make_typed<datatypes::xsd::DayTimeDuration>("-P1DT1S")) == Literal::make_typed<datatypes::xsd::DateTime>("2042-5-5T1:2:2Z"));
@@ -694,8 +697,8 @@ TEST_CASE("arithmetic") {
     CHECK((Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3") + Literal::make_typed<datatypes::xsd::Duration>("P1Y14MT5S")) == Literal::make_typed<datatypes::xsd::DateTime>("2044-7-6T1:2:8"));
     CHECK((Literal::make_typed<datatypes::xsd::Date>("2042-5-6") + Literal::make_typed<datatypes::xsd::YearMonthDuration>("P1Y")) == Literal::make_typed<datatypes::xsd::Date>("2043-5-6"));
     CHECK((Literal::make_typed<datatypes::xsd::Time>("1:2:3") + Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1S")) == Literal::make_typed<datatypes::xsd::Time>("1:2:4"));
-    CHECK(!(Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3") + Literal::make_typed_from_value<datatypes::xsd::YearMonthDuration>(std::chrono::months{std::numeric_limits<int64_t>::max()})).null());
-    CHECK(!(Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3") + Literal::make_typed_from_value<datatypes::xsd::DayTimeDuration>(std::chrono::milliseconds{std::numeric_limits<int64_t>::max()})).null());
+    CHECK(!(Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3") + Literal::make_typed_from_value<datatypes::xsd::YearMonthDuration>(std::chrono::months::max() / 2)).null());
+    CHECK(!(Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3") + Literal::make_typed_from_value<datatypes::xsd::DayTimeDuration>(std::chrono::nanoseconds::max())).null());
 
     CHECK((Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3") - Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1S")) == Literal::make_typed<datatypes::xsd::DateTime>("2042-5-5T1:2:2"));
     CHECK((Literal::make_typed<datatypes::xsd::DateTimeStamp>("2042-5-6T1:2:3Z") - Literal::make_typed<datatypes::xsd::DayTimeDuration>("-P1DT1S")) == Literal::make_typed<datatypes::xsd::DateTime>("2042-5-7T1:2:4Z"));
@@ -703,13 +706,13 @@ TEST_CASE("arithmetic") {
     CHECK((Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3") - Literal::make_typed<datatypes::xsd::Duration>("P1Y2MT3S")) == Literal::make_typed<datatypes::xsd::DateTime>("2041-3-6T1:2:0"));
     CHECK((Literal::make_typed<datatypes::xsd::Date>("2042-5-6") - Literal::make_typed<datatypes::xsd::YearMonthDuration>("P1Y")) == Literal::make_typed<datatypes::xsd::Date>("2041-5-6"));
     CHECK((Literal::make_typed<datatypes::xsd::Time>("1:2:3") - Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1S")) == Literal::make_typed<datatypes::xsd::Time>("1:2:2"));
-    CHECK(!(Literal::make_typed<datatypes::xsd::DateTime>("-2042-5-6T1:2:3") - Literal::make_typed_from_value<datatypes::xsd::YearMonthDuration>(std::chrono::months{std::numeric_limits<int64_t>::max()})).null());
-    CHECK(!(Literal::make_typed<datatypes::xsd::DateTime>("-2042-5-6T1:2:3") - Literal::make_typed_from_value<datatypes::xsd::DayTimeDuration>(std::chrono::milliseconds{std::numeric_limits<int64_t>::max()})).null());
+    CHECK(!(Literal::make_typed<datatypes::xsd::DateTime>("-2042-5-6T1:2:3") - Literal::make_typed_from_value<datatypes::xsd::YearMonthDuration>(std::chrono::months::max() / 2)).null());
+    CHECK(!(Literal::make_typed<datatypes::xsd::DateTime>("-2042-5-6T1:2:3") - Literal::make_typed_from_value<datatypes::xsd::DayTimeDuration>(std::chrono::nanoseconds::max())).null());
 
     CHECK((Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1S") + Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1H")) == Literal::make_typed<datatypes::xsd::DayTimeDuration>("P2DT1H1S"));
     CHECK((Literal::make_typed<datatypes::xsd::YearMonthDuration>("P1Y") + Literal::make_typed<datatypes::xsd::YearMonthDuration>("P1Y2M")) == Literal::make_typed<datatypes::xsd::YearMonthDuration>("P2Y2M"));
-    CHECK((Literal::make_typed_from_value<datatypes::xsd::DayTimeDuration>(std::chrono::nanoseconds{std::numeric_limits<int64_t>::max()}) + Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1H")).null());
-    CHECK((Literal::make_typed_from_value<datatypes::xsd::YearMonthDuration>(std::chrono::months{std::numeric_limits<int64_t>::max()}) + Literal::make_typed<datatypes::xsd::YearMonthDuration>("P1Y2M")).null());
+    CHECK((Literal::make_typed_from_value<datatypes::xsd::DayTimeDuration>(std::chrono::nanoseconds::max()) + Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1H")).null());
+    CHECK((Literal::make_typed_from_value<datatypes::xsd::YearMonthDuration>(std::chrono::months::max()) + Literal::make_typed<datatypes::xsd::YearMonthDuration>("P1Y2M")).null());
     CHECK((Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1M") - Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1S")) == Literal::make_typed<datatypes::xsd::DayTimeDuration>("PT59S"));
     CHECK((Literal::make_typed<datatypes::xsd::YearMonthDuration>("P1Y") - Literal::make_typed<datatypes::xsd::YearMonthDuration>("P2Y")) == Literal::make_typed<datatypes::xsd::YearMonthDuration>("-P1Y"));
 

--- a/tests/datatype/tests_time_types.cpp
+++ b/tests/datatype/tests_time_types.cpp
@@ -697,7 +697,10 @@ TEST_CASE("arithmetic") {
     CHECK((Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3") + Literal::make_typed<datatypes::xsd::Duration>("P1Y14MT5S")) == Literal::make_typed<datatypes::xsd::DateTime>("2044-7-6T1:2:8"));
     CHECK((Literal::make_typed<datatypes::xsd::Date>("2042-5-6") + Literal::make_typed<datatypes::xsd::YearMonthDuration>("P1Y")) == Literal::make_typed<datatypes::xsd::Date>("2043-5-6"));
     CHECK((Literal::make_typed<datatypes::xsd::Time>("1:2:3") + Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1S")) == Literal::make_typed<datatypes::xsd::Time>("1:2:4"));
-    CHECK((Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3") + Literal::make_typed_from_value<datatypes::xsd::YearMonthDuration>(std::chrono::months::max())).null()); // overflow
+    CHECK(!(Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3") + Literal::make_typed_from_value<datatypes::xsd::YearMonthDuration>(std::chrono::months::max())).null());
+    CHECK((Literal::make_typed<datatypes::xsd::DateTime>(std::format("{}-5-6T1:2:3", rdf4cpp::Year::max())) + Literal::make_typed_from_value<datatypes::xsd::YearMonthDuration>(std::chrono::months::max())).null());
+    CHECK((Literal::make_typed<datatypes::xsd::DateTime>(std::format("{}-5-6T1:2:3", rdf4cpp::Year::max())) + Literal::make_typed_from_value<datatypes::xsd::YearMonthDuration>(std::chrono::months{12})).null());
+    CHECK((Literal::make_typed<datatypes::xsd::DateTime>(std::format("{}-5-6T1:2:3", rdf4cpp::Year::max())) + Literal::make_typed_from_value<datatypes::xsd::DayTimeDuration>(std::chrono::years{1})).null());
     CHECK(!(Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3") + Literal::make_typed_from_value<datatypes::xsd::DayTimeDuration>(std::chrono::nanoseconds::max())).null());
 
     CHECK((Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3") - Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1S")) == Literal::make_typed<datatypes::xsd::DateTime>("2042-5-5T1:2:2"));
@@ -706,7 +709,10 @@ TEST_CASE("arithmetic") {
     CHECK((Literal::make_typed<datatypes::xsd::DateTime>("2042-5-6T1:2:3") - Literal::make_typed<datatypes::xsd::Duration>("P1Y2MT3S")) == Literal::make_typed<datatypes::xsd::DateTime>("2041-3-6T1:2:0"));
     CHECK((Literal::make_typed<datatypes::xsd::Date>("2042-5-6") - Literal::make_typed<datatypes::xsd::YearMonthDuration>("P1Y")) == Literal::make_typed<datatypes::xsd::Date>("2041-5-6"));
     CHECK((Literal::make_typed<datatypes::xsd::Time>("1:2:3") - Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1S")) == Literal::make_typed<datatypes::xsd::Time>("1:2:2"));
-    CHECK((Literal::make_typed<datatypes::xsd::DateTime>("-2042-5-6T1:2:3") - Literal::make_typed_from_value<datatypes::xsd::YearMonthDuration>(std::chrono::months::max())).null()); // overflow
+    CHECK(!(Literal::make_typed<datatypes::xsd::DateTime>("-2042-5-6T1:2:3") - Literal::make_typed_from_value<datatypes::xsd::YearMonthDuration>(std::chrono::months::max())).null());
+    CHECK((Literal::make_typed<datatypes::xsd::DateTime>(std::format("{}-5-6T1:2:3", Year::min())) - Literal::make_typed_from_value<datatypes::xsd::YearMonthDuration>(std::chrono::months::max())).null());
+    CHECK((Literal::make_typed<datatypes::xsd::DateTime>(std::format("{}-1-6T1:2:3", Year::min())) - Literal::make_typed_from_value<datatypes::xsd::YearMonthDuration>(std::chrono::months{12})).null());
+    CHECK((Literal::make_typed<datatypes::xsd::DateTime>(std::format("{}-1-6T1:2:3", Year::min())) - Literal::make_typed_from_value<datatypes::xsd::DayTimeDuration>(std::chrono::years{1})).null());
     CHECK(!(Literal::make_typed<datatypes::xsd::DateTime>("-2042-5-6T1:2:3") - Literal::make_typed_from_value<datatypes::xsd::DayTimeDuration>(std::chrono::nanoseconds::max())).null());
 
     CHECK((Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1S") + Literal::make_typed<datatypes::xsd::DayTimeDuration>("P1DT1H")) == Literal::make_typed<datatypes::xsd::DayTimeDuration>("P2DT1H1S"));


### PR DESCRIPTION
Fix
![grafik](https://github.com/user-attachments/assets/700b156a-3da7-4a65-8a01-1a48e09fd9bc)

That was caused by additions that overflowed int64_t.
Please double check that this is not an issue.

Additionally, I've aligned the interface of some types more towards `std::chrono` to hopefully break less code (also of ours). This primarily consists of making fields private and providing accessors instead (like in chrono).