### PR TITLE
Fix: binops with unknown datatypes

### DIFF
--- a/src/rdf4cpp/Literal.cpp
+++ b/src/rdf4cpp/Literal.cpp
@@ -1133,7 +1133,16 @@ std::partial_ordering Literal::compare_impl(Literal const &other, std::strong_or
         return std::partial_ordering::unordered;
     }
 
-    if (this->handle_ == other.handle_) {
+    if (this->handle_.id().node_id().literal_type().is_fixed() && this->handle_ == other.handle_) {
+        // Without the check for is_fixed() we would allow all datatypes (even unknown/uncomparable) ones to be compared using equality.
+        // This check however is somewhat of a workaround; it just happens to work correctly because all known (fixed) types happen to be comparable.
+        // If one of our datatypes was not comparable, it would fail in the following scenario:
+        //     "abc"^^custom =  "abc"^^custom => true
+        //     "abc"^^custom != "abc"^^custom => false
+        //     "abc"^^custom =  "cde"^^custom => null
+        //     "abc"^^custom != "cde"^^custom => null
+        // As you can see the behaviour would be inconsistent.
+        // TODO we should probably fix this properly if we ever add a non-comparable type
         return std::partial_ordering::equivalent;
     }
 

--- a/src/rdf4cpp/Literal.cpp
+++ b/src/rdf4cpp/Literal.cpp
@@ -993,10 +993,8 @@ Literal Literal::numeric_binop_impl(OpSelect op_select, Literal const &other, st
 
     auto const this_datatype = this->datatype_id();
     auto const *this_entry = DatatypeRegistry::get_entry(this_datatype);
-    assert(this_entry != nullptr);
-
-    if (!this_entry->numeric_ops.has_value()) {
-        return Literal{};  // not numeric
+    if (this_entry == nullptr || !this_entry->numeric_ops.has_value()) {
+        return Literal{};  // not registered or not numeric
     }
 
     auto const other_datatype = other.datatype_id();
@@ -1079,9 +1077,7 @@ Literal Literal::numeric_unop_impl(OpSelect op_select, storage::DynNodeStoragePt
 
     auto const this_datatype = this->datatype_id();
     auto const this_entry = DatatypeRegistry::get_entry(this_datatype);
-    assert(this_entry != nullptr);
-
-    if (!this_entry->numeric_ops.has_value()) {
+    if (this_entry == nullptr || !this_entry->numeric_ops.has_value()) {
         return Literal{};  // this_datatype not numeric
     }
 
@@ -1474,10 +1470,14 @@ std::optional<Literal> Literal::chrono_add_impl(Literal const &other, storage::D
     auto const other_datatype = other.datatype_id();
 
     auto const *this_entry = DatatypeRegistry::get_entry(this_datatype);
-    assert(this_entry != nullptr);
+    if (this_entry == nullptr) {
+        return std::nullopt; // not registered
+    }
 
     auto const *other_entry = DatatypeRegistry::get_entry(other_datatype);
-    assert(other_entry != nullptr);
+    if (other_entry == nullptr) {
+        return std::nullopt; // not registered
+    }
 
     if (!other_entry->duration_ops.has_value()) {
         // other is not duration
@@ -1551,9 +1551,14 @@ std::optional<Literal> Literal::chrono_sub_impl(Literal const &other, storage::D
     auto const other_datatype = other.datatype_id();
 
     auto const *this_entry = DatatypeRegistry::get_entry(this_datatype);
-    assert(this_entry != nullptr);
+    if (this_entry == nullptr) {
+        return std::nullopt; // not registered
+    }
 
     auto const *other_entry = DatatypeRegistry::get_entry(other_datatype);
+    if (other_entry == nullptr) {
+        return std::nullopt; // not registered
+    }
 
     if (this_entry->timepoint_ops.has_value()) {
         if (other_entry->timepoint_ops.has_value()) {
@@ -1631,17 +1636,15 @@ std::optional<Literal> Literal::chrono_mul_impl(Literal const &other, storage::D
 
     auto const this_datatype = this->datatype_id();
     auto const *this_entry = DatatypeRegistry::get_entry(this_datatype);
-    assert(this_entry != nullptr);
-    if (!this_entry->duration_ops.has_value()) {
-        // lhs is not duration
+    if (this_entry == nullptr || !this_entry->duration_ops.has_value()) {
+        // lhs is not registered or not a duration
         return std::nullopt;
     }
 
     auto const other_datatype = other.datatype_id();
     auto const *other_entry = DatatypeRegistry::get_entry(other_datatype);
-    assert(other_entry != nullptr);
-    if (!other_entry->numeric_ops.has_value()) {
-        // rhs is not numeric
+    if (other_entry == nullptr || !other_entry->numeric_ops.has_value()) {
+        // rhs is not registered or not numeric
         return std::nullopt;
     }
 
@@ -1699,16 +1702,16 @@ std::optional<Literal> Literal::chrono_div_impl(Literal const &other, storage::D
     auto const this_datatype = this->datatype_id();
 
     auto const *this_entry = DatatypeRegistry::get_entry(this_datatype);
-    assert(this_entry != nullptr);
-
-    if (!this_entry->duration_ops.has_value()) {
-        // lhs is not duration
+    if (this_entry == nullptr || !this_entry->duration_ops.has_value()) {
+        // lhs is not registered or not duration
         return std::nullopt;
     }
 
     auto const other_datatype = other.datatype_id();
     auto const *other_entry = DatatypeRegistry::get_entry(other_datatype);
-    assert(other_entry != nullptr);
+    if (other_entry == nullptr) {
+        return std::nullopt; // other is not registered
+    }
 
     if (other_entry->duration_ops.has_value()) {
         // this & other are durations

--- a/src/rdf4cpp/Literal.cpp
+++ b/src/rdf4cpp/Literal.cpp
@@ -1021,10 +1021,8 @@ Literal Literal::numeric_binop_impl(OpSelect op_select, Literal const &other, st
         return Literal::make_typed_unchecked(std::move(*op_res.result_value), op_res.result_type_id, *result_entry, node_storage);
     } else {
         auto const *other_entry = DatatypeRegistry::get_entry(other_datatype);
-        assert(other_entry != nullptr);
-
-        if (!other_entry->numeric_ops.has_value()) {
-            return Literal{};  // not numeric
+        if (other_entry == nullptr || !other_entry->numeric_ops.has_value()) {
+            return Literal{}; // not registered, or not numeric
         }
 
         auto const equalizer = DatatypeRegistry::get_common_numeric_op_type_conversion(*this_entry,

--- a/src/rdf4cpp/datatypes/xsd/Base64Binary.hpp
+++ b/src/rdf4cpp/datatypes/xsd/Base64Binary.hpp
@@ -85,7 +85,8 @@ extern template struct LiteralDatatypeImpl<xsd_base64_binary,
 namespace rdf4cpp::datatypes::xsd {
 
 struct Base64Binary : registry::LiteralDatatypeImpl<registry::xsd_base64_binary,
-                                                    registry::capabilities::FixedId> {};
+                                                    registry::capabilities::FixedId,
+                                                    registry::capabilities::Comparable> {};
 
 } // namespace rdf4cpp::datatypes::xsd
 

--- a/src/rdf4cpp/datatypes/xsd/HexBinary.hpp
+++ b/src/rdf4cpp/datatypes/xsd/HexBinary.hpp
@@ -112,7 +112,8 @@ extern template struct LiteralDatatypeImpl<xsd_hex_binary,
 namespace rdf4cpp::datatypes::xsd {
 
 struct HexBinary : registry::LiteralDatatypeImpl<registry::xsd_hex_binary,
-                                                 registry::capabilities::FixedId> {};
+                                                 registry::capabilities::FixedId,
+                                                 registry::capabilities::Comparable> {};
 
 } // namespace rdf4cpp::datatypes::xsd
 

--- a/tests/nodes/tests_Literal.cpp
+++ b/tests/nodes/tests_Literal.cpp
@@ -1058,6 +1058,14 @@ struct get_find_values<FakeDatatype> { // no fixed id
 
 
 TEST_CASE_TEMPLATE("Literal::find", T, datatypes::xsd::String, datatypes::rdf::LangString, datatypes::xsd::Int, datatypes::xsd::Date, FakeDatatype) {
+    auto eq_check = [](Literal lhs, Literal rhs) {
+        if constexpr (std::is_same_v<T, FakeDatatype>) {
+            CHECK(lhs <=> rhs == std::partial_ordering::unordered);
+        } else {
+            CHECK(lhs == rhs);
+        }
+    };
+
     if constexpr (requires { get_find_values<T>::av; }) {
         static constexpr auto av = get_find_values<T>::av;
         static constexpr auto bv = get_find_values<T>::bv;
@@ -1065,7 +1073,7 @@ TEST_CASE_TEMPLATE("Literal::find", T, datatypes::xsd::String, datatypes::rdf::L
 
         CHECK(Literal::find_typed_from_value<T>(av, nst).null());
         Literal l = Literal::make_typed_from_value<T>(av, nst);
-        CHECK(Literal::find_typed_from_value<T>(av, nst) == l);
+        eq_check(Literal::find_typed_from_value<T>(av, nst), l);
         CHECK(Literal::find_typed_from_value<T>(av, nst).backend_handle() == l.backend_handle());
         CHECK(Literal::find_typed_from_value<T>(bv, nst).null());
     }
@@ -1081,14 +1089,14 @@ TEST_CASE_TEMPLATE("Literal::find", T, datatypes::xsd::String, datatypes::rdf::L
 
         CHECK(Literal::find_typed<T>(as, nst).null());
         Literal l = Literal::make_typed<T>(as, nst);
-        CHECK(Literal::find_typed<T>(as, nst) == l);
+        eq_check(Literal::find_typed<T>(as, nst), l);
         CHECK(Literal::find_typed<T>(as, nst).backend_handle() == l.backend_handle());
         CHECK(Literal::find_typed<T>(bs, nst).null());
     }
     if constexpr (requires { get_find_values<T>::inls; }) {
         auto nst = storage::reference_node_storage::SyncReferenceNodeStorage{};
         auto l = Literal::find_typed<T>(get_find_values<T>::inls, nst);
-        CHECK(l == Literal::make_typed<T>(get_find_values<T>::inls));
+        eq_check(Literal::make_typed<T>(get_find_values<T>::inls), l);
     }
 }
 

--- a/tests/nodes/tests_Literal_ops.cpp
+++ b/tests/nodes/tests_Literal_ops.cpp
@@ -224,6 +224,42 @@ TEST_CASE("Literal - numeric ops") {
             CHECK((-lit).null());
         }
     }
+
+    SUBCASE("op with unknown") {
+        using namespace shorthands;
+        using namespace std::chrono_literals;
+
+        auto const unknown = Literal::make_typed("123", IRI{"http://mydatatype.com#int"});
+
+        auto const num = 5_xsd_int;
+        auto const tp = Literal::make_typed_from_value<datatypes::xsd::Date>(std::make_pair(YearMonthDay{Year{2000}, std::chrono::January, 1d}, std::nullopt));
+        auto const dur = Literal::make_typed_from_value<datatypes::xsd::DayTimeDuration>(100ns);
+
+        auto check_null = [](auto x) {
+            CHECK(x.null());
+        };
+
+        // simulate code paths
+        check_null(num + unknown);
+        check_null(unknown + num);
+        check_null(tp + unknown); // tp + dur
+        check_null(tp - unknown); // tp - dur / tp - tp
+        check_null(dur + unknown); // dur + dur
+        check_null(dur - unknown); // dur - dur
+        check_null(dur / unknown); // dur / dur and dur / num
+        check_null(dur * unknown); // dur * num
+
+        // unknown with unknown
+        check_null(unknown + unknown);
+        check_null(unknown - unknown);
+        check_null(unknown / unknown);
+        check_null(unknown * unknown);
+        check_null(unknown && unknown);
+        check_null(unknown || unknown);
+        check_null(+unknown);
+        check_null(-unknown);
+        check_null(!unknown);
+    }
 }
 
 // create fake hierarchy

--- a/tests/nodes/tests_Literal_ops.cpp
+++ b/tests/nodes/tests_Literal_ops.cpp
@@ -235,8 +235,12 @@ TEST_CASE("Literal - numeric ops") {
         auto const tp = Literal::make_typed_from_value<datatypes::xsd::Date>(std::make_pair(YearMonthDay{Year{2000}, std::chrono::January, 1d}, std::nullopt));
         auto const dur = Literal::make_typed_from_value<datatypes::xsd::DayTimeDuration>(100ns);
 
-        auto check_null = [](auto x) {
+        auto check_null = [](Literal x) {
             CHECK(x.null());
+        };
+
+        auto check_err = [](TriBool b) {
+            CHECK_EQ(b, TriBool::Err);
         };
 
         // simulate code paths
@@ -259,6 +263,18 @@ TEST_CASE("Literal - numeric ops") {
         check_null(+unknown);
         check_null(-unknown);
         check_null(!unknown);
+        check_err(unknown.eq(unknown));
+        check_err(unknown.ne(unknown));
+        check_err(unknown.lt(unknown));
+        check_err(unknown.le(unknown));
+        check_err(unknown.gt(unknown));
+        check_err(unknown.ge(unknown));
+        CHECK(unknown.order_eq(unknown));
+        CHECK_FALSE(unknown.order_ne(unknown));
+        CHECK_FALSE(unknown.order_lt(unknown));
+        CHECK(unknown.order_le(unknown));
+        CHECK_FALSE(unknown.order_gt(unknown));
+        CHECK(unknown.order_ge(unknown));
     }
 }
 

--- a/tests/nodes/tests_Node.cpp
+++ b/tests/nodes/tests_Node.cpp
@@ -92,7 +92,7 @@ TEST_SUITE("comparisons") {
 
         SUBCASE("incomparability") {
             CHECK(Literal::make_typed_from_value<Incomparable>(1) <=> Literal::make_typed_from_value<Incomparable>(2) == std::partial_ordering::unordered);
-            CHECK(Literal::make_typed_from_value<Incomparable>(1) <=> Literal::make_typed_from_value<Incomparable>(1) == std::partial_ordering::equivalent); // exactly the same object so still equal
+            CHECK(Literal::make_typed_from_value<Incomparable>(1) <=> Literal::make_typed_from_value<Incomparable>(1) == std::partial_ordering::unordered);
             CHECK(Literal::make_typed_from_value<Int>(1) <=> Literal::make_typed_from_value<Incomparable>(1) == std::partial_ordering::unordered);
             CHECK(Literal::make_typed_from_value<Incomparable>(1) <=> Literal::make_typed_from_value<Int>(1) == std::partial_ordering::unordered);
         }


### PR DESCRIPTION
Fixes an issue where a binary operation with an unknown right hand side would trigger an assertion.

Additionally, fixed an inconsistency when comparing uncomparable datatypes.