### PR TITLE
Fix: short form serialization of non-finite doubles

### DIFF
--- a/src/rdf4cpp/Literal.cpp
+++ b/src/rdf4cpp/Literal.cpp
@@ -724,8 +724,10 @@ bool Literal::serialize(writer::BufWriterParts const writer, NodeSerializationOp
         RDF4CPP_DETAIL_TRY_WRITE_STR("@");
         RDF4CPP_DETAIL_TRY_WRITE_STR(value.language_tag);
         return true;
-    } else if (opts.use_short_form && (this->datatype_eq<datatypes::xsd::Integer>() || this->datatype_eq<datatypes::xsd::Double>()
-            || this->datatype_eq<datatypes::xsd::Decimal>() || this->datatype_eq<datatypes::xsd::Boolean>())) {
+    } else if (opts.use_short_form && (this->datatype_eq<datatypes::xsd::Integer>()
+                || this->datatype_eq<datatypes::xsd::Decimal>()
+                || this->datatype_eq<datatypes::xsd::Boolean>()
+                || (this->datatype_eq<datatypes::xsd::Double>() && std::isfinite(this->value<datatypes::xsd::Double>())))) {
 
         return this->serialize_lexical_form(writer);
     } else if (this->is_inlined()) {

--- a/tests/serializer/tests_Serialization.cpp
+++ b/tests/serializer/tests_Serialization.cpp
@@ -3,6 +3,8 @@
 #include <rdf4cpp.hpp>
 #include <rdf4cpp/storage/reference_node_storage/UnsyncReferenceNodeStorage.hpp>
 
+#include <cmath>
+
 enum struct OutputFormat {
     NTriples,
     Turtle,
@@ -29,6 +31,14 @@ TEST_CASE("Literal short form and prefixed") {
     writer::write_str(",", ser);
     Literal::make_typed<datatypes::xsd::Double>("4").serialize(ser, NodeSerializationOpts::prefixed_and_short_form());
     writer::write_str(",", ser);
+    Literal::make_typed<datatypes::xsd::Double>("INF").serialize(ser, NodeSerializationOpts::prefixed_and_short_form());
+    writer::write_str(",", ser);
+    Literal::make_typed<datatypes::xsd::Double>("-INF").serialize(ser, NodeSerializationOpts::prefixed_and_short_form());
+    writer::write_str(",", ser);
+    Literal::make_typed<datatypes::xsd::Double>("NaN").serialize(ser, NodeSerializationOpts::prefixed_and_short_form());
+    writer::write_str(",", ser);
+    Literal::make_typed_from_value<datatypes::xsd::Double>(HUGE_VAL).serialize(ser, NodeSerializationOpts::prefixed_and_short_form());
+    writer::write_str(",", ser);
     Literal::make_typed<datatypes::xsd::Float>("4").serialize(ser, NodeSerializationOpts::prefixed_and_short_form());
     writer::write_str(",", ser);
     Literal::make_typed<datatypes::xsd::UnsignedByte>("4").serialize(ser, NodeSerializationOpts::prefixed_and_short_form());
@@ -36,7 +46,7 @@ TEST_CASE("Literal short form and prefixed") {
     Literal::make_typed<datatypes::xsd::Integer>("4").serialize(ser, NodeSerializationOpts::prefixed_and_short_form());
     ser.finalize();
 
-    CHECK_EQ(buf, R"("2042-05-04"^^xsd:date,true,4.0,4.0E0,"4.0E0"^^xsd:float,"4"^^xsd:unsignedByte,4)");
+    CHECK_EQ(buf, R"("2042-05-04"^^xsd:date,true,4.0,4.0E0,"INF"^^xsd:double,"-INF"^^xsd:double,"NaN"^^xsd:double,"INF"^^xsd:double,"4.0E0"^^xsd:float,"4"^^xsd:unsignedByte,4)");
 }
 
 TEST_CASE("Literal short form") {


### PR DESCRIPTION
Fix serialization of non-finite `xsd:double` values, such as `INF`, `-INF`, `NaN` and `HUGE_VAL`.

Excerpt from turtle spec:
![grafik](https://github.com/user-attachments/assets/9b54501b-b0d5-4164-a964-32b3160fc668)
