### PR TITLE
Fix: parsing of absolute IRI with dots

### DIFF
--- a/private/rdf4cpp/parser/IStreamQuadIteratorSerdImpl.cpp
+++ b/private/rdf4cpp/parser/IStreamQuadIteratorSerdImpl.cpp
@@ -58,7 +58,7 @@ nonstd::expected<IRI, SerdStatus> IStreamQuadIterator::Impl::get_iri(SerdNode co
         auto const s = node_into_string_view(node);
 
         if (flags.syntax_allows_prefixes()) {
-            return this->state->iri_factory.from_relative(s, this->state->node_storage);
+            return this->state->iri_factory.from_maybe_relative(s, this->state->node_storage);
         } else {
             return this->state->iri_factory.create_and_validate(s, this->state->node_storage);
         }

--- a/src/rdf4cpp/IRIFactory.cpp
+++ b/src/rdf4cpp/IRIFactory.cpp
@@ -161,11 +161,17 @@ static std::string_view merge_path_with_base(IRIView::AllParts const &base, std:
 /**
  * Converts rel to an absolute IRI by merging it with the given base
  */
+template<bool always_remove_dots>
 static std::string_view to_absolute(IRIView::AllParts const &base, std::string_view rel) noexcept {
     auto [r_scheme, r_auth, r_path, r_query, r_frag] = IRIView{rel}.all_parts();
 
     if (r_scheme.has_value()) {
-        return construct(*r_scheme, r_auth, remove_dot_segments(r_path), r_query, r_frag);
+        if constexpr(always_remove_dots) {
+            return construct(*r_scheme, r_auth, remove_dot_segments(r_path), r_query, r_frag);
+        }
+        else {
+            return rel;
+        }
     }
 
     auto const &[b_scheme, b_auth, b_path, b_query, _b_frag] = base;
@@ -198,7 +204,11 @@ IRIFactory::IRIFactory(prefix_map_type &&prefixes, std::string_view base) : pref
 }
 
 nonstd::expected<IRI, IRIFactoryError> IRIFactory::from_relative(std::string_view rel, storage::DynNodeStoragePtr node_storage) const noexcept {
-    return create_and_validate(to_absolute(base_parts_cache, rel), node_storage);
+    return create_and_validate(to_absolute<true>(base_parts_cache, rel), node_storage);
+}
+
+nonstd::expected<IRI, IRIFactoryError> IRIFactory::from_maybe_relative(std::string_view rel, storage::DynNodeStoragePtr node_storage) const noexcept {
+    return create_and_validate(to_absolute<false>(base_parts_cache, rel), node_storage);
 }
 
 nonstd::expected<IRI, IRIFactoryError> IRIFactory::from_prefix(std::string_view prefix, std::string_view local, storage::DynNodeStoragePtr node_storage) const {

--- a/src/rdf4cpp/IRIFactory.hpp
+++ b/src/rdf4cpp/IRIFactory.hpp
@@ -49,13 +49,21 @@ public:
     [[nodiscard]] const_reverse_iterator rend() const noexcept { return prefixes.rend(); }
 
     /**
-     * Creates a IRI from a possibly relative IRI.
+     * Creates a IRI from a relative IRI.
      * Implements https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.
      * @param rel
      * @param storage
      * @return
      */
     [[nodiscard]] nonstd::expected<IRI, IRIFactoryError> from_relative(std::string_view rel, storage::DynNodeStoragePtr node_storage = storage::default_node_storage) const noexcept;
+    /**
+     * Creates a IRI from a possibly relative IRI.
+     * if rel is relative, returns the same as from_relative, otherwise returns rel unchanged.
+     * @param rel
+     * @param storage
+     * @return
+     */
+    [[nodiscard]] nonstd::expected<IRI, IRIFactoryError> from_maybe_relative(std::string_view rel, storage::DynNodeStoragePtr node_storage = storage::default_node_storage) const noexcept;
     /**
      * Creates a IRI by looking up a prefix in the prefix map and possibly resolving a relative IRI.
      * @param prefix

--- a/tests/nodes/tests_IRIFactory.cpp
+++ b/tests/nodes/tests_IRIFactory.cpp
@@ -155,6 +155,10 @@ TEST_CASE("base") {
     CHECK(fact.from_relative("g?y/../x").value().identifier() == "http://a/b/c/g?y/../x");
     CHECK(fact.from_relative("g#y/./x").value().identifier() == "http://a/b/c/g#y/./x");
     CHECK(fact.from_relative("g#y/../x").value().identifier() == "http://a/b/c/g#y/../x");
+
+    CHECK(fact.from_relative("http://ex.com/a/./b/../c").value().identifier() == "http://ex.com/a/c");
+    CHECK(fact.from_maybe_relative("http://ex.com/a/./b/../c").value().identifier() == "http://ex.com/a/./b/../c");
+    CHECK(fact.from_maybe_relative("/x/./b/../c").value().identifier() == "http://a/x/c");
 }
 
 TEST_CASE("base reassign") {
@@ -190,6 +194,7 @@ TEST_CASE("prefix") {
     CHECK(fact.from_prefix("pre", "bar").value().identifier() == "http://ex.org/bar");
     CHECK(fact.from_prefix("foo", "bar").value().identifier() == "http://foo.org/bar");
     CHECK(fact.from_prefix("bar", "bar").error() == IRIFactoryError::UnknownPrefix);
+    CHECK(fact.from_prefix("pre", "a/./b/../c").value().identifier() == "http://ex.org/a/./b/../c");
 
     CHECK(fact.assign_prefix("pre", "http://ex.org/pre2/") == IRIFactoryError::Ok);
     CHECK(fact.from_prefix("pre", "bar").value().identifier() == "http://ex.org/pre2/bar");

--- a/tests/nodes/tests_IRIFactory.cpp
+++ b/tests/nodes/tests_IRIFactory.cpp
@@ -199,6 +199,9 @@ TEST_CASE("prefix") {
     CHECK(fact.assign_prefix("pre", "http://ex.org/pre2/") == IRIFactoryError::Ok);
     CHECK(fact.from_prefix("pre", "bar").value().identifier() == "http://ex.org/pre2/bar");
 
+    CHECK(fact.assign_prefix("dot", "http://ex.org/a/./b/../c#") == IRIFactoryError::Ok);
+    CHECK(fact.from_prefix("dot", "bar").value().identifier() == "http://ex.org/a/./b/../c#bar");
+
     fact.clear_prefix("pre");
     CHECK(fact.from_prefix("pre", "bar").error() == IRIFactoryError::UnknownPrefix);
 
@@ -217,6 +220,10 @@ TEST_CASE("relative prefix") {
 
     fact.assign_prefix_unchecked("pre", "pre2/");
     CHECK(fact.from_prefix("pre", "bar").value().identifier() == "http://ex.org/pre2/bar");
+
+    CHECK(fact.from_prefix("pre", "a/./b/../c").value().identifier() == "http://ex.org/pre2/a/c");
+    CHECK(fact.assign_prefix("dot", "a/./b/../c#") == IRIFactoryError::Ok);
+    CHECK(fact.from_prefix("dot", "bar").value().identifier() == "http://ex.org/a/c#bar");
 
     fact.clear_prefix("pre");
     CHECK(fact.from_prefix("pre", "bar").error() == IRIFactoryError::UnknownPrefix);

--- a/tests/parser/tests_IStreamQuadIterator.cpp
+++ b/tests/parser/tests_IStreamQuadIterator.cpp
@@ -747,4 +747,14 @@ TEST_SUITE("IStreamQuadIterator") {
             std::cout << qit->error() << std::endl;
         }
     }
+
+    TEST_CASE("absolute IRI with dots") {
+        // https://github.com/w3c/rdf-tests/blob/main/sparql/sparql10/i18n/normalization-02.ttl (partial)
+        std::istringstream iss{"@prefix : <http://example/vocab#>. \n:s2 :p <eXAMPLE://a/./b/../b/%63/%7bfoo%7d#xyz>."};
+        for (IStreamQuadIterator qit{iss}; qit != std::default_sentinel; ++qit) {
+            CHECK(qit->has_value());
+            CHECK(qit->value().object().is_iri());
+            CHECK(qit->value().object().as_iri().identifier() == "eXAMPLE://a/./b/../b/%63/%7bfoo%7d#xyz");
+        }
+    }
 }


### PR DESCRIPTION
this test failed before: https://github.com/w3c/rdf-tests/blob/main/sparql/sparql10/i18n/normalization-02.ttl