### PR TITLE
Fix: leading zeros parsing

### DIFF
--- a/src/rdf4cpp/datatypes/registry/util/ConstexprString.hpp
+++ b/src/rdf4cpp/datatypes/registry/util/ConstexprString.hpp
@@ -35,6 +35,10 @@ struct ConstexprString {
         return std::string_view{value.data(), value.size() - 1};
     }
 
+    [[nodiscard]] constexpr char const *c_str() const noexcept {
+        return value.data();
+    }
+
     template<size_t M>
     constexpr std::strong_ordering operator<=>(ConstexprString<M> const &other) const noexcept {
         auto min = std::min(M, N);

--- a/src/rdf4cpp/datatypes/xsd/integers/signed/Integer.cpp
+++ b/src/rdf4cpp/datatypes/xsd/integers/signed/Integer.cpp
@@ -13,6 +13,10 @@ capabilities::Default<xsd_integer>::cpp_type capabilities::Default<xsd_integer>:
         s.remove_prefix(1);
     }
 
+    if (auto const pos = s.find_first_not_of('0'); pos != std::string::npos) {
+        s.remove_prefix(pos);
+    }
+
     try {
         return cpp_type{s};
     } catch (std::runtime_error const &e) {

--- a/tests/nodes/tests_Literal.cpp
+++ b/tests/nodes/tests_Literal.cpp
@@ -1163,26 +1163,17 @@ TEST_CASE("Literal::fetch_or_serialize_lexical_form") {
     }
 }
 
-template<datatypes::LiteralDatatype L>
-void check_leading_zeros_parse() {
-    SUBCASE(L::identifier.c_str()) {
-        auto lit = Literal::make_typed<L>("09");
-        CHECK_FALSE(lit.null());
-        CHECK_EQ(lit.template value<L>(), 9);
+TEST_CASE_TEMPLATE("leading zeros parsing", L, datatypes::xsd::Integer,
+                                               datatypes::xsd::Int,
+                                               datatypes::xsd::Float,
+                                               datatypes::xsd::Double,
+                                               datatypes::xsd::Decimal) {
+    auto lit = Literal::make_typed<L>("09");
+    CHECK_FALSE(lit.null());
+    CHECK_EQ(lit.template value<L>(), 9);
 
-        lit = Literal::make_typed<L>("000");
-        CHECK_FALSE(lit.null());
-        CHECK_EQ(lit.template value<L>(), 0);
-    }
-}
-
-TEST_CASE("leading zeros parsing") {
-    using namespace datatypes;
-
-    check_leading_zeros_parse<xsd::Integer>();
-    check_leading_zeros_parse<xsd::Int>();
-    check_leading_zeros_parse<xsd::Float>();
-    check_leading_zeros_parse<xsd::Double>();
-    check_leading_zeros_parse<xsd::Decimal>();
+    lit = Literal::make_typed<L>("000");
+    CHECK_FALSE(lit.null());
+    CHECK_EQ(lit.template value<L>(), 0);
 }
 

--- a/tests/nodes/tests_Literal.cpp
+++ b/tests/nodes/tests_Literal.cpp
@@ -1163,3 +1163,26 @@ TEST_CASE("Literal::fetch_or_serialize_lexical_form") {
     }
 }
 
+template<datatypes::LiteralDatatype L>
+void check_leading_zeros_parse() {
+    SUBCASE(L::identifier.c_str()) {
+        auto lit = Literal::make_typed<L>("09");
+        CHECK_FALSE(lit.null());
+        CHECK_EQ(lit.template value<L>(), 9);
+
+        lit = Literal::make_typed<L>("000");
+        CHECK_FALSE(lit.null());
+        CHECK_EQ(lit.template value<L>(), 0);
+    }
+}
+
+TEST_CASE("leading zeros parsing") {
+    using namespace datatypes;
+
+    check_leading_zeros_parse<xsd::Integer>();
+    check_leading_zeros_parse<xsd::Int>();
+    check_leading_zeros_parse<xsd::Float>();
+    check_leading_zeros_parse<xsd::Double>();
+    check_leading_zeros_parse<xsd::Decimal>();
+}
+


### PR DESCRIPTION
Allow parsing of xsd:Integer with leading zeros

Close #353 