### PR TITLE
fix: remove outdated stability warning in docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,5 +13,3 @@ Welcome to rdf4cpp's documentation!
 rdf4cpp aims to be a stable, modern RDF library for C++.
 
 This page was build for rdf4cpp |release|.
-
-.. warning:: ⚠️ This repo is work-in-progress! Before v0.1.0 all APIs are considered unstable and might be subject to change. ⚠️


### PR DESCRIPTION
close #397 