### PR TITLE
Update openssl to 3.6.3 to resolve vulnerabilities

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -33,7 +33,7 @@ class Recipe(ConanFile):
         self.requires("boost/1.86.0", transitive_headers=True, libs=False)
         self.requires("expected-lite/0.8.0", transitive_headers=True)
         self.requires("pcre2/10.44", options={"support_jit": True})
-        self.requires("openssl/4.0.1")
+        self.requires("openssl/3.6.3")
         self.requires("uni-algo/1.2.0")
         self.requires("highway/1.2.0")
         self.requires("dice-hash/0.4.11", transitive_headers=True)

--- a/conanfile.py
+++ b/conanfile.py
@@ -44,7 +44,7 @@ class Recipe(ConanFile):
         if self.options.with_test_deps:
             self.test_requires("doctest/2.4.11")
             self.test_requires("nanobench/4.3.11")
-            self.test_requires("libcurl/8.21.1")
+            self.test_requires("libcurl/8.21.0")
 
     def set_name(self):
         if not hasattr(self, 'name') or self.version is None:

--- a/conanfile.py
+++ b/conanfile.py
@@ -44,7 +44,7 @@ class Recipe(ConanFile):
         if self.options.with_test_deps:
             self.test_requires("doctest/2.4.11")
             self.test_requires("nanobench/4.3.11")
-            self.test_requires("libcurl/8.12.1")
+            self.test_requires("libcurl/8.21.1")
 
     def set_name(self):
         if not hasattr(self, 'name') or self.version is None:

--- a/conanfile.py
+++ b/conanfile.py
@@ -33,7 +33,7 @@ class Recipe(ConanFile):
         self.requires("boost/1.86.0", transitive_headers=True, libs=False)
         self.requires("expected-lite/0.8.0", transitive_headers=True)
         self.requires("pcre2/10.44", options={"support_jit": True})
-        self.requires("openssl/3.3.2")
+        self.requires("openssl/4.0.1")
         self.requires("uni-algo/1.2.0")
         self.requires("highway/1.2.0")
         self.requires("dice-hash/0.4.11", transitive_headers=True)


### PR DESCRIPTION
conan audit scan now shows 0 vulnerabilities as of 23.07.2026T13:36+2

Not using openssl-4 because libcurl requires openssl<4