### PR TITLE
Fix: mac compat of NodeBackendID cast

### DIFF
--- a/src/rdf4cpp/storage/identifier/NodeBackendID.hpp
+++ b/src/rdf4cpp/storage/identifier/NodeBackendID.hpp
@@ -31,7 +31,7 @@ private:
     };
 
 public:
-    NodeBackendID() noexcept = default;
+    constexpr NodeBackendID() noexcept = default;
 
     explicit constexpr NodeBackendID(underlying_type const underlying_id) noexcept : underlying_{underlying_id} {
     }
@@ -154,6 +154,9 @@ public:
 
 static_assert(sizeof(NodeBackendID) == sizeof(uint64_t));
 static_assert(alignof(NodeBackendID) == alignof(uint64_t));
+static_assert(std::is_same_v<decltype(static_cast<uintptr_t>(NodeBackendID{})), uintptr_t>, "NodeBackendID must be convertible to uintptr_t");
+static_assert(std::is_same_v<decltype(static_cast<uint64_t>(NodeBackendID{})), uint64_t>, "NodeBackendID must be convertible to uint64_t");
+
 
 inline std::ostream &operator<<(std::ostream &os, NodeBackendID id) {
     if (id.is_literal()) {

--- a/src/rdf4cpp/storage/identifier/NodeBackendID.hpp
+++ b/src/rdf4cpp/storage/identifier/NodeBackendID.hpp
@@ -138,8 +138,9 @@ public:
         return underlying_;
     }
 
-    explicit constexpr operator underlying_type() const noexcept {
-        return underlying_;
+    template<std::unsigned_integral I> requires (sizeof(I) >= sizeof(underlying_type))
+    explicit constexpr operator I() const noexcept {
+        return static_cast<I>(underlying_);
     }
 
     constexpr std::strong_ordering operator<=>(NodeBackendID const &other) const noexcept {

--- a/tests/nodes/tests_Node.cpp
+++ b/tests/nodes/tests_Node.cpp
@@ -536,3 +536,8 @@ TEST_CASE("bnode inlining") {
     CHECK_EQ(v5.order(v1), std::strong_ordering::less);
     check_fetch_or_serialize(v5);
 }
+
+TEST_CASE("NodeBackendID cast") {
+    (void) static_cast<uintptr_t>(identifier::NodeBackendID{});
+    (void) static_cast<uint64_t>(identifier::NodeBackendID{});
+}

--- a/tests/nodes/tests_Node.cpp
+++ b/tests/nodes/tests_Node.cpp
@@ -536,8 +536,3 @@ TEST_CASE("bnode inlining") {
     CHECK_EQ(v5.order(v1), std::strong_ordering::less);
     check_fetch_or_serialize(v5);
 }
-
-TEST_CASE("NodeBackendID cast") {
-    (void) static_cast<uintptr_t>(identifier::NodeBackendID{});
-    (void) static_cast<uint64_t>(identifier::NodeBackendID{});
-}


### PR DESCRIPTION
On mac `uintptr_t` and `uint64_t` are distinct types even though they have the same size. This causes issues in some of our projects