### PR TITLE
Fix: serializing blank node graphs in TriG and N-Quads

### DIFF
--- a/private/rdf4cpp/writer/WriteQuad.hpp
+++ b/private/rdf4cpp/writer/WriteQuad.hpp
@@ -38,8 +38,7 @@ bool write_pred(Node const pred, writer::BufWriterParts const writer) {
     }
 
 [[nodiscard]] inline bool print_graph(Node const &graph) noexcept {
-    auto const g = graph.as_iri();
-    return g.is_default_graph() != TriBool::True;
+    return !graph.null() && graph.as_iri().is_default_graph() != TriBool::True;
 }
 
 template<writer::OutputFormat F, typename Q>

--- a/private/rdf4cpp/writer/WriteQuad.hpp
+++ b/private/rdf4cpp/writer/WriteQuad.hpp
@@ -39,7 +39,7 @@ bool write_pred(Node const pred, writer::BufWriterParts const writer) {
 
 [[nodiscard]] inline bool print_graph(Node const &graph) noexcept {
     auto const g = graph.as_iri();
-    return !g.is_default_graph();
+    return g.is_default_graph() != TriBool::True;
 }
 
 template<writer::OutputFormat F, typename Q>

--- a/tests/serializer/tests_Serialization.cpp
+++ b/tests/serializer/tests_Serialization.cpp
@@ -273,6 +273,30 @@ TEST_CASE("basic trig") {
              "<http://ex/sub> a \"7\"^^xsd:int .\n");
 }
 
+TEST_CASE("trig bnode graph") {
+    Quad q{
+        BlankNode::make("G"),
+        IRI::make("http://example.com#s"),
+        IRI::make("http://example.com#p"),
+        IRI::make("http://example.com#o"),
+    };
+
+    auto s = writer::StringWriter::oneshot([&q](auto &w) {
+        writer::SerializationState st{};
+        st.begin(w);
+        q.serialize_trig(st, w);
+        st.flush(w);
+        return true;
+    });
+
+    CHECK_EQ(s, R"(@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+_:G {
+<http://example.com#s> <http://example.com#p> <http://example.com#o> .
+}
+)");
+}
+
 template<OutputFormat F>
 std::string write_ext_data() {
     std::string buf;

--- a/tests/serializer/tests_Serialization.cpp
+++ b/tests/serializer/tests_Serialization.cpp
@@ -273,6 +273,22 @@ TEST_CASE("basic trig") {
              "<http://ex/sub> a \"7\"^^xsd:int .\n");
 }
 
+TEST_CASE("nquads bnode graph") {
+    Quad q{
+        BlankNode::make("G"),
+        IRI::make("http://example.com#s"),
+        IRI::make("http://example.com#p"),
+        IRI::make("http://example.com#o"),
+    };
+
+    auto s = writer::StringWriter::oneshot([&q](auto &w) {
+        q.serialize_nquads(w);
+        return true;
+    });
+
+    CHECK_EQ(s, "<http://example.com#s> <http://example.com#p> <http://example.com#o> _:G .\n");
+}
+
 TEST_CASE("trig bnode graph") {
     Quad q{
         BlankNode::make("G"),


### PR DESCRIPTION
Blank node graphs were not properly serialized because of a logic error in `print_graph`