### PR TITLE
Fix: serd assert bug by bumping version & make strict the default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ find_package(dice-template-library REQUIRED)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/version.hpp.in ${CMAKE_CURRENT_SOURCE_DIR}/src/rdf4cpp/version.hpp)
 
-set(serd_rev 9b294a0899ad4ff10f19e9cdf03d3cf694f60ab9)
+set(serd_rev 6d0e41dbbab57d2b392131cf780ebc376d921caa)
 set(serd_source_files
         include/serd/serd.h
         src/attributes.h

--- a/private/rdf4cpp/parser/IStreamQuadIteratorSerdImpl.cpp
+++ b/private/rdf4cpp/parser/IStreamQuadIteratorSerdImpl.cpp
@@ -358,7 +358,7 @@ IStreamQuadIterator::Impl::Impl(void *stream,
         this->state_is_owned = true;
     }
 
-    serd_reader_set_strict(this->reader, flags.contains(ParsingFlag::Strict));
+    serd_reader_set_strict(this->reader, !flags.contains(ParsingFlag::Lax));
     serd_reader_set_error_sink(this->reader, &Impl::on_error, this);
     serd_reader_start_source_stream(this->reader, read, error, stream, nullptr, 4096);
 }

--- a/src/rdf4cpp/parser/ParsingFlags.hpp
+++ b/src/rdf4cpp/parser/ParsingFlags.hpp
@@ -12,7 +12,7 @@ namespace rdf4cpp::parser {
  * If more than one is used accidentally at the same time, TriG is likely the result (even if it does never get specified).
  */
 enum struct ParsingFlag : uint8_t {
-    Strict           = 1 << 0,
+    Lax              = 1 << 0,
     NoParsePrefix    = 1 << 1,
     KeepBlankNodeIds = 1 << 2,
     NoParseBlankNode = 1 << 3,

--- a/tests/parser/tests_IStreamQuadIterator.cpp
+++ b/tests/parser/tests_IStreamQuadIterator.cpp
@@ -718,9 +718,25 @@ TEST_SUITE("IStreamQuadIterator") {
         // validate fix of https://gitlab.com/drobilla/serd/-/issues/32
         // previously this triggered an assertion
 
-        std::istringstream iss{"<htt"};
-        for (IStreamQuadIterator qit{iss}; qit != std::default_sentinel; ++qit) {
-            CHECK_EQ(qit->error().message, "unexpected end of file");
+        SUBCASE("iri") {
+            std::istringstream iss{"<htt"};
+            for (IStreamQuadIterator qit{iss}; qit != std::default_sentinel; ++qit) {
+                CHECK_FALSE(qit->has_value());
+            }
+        }
+
+        SUBCASE("literal") {
+            std::istringstream iss{"_:"};
+            for (IStreamQuadIterator qit{iss}; qit != std::default_sentinel; ++qit) {
+                CHECK_FALSE(qit->has_value());
+            }
+        }
+
+        SUBCASE("bnode") {
+            std::istringstream iss{"\"aaaa"};
+            for (IStreamQuadIterator qit{iss}; qit != std::default_sentinel; ++qit) {
+                CHECK_FALSE(qit->has_value());
+            }
         }
     }
 }

--- a/tests/parser/tests_IStreamQuadIterator.cpp
+++ b/tests/parser/tests_IStreamQuadIterator.cpp
@@ -91,7 +91,7 @@ TEST_SUITE("IStreamQuadIterator") {
 
         SUBCASE("strict") {
             std::istringstream iss{triples};
-            IStreamQuadIterator qit{iss, ParsingFlag::Strict};
+            IStreamQuadIterator qit{iss};
 
             CHECK_NE(qit, std::default_sentinel);
             CHECK_EQ(qit->value().subject(), IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/12"});
@@ -121,7 +121,7 @@ TEST_SUITE("IStreamQuadIterator") {
 
         SUBCASE("non-strict") {
             std::istringstream iss{triples};
-            IStreamQuadIterator qit{iss};
+            IStreamQuadIterator qit{iss, ParsingFlag::Lax};
 
             CHECK_NE(qit, std::default_sentinel);
             CHECK_EQ(qit->value().subject(), IRI{"http://data.semanticweb.org/workshop/admire/2012/paper/12"});
@@ -712,5 +712,15 @@ TEST_SUITE("IStreamQuadIterator") {
             ++iter;
         }
 
+    }
+
+    TEST_CASE("EOF in the middle") {
+        // validate fix of https://gitlab.com/drobilla/serd/-/issues/32
+        // previously this triggered an assertion
+
+        std::istringstream iss{"<htt"};
+        for (IStreamQuadIterator qit{iss}; qit != std::default_sentinel; ++qit) {
+            CHECK_EQ(qit->error().message, "unexpected end of file");
+        }
     }
 }

--- a/tests/parser/tests_IStreamQuadIterator.cpp
+++ b/tests/parser/tests_IStreamQuadIterator.cpp
@@ -725,14 +725,14 @@ TEST_SUITE("IStreamQuadIterator") {
             }
         }
 
-        SUBCASE("literal") {
+        SUBCASE("bnode") {
             std::istringstream iss{"_:"};
             for (IStreamQuadIterator qit{iss}; qit != std::default_sentinel; ++qit) {
                 CHECK_FALSE(qit->has_value());
             }
         }
 
-        SUBCASE("bnode") {
+        SUBCASE("literal") {
             std::istringstream iss{"\"aaaa"};
             for (IStreamQuadIterator qit{iss}; qit != std::default_sentinel; ++qit) {
                 CHECK_FALSE(qit->has_value());


### PR DESCRIPTION
Fixes https://gitlab.com/drobilla/serd/-/issues/32 by bumping serd version
Additionally, due to a [comment of the serd author](https://gitlab.com/drobilla/serd/-/issues/32#note_2323857439) regarding the reliability of lax mode, strict mode will now be the default.