### PR TITLE
Feature: convenience functions for `rdf:type` and datatype IRIs

### DIFF
--- a/private/rdf4cpp/writer/WriteQuad.hpp
+++ b/private/rdf4cpp/writer/WriteQuad.hpp
@@ -19,9 +19,7 @@ bool write_node(Node const node, writer::BufWriterParts const writer) noexcept {
 template<writer::OutputFormat F>
 bool write_pred(Node const pred, writer::BufWriterParts const writer) {
     if constexpr (writer::format_has_prefix<F>) {
-        static constexpr storage::identifier::LiteralType rdf_type = datatypes::registry::reserved_datatype_ids[datatypes::registry::rdf_type];
-
-        if (pred.is_iri() && iri_node_id_to_literal_type(pred.backend_handle().id()) == rdf_type) {
+        if (pred.as_iri().is_rdf_type()) {
             return writer::write_str("a", writer);
         }
     }

--- a/src/rdf4cpp/IRI.cpp
+++ b/src/rdf4cpp/IRI.cpp
@@ -134,34 +134,46 @@ IRI::operator std::string() const noexcept {
 }
 
 IRI IRI::default_graph(storage::DynNodeStoragePtr node_storage) {
-    auto const id = datatypes::registry::reserved_datatype_ids[datatypes::registry::default_graph_iri];
-    return IRI{storage::identifier::NodeBackendHandle{storage::identifier::literal_type_to_iri_node_id(id),
+    namespace reg = datatypes::registry;
+    namespace sid = storage::identifier;
+
+    auto const id = reg::reserved_datatype_ids[reg::default_graph_iri];
+    return IRI{sid::NodeBackendHandle{sid::literal_type_to_iri_node_id(id),
                node_storage}};
 }
 
 TriBool IRI::is_default_graph() const noexcept {
+    namespace reg = datatypes::registry;
+    namespace sid = storage::identifier;
+
     if (null()) {
         return TriBool::Err;
     }
 
-    auto const expected_id = datatypes::registry::reserved_datatype_ids[datatypes::registry::default_graph_iri];
-    auto const this_id = storage::identifier::iri_node_id_to_literal_type(backend_handle().id());
+    auto const expected_id = reg::reserved_datatype_ids[reg::default_graph_iri];
+    auto const this_id = sid::iri_node_id_to_literal_type(backend_handle().id());
     return this_id == expected_id;
 }
 
 IRI IRI::rdf_type(storage::DynNodeStoragePtr node_storage) {
-    auto const id = datatypes::registry::reserved_datatype_ids[datatypes::registry::rdf_type];
-    return IRI{storage::identifier::NodeBackendHandle{storage::identifier::literal_type_to_iri_node_id(id),
-                                                      node_storage}};
+    namespace reg = datatypes::registry;
+    namespace sid = storage::identifier;
+
+    auto const id = reg::reserved_datatype_ids[reg::rdf_type];
+    return IRI{sid::NodeBackendHandle{sid::literal_type_to_iri_node_id(id),
+                                      node_storage}};
 }
 
 TriBool IRI::is_rdf_type() const noexcept {
+    namespace reg = datatypes::registry;
+    namespace sid = storage::identifier;
+
     if (null()) {
         return TriBool::Err;
     }
 
-    auto const expected_id = datatypes::registry::reserved_datatype_ids[datatypes::registry::rdf_type];
-    auto const this_id = storage::identifier::iri_node_id_to_literal_type(backend_handle().id());
+    auto const expected_id = reg::reserved_datatype_ids[reg::rdf_type];
+    auto const this_id = sid::iri_node_id_to_literal_type(backend_handle().id());
     return this_id == expected_id;
 }
 

--- a/src/rdf4cpp/IRI.cpp
+++ b/src/rdf4cpp/IRI.cpp
@@ -149,6 +149,22 @@ TriBool IRI::is_default_graph() const noexcept {
     return this_id == expected_id;
 }
 
+IRI IRI::rdf_type(storage::DynNodeStoragePtr node_storage) {
+    auto const id = datatypes::registry::reserved_datatype_ids[datatypes::registry::rdf_type];
+    return IRI{storage::identifier::NodeBackendHandle{storage::identifier::literal_type_to_iri_node_id(id),
+                                                      node_storage}};
+}
+
+TriBool IRI::is_rdf_type() const noexcept {
+    if (null()) {
+        return TriBool::Err;
+    }
+
+    auto const expected_id = datatypes::registry::reserved_datatype_ids[datatypes::registry::rdf_type];
+    auto const this_id = storage::identifier::iri_node_id_to_literal_type(backend_handle().id());
+    return this_id == expected_id;
+}
+
 std::ostream &operator<<(std::ostream &os, IRI const &iri) {
     writer::BufOStreamWriter w{os};
     iri.serialize(w);

--- a/src/rdf4cpp/IRI.hpp
+++ b/src/rdf4cpp/IRI.hpp
@@ -146,6 +146,39 @@ public:
      * @return err if this is null, otherwise true iff this IRI is rdf:type
      */
     [[nodiscard]] TriBool is_rdf_type() const noexcept;
+
+    /**
+     * Get the IRI for the given datatype
+     * @tparam T datatype
+     * @param node_storage optional node storage where the returned IRI is placed
+     * @return datatype IRI
+     */
+    template<datatypes::LiteralDatatype T>
+    [[nodiscard]] static IRI datatype(storage::DynNodeStoragePtr node_storage = storage::default_node_storage) {
+        return IRI{T::datatype_id, node_storage};
+    }
+
+    /**
+     * Check if this IRI is the IRI of the given datatype
+     * @tparam T datatype
+     * @return err if this is null, otherwise true iff this IRI is the datatype IRI of the given datatype
+     */
+    template<datatypes::LiteralDatatype T>
+    [[nodiscard]] TriBool is_datatype() const noexcept {
+        if (null()) {
+            return TriBool::Err;
+        }
+
+        if constexpr (datatypes::HasFixedId<T>) {
+            if (auto const type = this->handle_.node_id().literal_type(); type.is_fixed()) {
+                return type == T::fixed_id;
+            }
+
+            return TriBool::False;
+        }
+
+        return identifier() == T::identifier;
+    }
 };
 
 inline namespace shorthands {

--- a/src/rdf4cpp/IRI.hpp
+++ b/src/rdf4cpp/IRI.hpp
@@ -125,7 +125,7 @@ public:
 
     /**
      * Get the default graph IRI.
-     * @param node_storage  optional custom node_storage where the returned IRI lives
+     * @param node_storage optional custom node_storage where the returned IRI lives
      * @return default graph IRI
      */
     [[nodiscard]] static IRI default_graph(storage::DynNodeStoragePtr node_storage = storage::default_node_storage);
@@ -134,6 +134,18 @@ public:
      * @return err if this is null, otherwise true iff this IRI is the default graph IRI
      */
     [[nodiscard]] TriBool is_default_graph() const noexcept;
+
+    /**
+     * Get the IRI for rdf:type
+     * @param node_storage optional custom node_storage where the returned IRI lives
+     * @return rdf:type IRI
+     */
+    [[nodiscard]] static IRI rdf_type(storage::DynNodeStoragePtr node_storage = storage::default_node_storage);
+
+    /**
+     * @return err if this is null, otherwise true iff this IRI is rdf:type
+     */
+    [[nodiscard]] TriBool is_rdf_type() const noexcept;
 };
 
 inline namespace shorthands {

--- a/src/rdf4cpp/IRI.hpp
+++ b/src/rdf4cpp/IRI.hpp
@@ -170,11 +170,8 @@ public:
         }
 
         if constexpr (datatypes::HasFixedId<T>) {
-            if (auto const type = this->handle_.node_id().literal_type(); type.is_fixed()) {
-                return type == T::fixed_id;
-            }
-
-            return TriBool::False;
+            auto const type = storage::identifier::iri_node_id_to_literal_type(handle_.id());
+            return type == T::fixed_id;
         }
 
         return identifier() == T::identifier;

--- a/src/rdf4cpp/IRI.hpp
+++ b/src/rdf4cpp/IRI.hpp
@@ -143,6 +143,7 @@ public:
     [[nodiscard]] static IRI rdf_type(storage::DynNodeStoragePtr node_storage = storage::default_node_storage);
 
     /**
+     * Check if this IRI is rdf:type
      * @return err if this is null, otherwise true iff this IRI is rdf:type
      */
     [[nodiscard]] TriBool is_rdf_type() const noexcept;

--- a/src/rdf4cpp/datatypes/xsd/time/YearMonthDuration.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/YearMonthDuration.cpp
@@ -8,6 +8,10 @@ namespace rdf4cpp::datatypes::registry {
 #ifndef DOXYGEN_PARSER
 template<>
 capabilities::Default<xsd_yearMonthDuration>::cpp_type capabilities::Default<xsd_yearMonthDuration>::from_string(std::string_view s) {
+    if (s.empty()) {
+        throw InvalidNode{std::format("{} parsing error: found empty string", identifier)};
+    }
+
     using namespace registry::util;
     bool negative = false;
     if (s[0] == '-') {

--- a/tests/datatype/tests_time_types.cpp
+++ b/tests/datatype/tests_time_types.cpp
@@ -581,7 +581,7 @@ TEST_CASE("datatype yearMonthDuration") {
     CHECK(Literal::make_typed<datatypes::xsd::YearMonthDuration>("P500Y30M").is_inlined());
     CHECK(storage::default_node_storage.has_specialized_storage_for(datatypes::xsd::YearMonthDuration::fixed_id));
     Literal a{};
-    CHECK_THROWS_WITH_AS(a = Literal::make_typed<datatypes::xsd::YearMonthDuration>(""), "http://www.w3.org/2001/XMLSchema#yearMonthDuration parsing error: duration missing P", InvalidNode);
+    CHECK_THROWS_WITH_AS(a = Literal::make_typed<datatypes::xsd::YearMonthDuration>(""), "http://www.w3.org/2001/XMLSchema#yearMonthDuration parsing error: found empty string", InvalidNode);
     CHECK_THROWS_WITH_AS(a = Literal::make_typed<datatypes::xsd::YearMonthDuration>("P"), "http://www.w3.org/2001/XMLSchema#yearMonthDuration parsing error: duration without any fields", InvalidNode);
     CHECK_THROWS_WITH_AS(a = Literal::make_typed<datatypes::xsd::YearMonthDuration>("PT"), "http://www.w3.org/2001/XMLSchema#yearMonthDuration parsing error: found T, expected empty", InvalidNode);
     CHECK_THROWS_WITH_AS(a = Literal::make_typed<datatypes::xsd::YearMonthDuration>("P5M24Y"), "http://www.w3.org/2001/XMLSchema#yearMonthDuration parsing error: found M, invalid for datatype", InvalidNode);

--- a/tests/nodes/tests_Node.cpp
+++ b/tests/nodes/tests_Node.cpp
@@ -536,3 +536,13 @@ TEST_CASE("bnode inlining") {
     CHECK_EQ(v5.order(v1), std::strong_ordering::less);
     check_fetch_or_serialize(v5);
 }
+
+TEST_CASE("rdf:type") {
+    IRI x{"http://www.w3.org/1999/02/22-rdf-syntax-ns#type"};
+    IRI y = IRI::rdf_type();
+
+    CHECK(x.is_rdf_type());
+    CHECK(y.is_rdf_type());
+    CHECK_EQ(x, y);
+    CHECK_EQ(x.backend_handle(), y.backend_handle());
+}

--- a/tests/nodes/tests_Node.cpp
+++ b/tests/nodes/tests_Node.cpp
@@ -546,3 +546,13 @@ TEST_CASE("rdf:type") {
     CHECK_EQ(x, y);
     CHECK_EQ(x.backend_handle(), y.backend_handle());
 }
+
+TEST_CASE("datatype IRIs") {
+    IRI x = IRI::datatype<datatypes::xsd::Integer>();
+    IRI y{"http://www.w3.org/2001/XMLSchema#integer"};
+
+    CHECK(x.is_datatype<datatypes::xsd::Integer>());
+    CHECK(y.is_datatype<datatypes::xsd::Integer>());
+    CHECK_EQ(x, y);
+    CHECK_EQ(x.backend_handle(), y.backend_handle());
+}


### PR DESCRIPTION
Adds: `IRI::rdf_type()`, `IRI::is_rdf_type()`, `IRI::datatype<>()` and `IRI::is_datatype<>()`.

Additionally, it fixes the parsing of xsd:yearMonthDuration which apparently has been buggy