### PR TITLE
Feature: add trigonometry & exponential funcs

### DIFF
--- a/src/rdf4cpp/Literal.cpp
+++ b/src/rdf4cpp/Literal.cpp
@@ -2608,21 +2608,7 @@ if (!var_name##_opt.has_value()) {                                              
 auto const var_name = *var_name##_opt;
 
 Literal Literal::math_exp(storage::DynNodeStoragePtr node_storage) const {
-
-    auto const th_opt = [&source_obj = (*this)]() -> std::optional<double> {
-        if (source_obj.null()) {
-            return std::nullopt;
-        }
-        if (!source_obj.datatype_eq<datatypes::xsd::Double>()) {
-            return source_obj.cast_to_value<datatypes::xsd::Double>();
-        }
-        return source_obj.value<datatypes::xsd::Double>();
-    }();
-    if (!th_opt.has_value()) {
-        return {};
-    }
-    auto const th = *th_opt;
-
+    CPP_DOUBLE_OR_RETURN_NULL(*this, th);
     return Literal::make_typed_from_value<datatypes::xsd::Double>(std::exp(th), select_node_storage(node_storage));
 }
 Literal Literal::math_exp10(storage::DynNodeStoragePtr node_storage) const {

--- a/src/rdf4cpp/Literal.cpp
+++ b/src/rdf4cpp/Literal.cpp
@@ -2591,106 +2591,88 @@ Literal lang_matches(Literal const &lang_tag, Literal const &lang_range, storage
 Literal Literal::math_pi(storage::DynNodeStoragePtr node_storage) {
     return Literal::make_typed_from_value<datatypes::xsd::Double>(std::numbers::pi, node_storage);
 }
+
+#define CPP_DOUBLE_OR_RETURN_NULL(source_expr, var_name)                               \
+auto const var_name##_opt = [&source_obj = (source_expr)]() -> std::optional<double> { \
+    if (source_obj.null()) {                                                           \
+        return std::nullopt;                                                           \
+    }                                                                                  \
+    if (!source_obj.datatype_eq<datatypes::xsd::Double>()) {                           \
+        return source_obj.cast_to_value<datatypes::xsd::Double>();                     \
+    }                                                                                  \
+    return source_obj.value<datatypes::xsd::Double>();                                 \
+}();                                                                                   \
+if (!var_name##_opt.has_value()) {                                                     \
+    return {};                                                                         \
+}                                                                                      \
+auto const var_name = *var_name##_opt;
+
 Literal Literal::math_exp(storage::DynNodeStoragePtr node_storage) const {
-    if (null() || !datatype_eq<datatypes::xsd::Double>()) {
+
+    auto const th_opt = [&source_obj = (*this)]() -> std::optional<double> {
+        if (source_obj.null()) {
+            return std::nullopt;
+        }
+        if (!source_obj.datatype_eq<datatypes::xsd::Double>()) {
+            return source_obj.cast_to_value<datatypes::xsd::Double>();
+        }
+        return source_obj.value<datatypes::xsd::Double>();
+    }();
+    if (!th_opt.has_value()) {
         return {};
     }
-    auto th = value<datatypes::xsd::Double>();
+    auto const th = *th_opt;
+
     return Literal::make_typed_from_value<datatypes::xsd::Double>(std::exp(th), select_node_storage(node_storage));
 }
 Literal Literal::math_exp10(storage::DynNodeStoragePtr node_storage) const {
-    if (null() || !datatype_eq<datatypes::xsd::Double>()) {
-        return {};
-    }
-    auto th = value<datatypes::xsd::Double>();
+    CPP_DOUBLE_OR_RETURN_NULL(*this, th);
     return Literal::make_typed_from_value<datatypes::xsd::Double>(std::pow(10.0, th), select_node_storage(node_storage));
 }
 Literal Literal::math_log(storage::DynNodeStoragePtr node_storage) const {
-    if (null() || !datatype_eq<datatypes::xsd::Double>()) {
-        return {};
-    }
-    auto th = value<datatypes::xsd::Double>();
+    CPP_DOUBLE_OR_RETURN_NULL(*this, th);
     return Literal::make_typed_from_value<datatypes::xsd::Double>(std::log(th), select_node_storage(node_storage));
 }
 Literal Literal::math_log10(storage::DynNodeStoragePtr node_storage) const {
-    if (null() || !datatype_eq<datatypes::xsd::Double>()) {
-        return {};
-    }
-    auto th = value<datatypes::xsd::Double>();
+    CPP_DOUBLE_OR_RETURN_NULL(*this, th);
     return Literal::make_typed_from_value<datatypes::xsd::Double>(std::log10(th), select_node_storage(node_storage));
 }
 Literal Literal::math_pow(Literal exp, storage::DynNodeStoragePtr node_storage) const {
-    if (null() || !datatype_eq<datatypes::xsd::Double>()) {
-        return {};
-    }
-    if (exp.null()) {
-        return {};
-    }
-    auto th = value<datatypes::xsd::Double>();
-    auto ex = exp.cast_to_value<datatypes::xsd::Double>();
-    if (!ex.has_value()) {
-        return {};
-    }
-    return Literal::make_typed_from_value<datatypes::xsd::Double>(std::pow(th, *ex), select_node_storage(node_storage));
+    CPP_DOUBLE_OR_RETURN_NULL(*this, th);
+    CPP_DOUBLE_OR_RETURN_NULL(exp, ex);
+    return Literal::make_typed_from_value<datatypes::xsd::Double>(std::pow(th, ex), select_node_storage(node_storage));
 }
 Literal Literal::math_sqrt(storage::DynNodeStoragePtr node_storage) const {
-    if (null() || !datatype_eq<datatypes::xsd::Double>()) {
-        return {};
-    }
-    auto th = value<datatypes::xsd::Double>();
+    CPP_DOUBLE_OR_RETURN_NULL(*this, th);
     return Literal::make_typed_from_value<datatypes::xsd::Double>(std::sqrt(th), select_node_storage(node_storage));
 }
 Literal Literal::math_sin(storage::DynNodeStoragePtr node_storage) const {
-    if (null() || !datatype_eq<datatypes::xsd::Double>()) {
-        return {};
-    }
-    auto th = value<datatypes::xsd::Double>();
+    CPP_DOUBLE_OR_RETURN_NULL(*this, th);
     return Literal::make_typed_from_value<datatypes::xsd::Double>(std::sin(th), select_node_storage(node_storage));
 }
 Literal Literal::math_cos(storage::DynNodeStoragePtr node_storage) const {
-    if (null() || !datatype_eq<datatypes::xsd::Double>()) {
-        return {};
-    }
-    auto th = value<datatypes::xsd::Double>();
+    CPP_DOUBLE_OR_RETURN_NULL(*this, th);
     return Literal::make_typed_from_value<datatypes::xsd::Double>(std::cos(th), select_node_storage(node_storage));
 }
 Literal Literal::math_tan(storage::DynNodeStoragePtr node_storage) const {
-    if (null() || !datatype_eq<datatypes::xsd::Double>()) {
-        return {};
-    }
-    auto th = value<datatypes::xsd::Double>();
+    CPP_DOUBLE_OR_RETURN_NULL(*this, th);
     return Literal::make_typed_from_value<datatypes::xsd::Double>(std::tan(th), select_node_storage(node_storage));
 }
 Literal Literal::math_asin(storage::DynNodeStoragePtr node_storage) const {
-    if (null() || !datatype_eq<datatypes::xsd::Double>()) {
-        return {};
-    }
-    auto th = value<datatypes::xsd::Double>();
+    CPP_DOUBLE_OR_RETURN_NULL(*this, th);
     return Literal::make_typed_from_value<datatypes::xsd::Double>(std::asin(th), select_node_storage(node_storage));
 }
 Literal Literal::math_acos(storage::DynNodeStoragePtr node_storage) const {
-    if (null() || !datatype_eq<datatypes::xsd::Double>()) {
-        return {};
-    }
-    auto th = value<datatypes::xsd::Double>();
+    CPP_DOUBLE_OR_RETURN_NULL(*this, th);
     return Literal::make_typed_from_value<datatypes::xsd::Double>(std::acos(th), select_node_storage(node_storage));
 }
 Literal Literal::math_atan(storage::DynNodeStoragePtr node_storage) const {
-    if (null() || !datatype_eq<datatypes::xsd::Double>()) {
-        return {};
-    }
-    auto th = value<datatypes::xsd::Double>();
+    CPP_DOUBLE_OR_RETURN_NULL(*this, th);
     return Literal::make_typed_from_value<datatypes::xsd::Double>(std::atan(th), select_node_storage(node_storage));
 }
 Literal Literal::math_atan2(Literal y, storage::DynNodeStoragePtr node_storage) const {
-    if (null() || !datatype_eq<datatypes::xsd::Double>()) {
-        return {};
-    }
-    if (y.null() || !y.datatype_eq<datatypes::xsd::Double>()) {
-        return {};
-    }
-    auto th = value<datatypes::xsd::Double>();
-    auto yd = y.value<datatypes::xsd::Double>();
+    CPP_DOUBLE_OR_RETURN_NULL(*this, th);
+    CPP_DOUBLE_OR_RETURN_NULL(y, yd);
     return Literal::make_typed_from_value<datatypes::xsd::Double>(std::atan2(th, yd), select_node_storage(node_storage));
 }
 

--- a/src/rdf4cpp/Literal.cpp
+++ b/src/rdf4cpp/Literal.cpp
@@ -2588,6 +2588,111 @@ Literal lang_matches(Literal const &lang_tag, Literal const &lang_range, storage
     auto const res = lang_matches(lang_tag.lexical_form(), lang_range.lexical_form());
     return Literal::make_boolean(res, lang_tag.select_node_storage(node_storage));
 }
+Literal Literal::math_pi(storage::DynNodeStoragePtr node_storage) {
+    return Literal::make_typed_from_value<datatypes::xsd::Double>(std::numbers::pi, node_storage);
+}
+Literal Literal::math_exp(storage::DynNodeStoragePtr node_storage) const {
+    if (null() || !datatype_eq<datatypes::xsd::Double>()) {
+        return {};
+    }
+    auto th = value<datatypes::xsd::Double>();
+    return Literal::make_typed_from_value<datatypes::xsd::Double>(std::exp(th), select_node_storage(node_storage));
+}
+Literal Literal::math_exp10(storage::DynNodeStoragePtr node_storage) const {
+    if (null() || !datatype_eq<datatypes::xsd::Double>()) {
+        return {};
+    }
+    auto th = value<datatypes::xsd::Double>();
+    return Literal::make_typed_from_value<datatypes::xsd::Double>(std::pow(10.0, th), select_node_storage(node_storage));
+}
+Literal Literal::math_log(storage::DynNodeStoragePtr node_storage) const {
+    if (null() || !datatype_eq<datatypes::xsd::Double>()) {
+        return {};
+    }
+    auto th = value<datatypes::xsd::Double>();
+    return Literal::make_typed_from_value<datatypes::xsd::Double>(std::log(th), select_node_storage(node_storage));
+}
+Literal Literal::math_log10(storage::DynNodeStoragePtr node_storage) const {
+    if (null() || !datatype_eq<datatypes::xsd::Double>()) {
+        return {};
+    }
+    auto th = value<datatypes::xsd::Double>();
+    return Literal::make_typed_from_value<datatypes::xsd::Double>(std::log10(th), select_node_storage(node_storage));
+}
+Literal Literal::math_pow(Literal exp, storage::DynNodeStoragePtr node_storage) const {
+    if (null() || !datatype_eq<datatypes::xsd::Double>()) {
+        return {};
+    }
+    if (exp.null()) {
+        return {};
+    }
+    auto th = value<datatypes::xsd::Double>();
+    auto ex = exp.cast_to_value<datatypes::xsd::Double>();
+    if (!ex.has_value()) {
+        return {};
+    }
+    return Literal::make_typed_from_value<datatypes::xsd::Double>(std::pow(th, *ex), select_node_storage(node_storage));
+}
+Literal Literal::math_sqrt(storage::DynNodeStoragePtr node_storage) const {
+    if (null() || !datatype_eq<datatypes::xsd::Double>()) {
+        return {};
+    }
+    auto th = value<datatypes::xsd::Double>();
+    return Literal::make_typed_from_value<datatypes::xsd::Double>(std::sqrt(th), select_node_storage(node_storage));
+}
+Literal Literal::math_sin(storage::DynNodeStoragePtr node_storage) const {
+    if (null() || !datatype_eq<datatypes::xsd::Double>()) {
+        return {};
+    }
+    auto th = value<datatypes::xsd::Double>();
+    return Literal::make_typed_from_value<datatypes::xsd::Double>(std::sin(th), select_node_storage(node_storage));
+}
+Literal Literal::math_cos(storage::DynNodeStoragePtr node_storage) const {
+    if (null() || !datatype_eq<datatypes::xsd::Double>()) {
+        return {};
+    }
+    auto th = value<datatypes::xsd::Double>();
+    return Literal::make_typed_from_value<datatypes::xsd::Double>(std::cos(th), select_node_storage(node_storage));
+}
+Literal Literal::math_tan(storage::DynNodeStoragePtr node_storage) const {
+    if (null() || !datatype_eq<datatypes::xsd::Double>()) {
+        return {};
+    }
+    auto th = value<datatypes::xsd::Double>();
+    return Literal::make_typed_from_value<datatypes::xsd::Double>(std::tan(th), select_node_storage(node_storage));
+}
+Literal Literal::math_asin(storage::DynNodeStoragePtr node_storage) const {
+    if (null() || !datatype_eq<datatypes::xsd::Double>()) {
+        return {};
+    }
+    auto th = value<datatypes::xsd::Double>();
+    return Literal::make_typed_from_value<datatypes::xsd::Double>(std::asin(th), select_node_storage(node_storage));
+}
+Literal Literal::math_acos(storage::DynNodeStoragePtr node_storage) const {
+    if (null() || !datatype_eq<datatypes::xsd::Double>()) {
+        return {};
+    }
+    auto th = value<datatypes::xsd::Double>();
+    return Literal::make_typed_from_value<datatypes::xsd::Double>(std::acos(th), select_node_storage(node_storage));
+}
+Literal Literal::math_atan(storage::DynNodeStoragePtr node_storage) const {
+    if (null() || !datatype_eq<datatypes::xsd::Double>()) {
+        return {};
+    }
+    auto th = value<datatypes::xsd::Double>();
+    return Literal::make_typed_from_value<datatypes::xsd::Double>(std::atan(th), select_node_storage(node_storage));
+}
+Literal Literal::math_atan2(Literal y, storage::DynNodeStoragePtr node_storage) const {
+    if (null() || !datatype_eq<datatypes::xsd::Double>()) {
+        return {};
+    }
+    if (y.null() || !y.datatype_eq<datatypes::xsd::Double>()) {
+        return {};
+    }
+    auto th = value<datatypes::xsd::Double>();
+    auto yd = y.value<datatypes::xsd::Double>();
+    return Literal::make_typed_from_value<datatypes::xsd::Double>(std::atan2(th, yd), select_node_storage(node_storage));
+}
 
 inline namespace shorthands {
 

--- a/src/rdf4cpp/Literal.hpp
+++ b/src/rdf4cpp/Literal.hpp
@@ -751,7 +751,7 @@ public:
 
         if constexpr (std::same_as<T, Boolean>) {
             // any -> bool
-            TriBool t = this->ebv();
+            TriBool const t = this->ebv();
             if (t == TriBool::Err)
                 return std::nullopt;
             else if (t == TriBool::True)

--- a/src/rdf4cpp/Literal.hpp
+++ b/src/rdf4cpp/Literal.hpp
@@ -1560,6 +1560,91 @@ public:
 
     friend struct Node;
     friend Literal lang_matches(Literal const &lang_tag, Literal const &lang_range, storage::DynNodeStoragePtr node_storage) noexcept;
+
+    /**
+     * https://www.w3.org/TR/xpath-functions/#func-math-pi
+     * @return std::numbers::pi as xsd::Double
+     */
+    [[nodiscard]] static Literal math_pi(storage::DynNodeStoragePtr node_storage = storage::default_node_storage);
+    /**
+     * https://www.w3.org/TR/xpath-functions/#func-math-exp
+     * returns null, if this is not of type xsd::Double.
+     * @return pow(e, this)
+     */
+    [[nodiscard]] Literal math_exp(storage::DynNodeStoragePtr node_storage = keep_node_storage) const;
+    /**
+     * https://www.w3.org/TR/xpath-functions/#func-math-exp10
+     * returns null, if this is not of type xsd::Double.
+     * @return pow(10, this)
+     */
+    [[nodiscard]] Literal math_exp10(storage::DynNodeStoragePtr node_storage = keep_node_storage) const;
+    /**
+     * https://www.w3.org/TR/xpath-functions/#func-math-log
+     * returns null, if this is not of type xsd::Double.
+     * @return log(e, this)
+     */
+    [[nodiscard]] Literal math_log(storage::DynNodeStoragePtr node_storage = keep_node_storage) const;
+    /**
+     * https://www.w3.org/TR/xpath-functions/#func-math-log10
+     * returns null, if this is not of type xsd::Double.
+     * @return log(10, this)
+     */
+    [[nodiscard]] Literal math_log10(storage::DynNodeStoragePtr node_storage = keep_node_storage) const;
+    /**
+     * https://www.w3.org/TR/xpath-functions/#func-math-pow
+     * returns null, if this is not of type xsd::Double or exp not numeric.
+     * @return pow(this, exp)
+     */
+    [[nodiscard]] Literal math_pow(Literal exp, storage::DynNodeStoragePtr node_storage = keep_node_storage) const;
+    /**
+     * https://www.w3.org/TR/xpath-functions/#func-math-sqrt
+     * returns null, if this is not of type xsd::Double.
+     * @return sqrt(this)
+     */
+    [[nodiscard]] Literal math_sqrt(storage::DynNodeStoragePtr node_storage = keep_node_storage) const;
+
+    /**
+     * https://www.w3.org/TR/xpath-functions/#func-math-sin
+     * returns null, if this is not of type xsd::Double.
+     * @return sin(this)
+     */
+    [[nodiscard]] Literal math_sin(storage::DynNodeStoragePtr node_storage = keep_node_storage) const;
+    /**
+     * https://www.w3.org/TR/xpath-functions/#func-math-cos
+     * returns null, if this is not of type xsd::Double.
+     * @return cos(this)
+     */
+    [[nodiscard]] Literal math_cos(storage::DynNodeStoragePtr node_storage = keep_node_storage) const;
+    /**
+     * https://www.w3.org/TR/xpath-functions/#func-math-tan
+     * returns null, if this is not of type xsd::Double.
+     * @return tan(this)
+     */
+    [[nodiscard]] Literal math_tan(storage::DynNodeStoragePtr node_storage = keep_node_storage) const;
+    /**
+     * https://www.w3.org/TR/xpath-functions/#func-math-asin
+     * returns null, if this is not of type xsd::Double.
+     * @return asin(this)
+     */
+    [[nodiscard]] Literal math_asin(storage::DynNodeStoragePtr node_storage = keep_node_storage) const;
+    /**
+     * https://www.w3.org/TR/xpath-functions/#func-math-acos
+     * returns null, if this is not of type xsd::Double.
+     * @return acos(this)
+     */
+    [[nodiscard]] Literal math_acos(storage::DynNodeStoragePtr node_storage = keep_node_storage) const;
+    /**
+     * https://www.w3.org/TR/xpath-functions/#func-math-atan
+     * returns null, if this is not of type xsd::Double.
+     * @return atan(this)
+     */
+    [[nodiscard]] Literal math_atan(storage::DynNodeStoragePtr node_storage = keep_node_storage) const;
+    /**
+     * https://www.w3.org/TR/xpath-functions/#func-math-atan2
+     * returns null, if this or y is not of type xsd::Double.
+     * @return atan2(this, y)
+     */
+    [[nodiscard]] Literal math_atan2(Literal y, storage::DynNodeStoragePtr node_storage = keep_node_storage) const;
 };
 
 /**

--- a/tests/nodes/tests_Literal.cpp
+++ b/tests/nodes/tests_Literal.cpp
@@ -1215,8 +1215,9 @@ TEST_CASE("trigonometry/exponential funcs") {
     static constexpr auto p_inf = std::numeric_limits<double>::infinity();
     static constexpr auto n_inf = -p_inf;
 
-    const auto str = Literal::make_simple("something");
-    const auto i = Literal::make_typed_from_value<xsd::Int>(42);
+    auto const str = Literal::make_simple("something");
+    auto const i0 = Literal::make_typed_from_value<xsd::Int>(0);
+    auto const f0 = Literal::make_typed_from_value<xsd::Int>(0);
 
     // adapted from https://www.w3.org/TR/xpath-functions/#trigonometry
     SUBCASE("pi") {
@@ -1224,6 +1225,8 @@ TEST_CASE("trigonometry/exponential funcs") {
     }
     SUBCASE("exp") {
         check(make(0.0).math_exp(), 1.0);
+        check(i0.math_exp(), 1.0);
+        check(f0.math_exp(), 1.0);
         check(make(1.0).math_exp(), 2.7182818284590455);
         check(make(2.0).math_exp(), 7.38905609893065);
         check(make(-1.0).math_exp(), 0.36787944117144233);
@@ -1231,10 +1234,11 @@ TEST_CASE("trigonometry/exponential funcs") {
         check(make(p_inf).math_exp(), p_inf);
         check(make(n_inf).math_exp(), 0.0);
         CHECK(str.math_exp().null());
-        CHECK(i.math_exp().null());
     }
     SUBCASE("exp10") {
         check(make(0.0).math_exp10(), 1.0);
+        check(i0.math_exp10(), 1.0);
+        check(f0.math_exp10(), 1.0);
         check(make(1.0).math_exp10(), 10);
         check(make(2.0).math_exp10(), 100);
         check(make(0.5).math_exp10(), 3.1622776601683795);
@@ -1243,10 +1247,11 @@ TEST_CASE("trigonometry/exponential funcs") {
         check(make(p_inf).math_exp10(), p_inf);
         check(make(n_inf).math_exp10(), 0.0);
         CHECK(str.math_exp10().null());
-        CHECK(i.math_exp10().null());
     }
     SUBCASE("log") {
         check(make(0.0).math_log(), n_inf);
+        check(i0.math_log(), n_inf);
+        check(f0.math_log(), n_inf);
         check(make(1.0).math_exp().math_log(), 1.0);
         check(make(1.0e-3).math_log(), -6.907755278982137);
         check(make(2).math_log(), 0.6931471805599453);
@@ -1255,10 +1260,11 @@ TEST_CASE("trigonometry/exponential funcs") {
         check(make(p_inf).math_log(), p_inf);
         check(make(n_inf).math_log(), nan);
         CHECK(str.math_log().null());
-        CHECK(i.math_log().null());
     }
     SUBCASE("log10") {
         check(make(0.0).math_log10(), n_inf);
+        check(i0.math_log10(), n_inf);
+        check(f0.math_log10(), n_inf);
         check(make(1.0e3).math_log10(), 3.0);
         check(make(1.0e-3).math_log10(), -3.0);
         check(make(2).math_log10(), 0.3010299956639812);
@@ -1267,13 +1273,16 @@ TEST_CASE("trigonometry/exponential funcs") {
         check(make(p_inf).math_log10(), p_inf);
         check(make(n_inf).math_log10(), nan);
         CHECK(str.math_log10().null());
-        CHECK(i.math_log10().null());
     }
     SUBCASE("pow") {
         check(make(2.0).math_pow(make(3.0)), 8.0);
         check(make(-2.0).math_pow(make(3.0)), -8.0);
         check(make(2.0).math_pow(make(0.0)), 1.0);
         check(make(0.0).math_pow(make(0.0)), 1.0);
+        check(i0.math_pow(i0), 1.0);
+        check(i0.math_pow(f0), 1.0);
+        check(f0.math_pow(i0), 1.0);
+        check(f0.math_pow(f0), 1.0);
         check(make(p_inf).math_pow(make(0.0)), 1.0);
         check(make(nan).math_pow(make(0.0)), 1.0);
         check(make(0.0).math_pow(make(1.0)), 0.0);
@@ -1297,11 +1306,12 @@ TEST_CASE("trigonometry/exponential funcs") {
         check(make(-1.0).math_pow(make(p_inf)), 1.0);
         check(make(-1.0).math_pow(make(n_inf)), 1.0);
         CHECK(str.math_pow(make(3.1)).null());
-        CHECK(i.math_pow(make(3.1)).null());
         CHECK(make(3.1).math_pow(str).null());
     }
     SUBCASE("sqrt") {
         check(make(0.0).math_sqrt(), 0.0);
+        check(i0.math_sqrt(), 0.0);
+        check(f0.math_sqrt(), 0.0);
         check(make(-0.0).math_sqrt(), -0.0);
         check(make(1.0).math_sqrt(), 1.0);
         check(make(2.0).math_sqrt(), 1.4142135623730951);
@@ -1310,11 +1320,11 @@ TEST_CASE("trigonometry/exponential funcs") {
         check(make(p_inf).math_sqrt(), p_inf);
         check(make(n_inf).math_sqrt(), nan);
         CHECK(str.math_sqrt().null());
-        CHECK(i.math_sqrt().null());
     }
-
     SUBCASE("sin") {
         check(make(0.0).math_sin(), 0.0);
+        check(i0.math_sin(), 0.0);
+        check(f0.math_sin(), 0.0);
         check(make(-0.0).math_sin(), -0.0);
         check(make(std::numbers::pi / 2).math_sin(), 1.0);
         check(make(-std::numbers::pi / 2).math_sin(), -1.0);
@@ -1323,10 +1333,11 @@ TEST_CASE("trigonometry/exponential funcs") {
         check(make(p_inf).math_sin(), nan);
         check(make(n_inf).math_sin(), nan);
         CHECK(str.math_sin().null());
-        CHECK(i.math_sin().null());
     }
     SUBCASE("cos") {
         check(make(0.0).math_cos(), 1.0);
+        check(i0.math_cos(), 1.0);
+        check(f0.math_cos(), 1.0);
         check(make(-0.0).math_cos(), 1.0);
         check(make(std::numbers::pi / 2).math_cos(), 0.0);
         check(make(-std::numbers::pi / 2).math_cos(), 0.0);
@@ -1335,10 +1346,11 @@ TEST_CASE("trigonometry/exponential funcs") {
         check(make(p_inf).math_cos(), nan);
         check(make(n_inf).math_cos(), nan);
         CHECK(str.math_cos().null());
-        CHECK(i.math_cos().null());
     }
     SUBCASE("tan") {
         check(make(0.0).math_tan(), 0.0);
+        check(i0.math_tan(), 0.0);
+        check(f0.math_tan(), 0.0);
         check(make(-0.0).math_tan(), -0.0);
         check(make(std::numbers::pi / 4).math_tan(), 1.0);
         check(make(-std::numbers::pi / 4).math_tan(), -1.0);
@@ -1349,10 +1361,11 @@ TEST_CASE("trigonometry/exponential funcs") {
         check(make(p_inf).math_tan(), nan);
         check(make(n_inf).math_tan(), nan);
         CHECK(str.math_tan().null());
-        CHECK(i.math_tan().null());
     }
     SUBCASE("asin") {
         check(make(0.0).math_asin(), 0.0);
+        check(i0.math_asin(), 0.0);
+        check(f0.math_asin(), 0.0);
         check(make(-0.0).math_asin(), -0.0);
         check(make(1.0).math_asin(), std::numbers::pi/2);
         check(make(-1.0).math_asin(), -std::numbers::pi/2);
@@ -1361,10 +1374,11 @@ TEST_CASE("trigonometry/exponential funcs") {
         check(make(p_inf).math_asin(), nan);
         check(make(n_inf).math_asin(), nan);
         CHECK(str.math_asin().null());
-        CHECK(i.math_asin().null());
     }
     SUBCASE("acos") {
         check(make(0.0).math_acos(), std::numbers::pi/2);
+        check(i0.math_acos(), std::numbers::pi/2);
+        check(f0.math_acos(), std::numbers::pi/2);
         check(make(-0.0).math_acos(), std::numbers::pi/2);
         check(make(1.0).math_acos(), 0.0);
         check(make(-1.0).math_acos(), std::numbers::pi);
@@ -1373,10 +1387,11 @@ TEST_CASE("trigonometry/exponential funcs") {
         check(make(p_inf).math_acos(), nan);
         check(make(n_inf).math_acos(), nan);
         CHECK(str.math_acos().null());
-        CHECK(i.math_acos().null());
     }
     SUBCASE("atan") {
         check(make(0.0).math_atan(), 0.0);
+        check(i0.math_atan(), 0.0);
+        check(f0.math_atan(), 0.0);
         check(make(-0.0).math_atan(), -0.0);
         check(make(1.0).math_atan(), std::numbers::pi / 4);
         check(make(-1.0).math_atan(), -std::numbers::pi / 4);
@@ -1384,10 +1399,13 @@ TEST_CASE("trigonometry/exponential funcs") {
         check(make(p_inf).math_atan(), std::numbers::pi / 2);
         check(make(n_inf).math_atan(), -std::numbers::pi / 2);
         CHECK(str.math_atan().null());
-        CHECK(i.math_atan().null());
     }
     SUBCASE("atan2") {
         check(make(0.0).math_atan2(make(0.0)), 0.0);
+        check(i0.math_atan2(i0), 0.0);
+        check(f0.math_atan2(i0), 0.0);
+        check(i0.math_atan2(f0), 0.0);
+        check(f0.math_atan2(f0), 0.0);
         check(make(-0.0).math_atan2(make(0.0)), -0.0);
         check(make(0.0).math_atan2(make(-0.0)), std::numbers::pi);
         check(make(-0.0).math_atan2(make(-0.0)), -std::numbers::pi);
@@ -1398,8 +1416,6 @@ TEST_CASE("trigonometry/exponential funcs") {
         check(make(-0.0).math_atan2(make(1.0)), -0.0);
         check(make(0.0).math_atan2(make(1.0)), 0.0);
         CHECK(str.math_atan2(make(1.0)).null());
-        CHECK(i.math_atan2(make(1.0)).null());
         CHECK(make(1.0).math_atan2(str).null());
-        CHECK(make(1.0).math_atan2(i).null());
     }
 }

--- a/tests/nodes/tests_Literal.cpp
+++ b/tests/nodes/tests_Literal.cpp
@@ -1190,3 +1190,216 @@ TEST_CASE_TEMPLATE("leading zeros parsing", L, datatypes::xsd::Integer,
     CHECK_EQ(lit.template value<L>(), 0);
 }
 
+TEST_CASE("trigonometry/exponential funcs") {
+    using Literal = rdf4cpp::Literal;
+    using namespace rdf4cpp::datatypes;
+
+    auto make = [](double d) {
+        return Literal::make_typed_from_value<xsd::Double>(d);
+    };
+    auto check = [](Literal l, double d) {
+        auto v = l.value<xsd::Double>();
+        if (std::isnan(d)) {
+            CHECK(std::isnan(v));
+        }
+        else if (std::isinf(d)) {
+            CHECK(std::isinf(v));
+            CHECK((v > 0) == (d > 0));
+            CHECK((v < 0) == (d < 0));
+        }
+        else {
+            CHECK(v == doctest::Approx(d));
+        }
+    };
+    static constexpr auto nan = std::numeric_limits<double>::quiet_NaN();
+    static constexpr auto p_inf = std::numeric_limits<double>::infinity();
+    static constexpr auto n_inf = -p_inf;
+
+    const auto str = Literal::make_simple("something");
+    const auto i = Literal::make_typed_from_value<xsd::Int>(42);
+
+    // adapted from https://www.w3.org/TR/xpath-functions/#trigonometry
+    SUBCASE("pi") {
+        CHECK(Literal::math_pi().value<xsd::Double>() == std::numbers::pi);
+    }
+    SUBCASE("exp") {
+        check(make(0.0).math_exp(), 1.0);
+        check(make(1.0).math_exp(), 2.7182818284590455);
+        check(make(2.0).math_exp(), 7.38905609893065);
+        check(make(-1.0).math_exp(), 0.36787944117144233);
+        check(make(nan).math_exp(), nan);
+        check(make(p_inf).math_exp(), p_inf);
+        check(make(n_inf).math_exp(), 0.0);
+        CHECK(str.math_exp().null());
+        CHECK(i.math_exp().null());
+    }
+    SUBCASE("exp10") {
+        check(make(0.0).math_exp10(), 1.0);
+        check(make(1.0).math_exp10(), 10);
+        check(make(2.0).math_exp10(), 100);
+        check(make(0.5).math_exp10(), 3.1622776601683795);
+        check(make(-1.0).math_exp10(), 0.1);
+        check(make(nan).math_exp10(), nan);
+        check(make(p_inf).math_exp10(), p_inf);
+        check(make(n_inf).math_exp10(), 0.0);
+        CHECK(str.math_exp10().null());
+        CHECK(i.math_exp10().null());
+    }
+    SUBCASE("log") {
+        check(make(0.0).math_log(), n_inf);
+        check(make(1.0).math_exp().math_log(), 1.0);
+        check(make(1.0e-3).math_log(), -6.907755278982137);
+        check(make(2).math_log(), 0.6931471805599453);
+        check(make(-1.0).math_log(), nan);
+        check(make(nan).math_log(), nan);
+        check(make(p_inf).math_log(), p_inf);
+        check(make(n_inf).math_log(), nan);
+        CHECK(str.math_log().null());
+        CHECK(i.math_log().null());
+    }
+    SUBCASE("log10") {
+        check(make(0.0).math_log10(), n_inf);
+        check(make(1.0e3).math_log10(), 3.0);
+        check(make(1.0e-3).math_log10(), -3.0);
+        check(make(2).math_log10(), 0.3010299956639812);
+        check(make(-1.0).math_log10(), nan);
+        check(make(nan).math_log10(), nan);
+        check(make(p_inf).math_log10(), p_inf);
+        check(make(n_inf).math_log10(), nan);
+        CHECK(str.math_log10().null());
+        CHECK(i.math_log10().null());
+    }
+    SUBCASE("pow") {
+        check(make(2.0).math_pow(make(3.0)), 8.0);
+        check(make(-2.0).math_pow(make(3.0)), -8.0);
+        check(make(2.0).math_pow(make(0.0)), 1.0);
+        check(make(0.0).math_pow(make(0.0)), 1.0);
+        check(make(p_inf).math_pow(make(0.0)), 1.0);
+        check(make(nan).math_pow(make(0.0)), 1.0);
+        check(make(0.0).math_pow(make(1.0)), 0.0);
+        check(make(0.0).math_pow(make(4.2)), 0.0);
+        check(make(0.0).math_pow(make(-4.2)), p_inf);
+        check(make(-0.0).math_pow(make(-4.2)), p_inf);
+        check(make(16.0).math_pow(make(0.5)), 4.0);
+        check(make(0.0).math_pow(make(4.2)), 0.0);
+        check(make(0.0).math_pow(make(-3.0)), p_inf);
+        check(make(-0.0).math_pow(make(-3.0)), n_inf);
+        check(make(-0.0).math_pow(make(-3.1)), p_inf);
+        check(make(0.0).math_pow(make(-3.1)), p_inf);
+        check(make(0.0).math_pow(make(3.0)), 0.0);
+        check(make(-0.0).math_pow(make(3.0)), -0.0);
+        check(make(-0.0).math_pow(make(3.1)), 0.0);
+        check(make(0.0).math_pow(make(3.1)), 0.0);
+        check(make(0.0).math_pow(make(3.1)), 0.0);
+        check(make(1.0).math_pow(make(p_inf)), 1.0);
+        check(make(1.0).math_pow(make(n_inf)), 1.0);
+        check(make(1.0).math_pow(make(nan)), 1.0);
+        check(make(-1.0).math_pow(make(p_inf)), 1.0);
+        check(make(-1.0).math_pow(make(n_inf)), 1.0);
+        CHECK(str.math_pow(make(3.1)).null());
+        CHECK(i.math_pow(make(3.1)).null());
+        CHECK(make(3.1).math_pow(str).null());
+    }
+    SUBCASE("sqrt") {
+        check(make(0.0).math_sqrt(), 0.0);
+        check(make(-0.0).math_sqrt(), -0.0);
+        check(make(1.0).math_sqrt(), 1.0);
+        check(make(2.0).math_sqrt(), 1.4142135623730951);
+        check(make(-2.0).math_sqrt(), nan);
+        check(make(nan).math_sqrt(), nan);
+        check(make(p_inf).math_sqrt(), p_inf);
+        check(make(n_inf).math_sqrt(), nan);
+        CHECK(str.math_sqrt().null());
+        CHECK(i.math_sqrt().null());
+    }
+
+    SUBCASE("sin") {
+        check(make(0.0).math_sin(), 0.0);
+        check(make(-0.0).math_sin(), -0.0);
+        check(make(std::numbers::pi / 2).math_sin(), 1.0);
+        check(make(-std::numbers::pi / 2).math_sin(), -1.0);
+        check(make(std::numbers::pi).math_sin(), 0.0);
+        check(make(nan).math_sin(), nan);
+        check(make(p_inf).math_sin(), nan);
+        check(make(n_inf).math_sin(), nan);
+        CHECK(str.math_sin().null());
+        CHECK(i.math_sin().null());
+    }
+    SUBCASE("cos") {
+        check(make(0.0).math_cos(), 1.0);
+        check(make(-0.0).math_cos(), 1.0);
+        check(make(std::numbers::pi / 2).math_cos(), 0.0);
+        check(make(-std::numbers::pi / 2).math_cos(), 0.0);
+        check(make(std::numbers::pi).math_cos(), -1.0);
+        check(make(nan).math_cos(), nan);
+        check(make(p_inf).math_cos(), nan);
+        check(make(n_inf).math_cos(), nan);
+        CHECK(str.math_cos().null());
+        CHECK(i.math_cos().null());
+    }
+    SUBCASE("tan") {
+        check(make(0.0).math_tan(), 0.0);
+        check(make(-0.0).math_tan(), -0.0);
+        check(make(std::numbers::pi / 4).math_tan(), 1.0);
+        check(make(-std::numbers::pi / 4).math_tan(), -1.0);
+        check(make(1) / make(std::numbers::pi / 2).math_tan(), 0.0);
+        check(make(1) / make(-std::numbers::pi / 2).math_tan(), 0.0);
+        check(make(std::numbers::pi).math_tan(), 0.0);
+        check(make(nan).math_tan(), nan);
+        check(make(p_inf).math_tan(), nan);
+        check(make(n_inf).math_tan(), nan);
+        CHECK(str.math_tan().null());
+        CHECK(i.math_tan().null());
+    }
+    SUBCASE("asin") {
+        check(make(0.0).math_asin(), 0.0);
+        check(make(-0.0).math_asin(), -0.0);
+        check(make(1.0).math_asin(), std::numbers::pi/2);
+        check(make(-1.0).math_asin(), -std::numbers::pi/2);
+        check(make(2.0).math_asin(), nan);
+        check(make(nan).math_asin(), nan);
+        check(make(p_inf).math_asin(), nan);
+        check(make(n_inf).math_asin(), nan);
+        CHECK(str.math_asin().null());
+        CHECK(i.math_asin().null());
+    }
+    SUBCASE("acos") {
+        check(make(0.0).math_acos(), std::numbers::pi/2);
+        check(make(-0.0).math_acos(), std::numbers::pi/2);
+        check(make(1.0).math_acos(), 0.0);
+        check(make(-1.0).math_acos(), std::numbers::pi);
+        check(make(2.0).math_acos(), nan);
+        check(make(nan).math_acos(), nan);
+        check(make(p_inf).math_acos(), nan);
+        check(make(n_inf).math_acos(), nan);
+        CHECK(str.math_acos().null());
+        CHECK(i.math_acos().null());
+    }
+    SUBCASE("atan") {
+        check(make(0.0).math_atan(), 0.0);
+        check(make(-0.0).math_atan(), -0.0);
+        check(make(1.0).math_atan(), std::numbers::pi / 4);
+        check(make(-1.0).math_atan(), -std::numbers::pi / 4);
+        check(make(nan).math_atan(), nan);
+        check(make(p_inf).math_atan(), std::numbers::pi / 2);
+        check(make(n_inf).math_atan(), -std::numbers::pi / 2);
+        CHECK(str.math_atan().null());
+        CHECK(i.math_atan().null());
+    }
+    SUBCASE("atan2") {
+        check(make(0.0).math_atan2(make(0.0)), 0.0);
+        check(make(-0.0).math_atan2(make(0.0)), -0.0);
+        check(make(0.0).math_atan2(make(-0.0)), std::numbers::pi);
+        check(make(-0.0).math_atan2(make(-0.0)), -std::numbers::pi);
+        check(make(-1.0).math_atan2(make(0.0)), -std::numbers::pi / 2);
+        check(make(1.0).math_atan2(make(0.0)), std::numbers::pi / 2);
+        check(make(-0.0).math_atan2(make(-1.0)), -std::numbers::pi);
+        check(make(0.0).math_atan2(make(-1.0)), std::numbers::pi);
+        check(make(-0.0).math_atan2(make(1.0)), -0.0);
+        check(make(0.0).math_atan2(make(1.0)), 0.0);
+        CHECK(str.math_atan2(make(1.0)).null());
+        CHECK(i.math_atan2(make(1.0)).null());
+        CHECK(make(1.0).math_atan2(str).null());
+        CHECK(make(1.0).math_atan2(i).null());
+    }
+}


### PR DESCRIPTION
close #126 

where xpath only defines these functions specifically for doubles, all other types result in an error (null Literal returned). We allow all types as arguments that can be converted to double. 