### PR TITLE
Fix: make random bnode id generator xml compliant

### DIFF
--- a/src/rdf4cpp/bnode_mngt/reference_backends/generator/RandomIdGenerator.cpp
+++ b/src/rdf4cpp/bnode_mngt/reference_backends/generator/RandomIdGenerator.cpp
@@ -7,10 +7,11 @@ namespace rdf4cpp::bnode_mngt {
 
 namespace generator_detail {
 
-static constexpr std::array<char, 36> bnode_id_valid_chars{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
-                                                           'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
-                                                           'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6',
-                                                           '7', '8', '9'};
+static constexpr std::array bnode_id_valid_chars{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
+                                                 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
+                                                 'w', 'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G',
+                                                 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R',
+                                                 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'};
 
 static constexpr size_t generated_id_size = 32;
 


### PR DESCRIPTION
XML is more strict than turtle for bnode labels. Speficially, no numbers at the front.