### PR TITLE
Prevent exceptions of unintended type from escaping from parser

### DIFF
--- a/private/rdf4cpp/parser/IStreamQuadIteratorSerdImpl.cpp
+++ b/private/rdf4cpp/parser/IStreamQuadIteratorSerdImpl.cpp
@@ -52,6 +52,13 @@ nonstd::expected<Node, SerdStatus> IStreamQuadIterator::Impl::get_bnode(std::str
                                         .message = std::string{e.what()} + ". note: position may not be accurate and instead point to the end of the triple."};
 
         return nonstd::make_unexpected(SERD_ERR_BAD_SYNTAX);
+    } catch (...) {
+        this->last_error = ParsingError{.error_type = ParsingError::Type::BadBlankNode,
+                                        .line = serd_reader_get_current_line(this->reader),
+                                        .col = serd_reader_get_current_col(this->reader),
+                                        .message = "Unknown internal error. note: position may not be accurate and instead point to the end of the triple."};
+
+        return nonstd::make_unexpected(SERD_ERR_BAD_SYNTAX);
     }
 }
 
@@ -159,6 +166,13 @@ nonstd::expected<Literal, SerdStatus> IStreamQuadIterator::Impl::get_literal(Ser
                                         .line = serd_reader_get_current_line(this->reader),
                                         .col = serd_reader_get_current_col(this->reader),
                                         .message = std::string{e.what()} + ". note: position may not be accurate and instead point to the end of the triple."};
+
+        return nonstd::make_unexpected(SERD_ERR_BAD_SYNTAX);
+    } catch (...) {
+        this->last_error = ParsingError{.error_type = ParsingError::Type::BadLiteral,
+                                        .line = serd_reader_get_current_line(this->reader),
+                                        .col = serd_reader_get_current_col(this->reader),
+                                        .message = "Unknown internal error. note: position may not be accurate and instead point to the end of the triple."};
 
         return nonstd::make_unexpected(SERD_ERR_BAD_SYNTAX);
     }

--- a/tests/parser/tests_IStreamQuadIterator.cpp
+++ b/tests/parser/tests_IStreamQuadIterator.cpp
@@ -757,11 +757,4 @@ TEST_SUITE("IStreamQuadIterator") {
             CHECK(qit->value().object().as_iri().identifier() == "eXAMPLE://a/./b/../b/%63/%7bfoo%7d#xyz");
         }
     }
-
-    TEST_CASE("bug") {
-        std::istringstream iss{R"(<https://lux.collections.yale.edu/data/object/18eeb377-f049-4f0b-a027-dcd00d1ee32f> <https://lux.collections.yale.edu/ns/weight> "5e-05"^^<http://www.w3.org/2001/XMLSchema#decimal> .)"};
-        for (IStreamQuadIterator qit{iss}; qit != std::default_sentinel; ++qit) {
-            CHECK_FALSE(qit->has_value());
-        }
-    }
 }

--- a/tests/parser/tests_IStreamQuadIterator.cpp
+++ b/tests/parser/tests_IStreamQuadIterator.cpp
@@ -757,4 +757,11 @@ TEST_SUITE("IStreamQuadIterator") {
             CHECK(qit->value().object().as_iri().identifier() == "eXAMPLE://a/./b/../b/%63/%7bfoo%7d#xyz");
         }
     }
+
+    TEST_CASE("bug") {
+        std::istringstream iss{R"(<https://lux.collections.yale.edu/data/object/18eeb377-f049-4f0b-a027-dcd00d1ee32f> <https://lux.collections.yale.edu/ns/weight> "5e-05"^^<http://www.w3.org/2001/XMLSchema#decimal> .)"};
+        for (IStreamQuadIterator qit{iss}; qit != std::default_sentinel; ++qit) {
+            CHECK_FALSE(qit->has_value());
+        }
+    }
 }


### PR DESCRIPTION
This was not actually an issue, but it is a good idea to have.