### PR TITLE
fix readthedocs documentation build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==4.5.0
-breathe==4.35.0
-exhale==0.3.6
+sphinx==8.2.3
+breathe==4.36.0
+exhale==0.3.7
 furo


### PR DESCRIPTION
close #352 

why it was broken: very old sphinx version
now builds locally in a venv