### PR TITLE
Fix: update clang-21 to resolve compiler error with combination of conan 2.31 and clang-20

### DIFF
--- a/.github/workflows/publish-conan-branch-package.yml
+++ b/.github/workflows/publish-conan-branch-package.yml
@@ -13,7 +13,7 @@ jobs:
       os: ubuntu-24.04
       compiler: clang-20
       cmake-version: 4.4.0
-      conan-version: 2.31.0
+      conan-version: 2.30.0
       conan-options: -o boost/*:header_only=True
     secrets:
       CONAN_CICD_USERNAME: ${{ secrets.CONAN_CICD_USERNAME }}

--- a/.github/workflows/publish-conan-branch-package.yml
+++ b/.github/workflows/publish-conan-branch-package.yml
@@ -11,9 +11,9 @@ jobs:
     with:
       public_artifactory: true
       os: ubuntu-24.04
-      compiler: clang-20
+      compiler: clang-21
       cmake-version: 4.4.0
-      conan-version: 2.30.0
+      conan-version: 2.31.0
       conan-options: -o boost/*:header_only=True
     secrets:
       CONAN_CICD_USERNAME: ${{ secrets.CONAN_CICD_USERNAME }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -12,7 +12,7 @@ jobs:
     with:
       public_artifactory: true
       os: ubuntu-24.04
-      compiler: clang-20
+      compiler: clang-21
       cmake-version: 4.4.0
       conan-version: 2.31.0
       use-tag: true

--- a/.github/workflows/test_packaging_and_deployment.yml
+++ b/.github/workflows/test_packaging_and_deployment.yml
@@ -6,7 +6,7 @@ jobs:
     uses: ./.github/workflows/reusable_packaging_and_deployment.yml
     with:
       os: ubuntu-24.04
-      compiler: clang-20
+      compiler: clang-21
       cmake-version: 4.4.0
       conan-version: 2.31.0
 


### PR DESCRIPTION
conan branch package workflow failing with ISO C99 does not allow implicit function decl

- conan 2.31 + clang-20 does not work
- conan 2.30 + clang-20 works
- conan 2.31 + clang-21 works

Opted to upgrade to clang-21
